### PR TITLE
ci(www): deploy docs with Cloudflare Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
     env:
       CI: true
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_PROJECT_NAME: canvas-timeline-www
       PACKAGE_LINE_COVERAGE_MINIMUM: 80
 
@@ -70,27 +72,27 @@ jobs:
         run: vp run package:check
 
       - name: Deploy production docs to Cloudflare Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy-production
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/www
           command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
 
       - name: Deploy preview docs to Cloudflare Pages
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy-preview
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/www
           command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}
 
       - name: Comment docs preview URL
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.deploy-preview.conclusion == 'success'
         env:
           DEPLOYMENT_URL: ${{ steps.deploy-preview.outputs.deployment-url }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   quality:
@@ -23,6 +24,7 @@ jobs:
 
     env:
       CI: true
+      CLOUDFLARE_PROJECT_NAME: canvas-timeline-www
       PACKAGE_LINE_COVERAGE_MINIMUM: 80
 
     steps:
@@ -66,6 +68,59 @@ jobs:
 
       - name: Validate publishable packages
         run: vp run package:check
+
+      - name: Deploy production docs to Cloudflare Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: deploy-production
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/www
+          command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
+
+      - name: Deploy preview docs to Cloudflare Pages
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        id: deploy-preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/www
+          command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}
+
+      - name: Comment docs preview URL
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy-preview.outputs.deployment-url }}
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.deploy-preview.outputs.pages-deployment-alias-url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          comment_marker='<!-- canvas-timeline-www-preview -->'
+          preview_url="${PREVIEW_URL:-$DEPLOYMENT_URL}"
+          body="$(printf '%s\n### Docs preview deployed\n\nPreview: %s\n\nLatest deployment: %s' \
+            "$comment_marker" \
+            "$preview_url" \
+            "$DEPLOYMENT_URL")"
+
+          comment_id="$(
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              --jq ".[] | select(.body | startswith(\"$comment_marker\")) | .id" \
+              | head -n 1
+          )"
+
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${comment_id}" \
+              -f body="$body"
+          else
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="$body"
+          fi
 
       - name: Save Vite Task cache
         if: success()


### PR DESCRIPTION
## Summary

- Deploy the docs site to Cloudflare Pages from the existing CI workflow after quality, build, and package validation pass.
- Add same-repo PR preview deployments with a sticky preview URL comment.
- Keep fork PRs from running deployment steps so Cloudflare secrets are not exposed.

## Release Impact

- Packages/API: None.
- Docs/demos: Publishes the existing `apps/www` build output from `apps/www/dist`.
- Breaking changes: None.
- Checklist areas reviewed: 0, 5, 6, 8, 9, and Final Shape Check.

## Validation

- `vp fmt .github/workflows/ci.yml`
- Ruby YAML parse for `.github/workflows/ci.yml`
- `vp run build:www`
