### PR TITLE
fix(www): resolve quality type analysis issues

### DIFF
--- a/.changeset/fix-www-quality-check.md
+++ b/.changeset/fix-www-quality-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix docs-site type analysis issues in the quality gate.

--- a/apps/www/src/data/blog.ts
+++ b/apps/www/src/data/blog.ts
@@ -18,7 +18,10 @@ const publishedDateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 export async function getBlogPosts(): Promise<BlogPost[]> {
-  const posts = await getCollection('blog', ({ data }) => import.meta.env.DEV || !data.draft);
+  const posts = await getCollection(
+    'blog',
+    (post: BlogPost) => import.meta.env.DEV || !post.data.draft
+  );
 
   return sortBlogPosts(posts);
 }

--- a/apps/www/src/env.d.ts
+++ b/apps/www/src/env.d.ts
@@ -8,3 +8,11 @@ declare module '*?raw' {
   const source: string;
   export default source;
 }
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | { readonly [key: string]: JsonValue } | readonly JsonValue[];
+
+declare module '*.json' {
+  const value: JsonValue;
+  export default value;
+}

--- a/apps/www/src/lib/api-reference.ts
+++ b/apps/www/src/lib/api-reference.ts
@@ -79,7 +79,228 @@ export interface ApiReference {
   warnings: string[];
 }
 
-export const apiReference = apiReferenceData as ApiReference;
+type JsonObject = { readonly [key: string]: JsonValue };
+
+function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readObject(value: JsonValue | undefined, fieldName: string): JsonObject {
+  if (!isJsonObject(value)) {
+    throw new TypeError(`API reference field "${fieldName}" must be an object.`);
+  }
+
+  return value;
+}
+
+function readString(value: JsonValue | undefined, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`API reference field "${fieldName}" must be a string.`);
+  }
+
+  return value;
+}
+
+function readBoolean(value: JsonValue | undefined, fieldName: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`API reference field "${fieldName}" must be a boolean.`);
+  }
+
+  return value;
+}
+
+function readNumber(value: JsonValue | undefined, fieldName: string): number {
+  if (typeof value !== 'number') {
+    throw new TypeError(`API reference field "${fieldName}" must be a number.`);
+  }
+
+  return value;
+}
+
+function readOptionalString(value: JsonValue | undefined, fieldName: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return readString(value, fieldName);
+}
+
+function readArray(value: JsonValue | undefined, fieldName: string): readonly JsonValue[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`API reference field "${fieldName}" must be an array.`);
+  }
+
+  return value;
+}
+
+function readStringArray(value: JsonValue | undefined, fieldName: string): string[] {
+  return readArray(value, fieldName).map((item, index) =>
+    readString(item, `${fieldName}[${index}]`)
+  );
+}
+
+function readRecordArray(
+  value: JsonValue | undefined,
+  fieldName: string
+): Record<string, string>[] {
+  return readArray(value, fieldName).map((item, index) => {
+    const object = readObject(item, `${fieldName}[${index}]`);
+    return Object.fromEntries(
+      Object.entries(object).map(([key, entry]) => [key, readString(entry, `${fieldName}.${key}`)])
+    );
+  });
+}
+
+function parseApiParameter(value: JsonValue, fieldName: string): ApiParameter {
+  const object = readObject(value, fieldName);
+
+  return {
+    name: readString(object.name, `${fieldName}.name`),
+    type: readString(object.type, `${fieldName}.type`),
+    optional: readBoolean(object.optional, `${fieldName}.optional`),
+    defaultValue: readOptionalString(object.defaultValue, `${fieldName}.defaultValue`),
+    summary: readOptionalString(object.summary, `${fieldName}.summary`),
+  };
+}
+
+function parseApiTypeParameter(value: JsonValue, fieldName: string): ApiTypeParameter {
+  const object = readObject(value, fieldName);
+
+  return {
+    name: readString(object.name, `${fieldName}.name`),
+    default: readOptionalString(object.default, `${fieldName}.default`),
+    constraint: readOptionalString(object.constraint, `${fieldName}.constraint`),
+    summary: readOptionalString(object.summary, `${fieldName}.summary`),
+  };
+}
+
+function parseApiMember(value: JsonValue, fieldName: string): ApiMember {
+  const object = readObject(value, fieldName);
+
+  return {
+    name: readString(object.name, `${fieldName}.name`),
+    kind: readString(object.kind, `${fieldName}.kind`),
+    signature: readString(object.signature, `${fieldName}.signature`),
+    type: readOptionalString(object.type, `${fieldName}.type`),
+    optional: readBoolean(object.optional, `${fieldName}.optional`),
+    params: readArray(object.params, `${fieldName}.params`).map((item, index) =>
+      parseApiParameter(item, `${fieldName}.params[${index}]`)
+    ),
+    returns: readOptionalString(object.returns, `${fieldName}.returns`),
+    summary: readOptionalString(object.summary, `${fieldName}.summary`),
+  };
+}
+
+function parseLiteralTable(value: JsonValue | undefined, fieldName: string) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const object = readObject(value, fieldName);
+
+  return {
+    columns: readStringArray(object.columns, `${fieldName}.columns`),
+    rows: readRecordArray(object.rows, `${fieldName}.rows`),
+  };
+}
+
+function parseApiAlias(value: JsonValue | undefined, fieldName: string) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const object = readObject(value, fieldName);
+
+  return {
+    packageSlug: readString(object.packageSlug, `${fieldName}.packageSlug`),
+    packageName: readString(object.packageName, `${fieldName}.packageName`),
+    symbolName: readString(object.symbolName, `${fieldName}.symbolName`),
+    symbolSlug: readString(object.symbolSlug, `${fieldName}.symbolSlug`),
+  };
+}
+
+function parseApiSource(value: JsonValue | undefined, fieldName: string) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const object = readObject(value, fieldName);
+
+  return {
+    fileName: readString(object.fileName, `${fieldName}.fileName`),
+    line: readNumber(object.line, `${fieldName}.line`),
+    url: readOptionalString(object.url, `${fieldName}.url`),
+  };
+}
+
+function parseApiSymbol(value: JsonValue, fieldName: string): ApiSymbol {
+  const object = readObject(value, fieldName);
+
+  return {
+    slug: readString(object.slug, `${fieldName}.slug`),
+    name: readString(object.name, `${fieldName}.name`),
+    kind: readString(object.kind, `${fieldName}.kind`),
+    summary: readString(object.summary, `${fieldName}.summary`),
+    signature: readString(object.signature, `${fieldName}.signature`),
+    params: readArray(object.params, `${fieldName}.params`).map((item, index) =>
+      parseApiParameter(item, `${fieldName}.params[${index}]`)
+    ),
+    typeParameters: readArray(object.typeParameters, `${fieldName}.typeParameters`).map(
+      (item, index) => parseApiTypeParameter(item, `${fieldName}.typeParameters[${index}]`)
+    ),
+    properties: readArray(object.properties, `${fieldName}.properties`).map((item, index) =>
+      parseApiMember(item, `${fieldName}.properties[${index}]`)
+    ),
+    methods: readArray(object.methods, `${fieldName}.methods`).map((item, index) =>
+      parseApiMember(item, `${fieldName}.methods[${index}]`)
+    ),
+    constructors: readArray(object.constructors, `${fieldName}.constructors`).map((item, index) =>
+      parseApiMember(item, `${fieldName}.constructors[${index}]`)
+    ),
+    returnMembers: readArray(object.returnMembers, `${fieldName}.returnMembers`).map(
+      (item, index) => parseApiMember(item, `${fieldName}.returnMembers[${index}]`)
+    ),
+    literalTable: parseLiteralTable(object.literalTable, `${fieldName}.literalTable`),
+    aliasOf: parseApiAlias(object.aliasOf, `${fieldName}.aliasOf`),
+    returns: readOptionalString(object.returns, `${fieldName}.returns`),
+    returnsSummary: readOptionalString(object.returnsSummary, `${fieldName}.returnsSummary`),
+    examples: readStringArray(object.examples, `${fieldName}.examples`),
+    sourcePackage: readString(object.sourcePackage, `${fieldName}.sourcePackage`),
+    packageName: readOptionalString(object.packageName, `${fieldName}.packageName`),
+    source: parseApiSource(object.source, `${fieldName}.source`),
+  };
+}
+
+function parseApiPackage(value: JsonValue, fieldName: string): ApiPackage {
+  const object = readObject(value, fieldName);
+
+  return {
+    slug: readString(object.slug, `${fieldName}.slug`),
+    name: readString(object.name, `${fieldName}.name`),
+    entryPoint: readString(object.entryPoint, `${fieldName}.entryPoint`),
+    symbols: readArray(object.symbols, `${fieldName}.symbols`).map((item, index) =>
+      parseApiSymbol(item, `${fieldName}.symbols[${index}]`)
+    ),
+    warnings: readStringArray(object.warnings, `${fieldName}.warnings`),
+  };
+}
+
+function parseApiReference(value: JsonValue): ApiReference {
+  const object = readObject(value, 'apiReference');
+
+  return {
+    generatedAt: readString(object.generatedAt, 'apiReference.generatedAt'),
+    packages: readArray(object.packages, 'apiReference.packages').map((item, index) =>
+      parseApiPackage(item, `apiReference.packages[${index}]`)
+    ),
+    symbols: readArray(object.symbols, 'apiReference.symbols').map((item, index) =>
+      parseApiSymbol(item, `apiReference.symbols[${index}]`)
+    ),
+    warnings: readStringArray(object.warnings, 'apiReference.warnings'),
+  };
+}
+
+export const apiReference = parseApiReference(apiReferenceData);
 
 function getApiPackage(slug: string) {
   return apiReference.packages.find((packageDoc) => packageDoc.slug === slug);

--- a/apps/www/src/lib/structured-data.ts
+++ b/apps/www/src/lib/structured-data.ts
@@ -202,7 +202,7 @@ export function createBlogFaqStructuredData(
   return {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: faqItems.map((item) => ({
+    mainEntity: faqItems.map((item: NonNullable<BlogPost['data']['faq']>[number]) => ({
       '@type': 'Question',
       name: item.question,
       acceptedAnswer: {

--- a/apps/www/src/pages/docs/[...slug].md.ts
+++ b/apps/www/src/pages/docs/[...slug].md.ts
@@ -12,7 +12,7 @@ interface Props {
 export const getStaticPaths = (async () => {
   const docs = await getCollection('docs');
 
-  return docs.map((entry) => ({
+  return docs.map((entry: DocsEntry) => ({
     params: { slug: entry.id },
     props: { entry },
   }));


### PR DESCRIPTION
## Summary

- Add strict typings for docs content callbacks that `vp check` flags under type-aware linting.
- Parse generated API reference JSON through a typed boundary so the checker can run before the generated file exists.
- Add an empty changeset for the docs-site quality fix.

## Release Impact

- Packages/API: None.
- Docs/demos: Docs-site type safety only.
- Breaking changes: None.
- Checklist areas reviewed: 8, 10.

## Validation

- `vp check`
- `vp exec changeset status --since=origin/ci/changesets/remove-stale-demo-ignore`
