### PR TITLE
docs(config): tighten PR validation guidance

### DIFF
--- a/.agents/skills/canvas-timeline-pr/SKILL.md
+++ b/.agents/skills/canvas-timeline-pr/SKILL.md
@@ -21,16 +21,26 @@ and avoiding duplicate PRs.
    - `git status -sb`
    - `git log --oneline --decorate --max-count=8`
    - `git diff --stat origin/main...HEAD` when the base is `main`
+   - `.github/workflows/*.yml` for required PR checks that apply to the
+     changed files.
+   - Commitlint or repository commit-scope configuration before choosing a PR
+     title or commit message scope.
 2. Identify release-relevant impact by reading only the relevant sections of
    `.github/docs/public-release-checklist.md`.
 3. Confirm the PR has the right release artifact:
    - Package/API changes: add or verify a Changeset.
-   - Non-package changes: add an empty Changeset only when CI requires one.
+   - Non-package changes: add an empty Changeset whenever the Changeset status
+     workflow is required for PRs.
    - Breaking changes before public release: call them out clearly; do not add
      backwards-compatibility aliases or fallback exports.
 4. Run validation proportional to impact. Prefer already-documented Vite+ gates.
-5. Draft a concise PR title and body that names impact, validation, and release
+5. For stacked cleanup PRs, base later PRs on the smallest earlier branch that
+   provides required CI/config fixes instead of duplicating those commits.
+6. Draft a concise PR title and body that names impact, validation, and release
    checklist areas reviewed.
+7. After opening the PR, run `gh pr checks <number>` or inspect the check
+   rollup. If a required check fails, inspect the failing log before declaring
+   the PR ready.
 
 ## Checklist Routing
 
@@ -70,6 +80,13 @@ vp run repo:package:check
 
 Use `vp run ci` for final confidence when time allows or when preparing a
 release-facing PR.
+
+Before opening a PR, validate the PR title locally when commitlint runs on pull
+request titles:
+
+```bash
+printf '%s\n' "<type>(<scope>): <summary>" | vp exec commitlint --verbose
+```
 
 ## PR Body Shape
 

--- a/.changeset/update-pr-skill-guidance.md
+++ b/.changeset/update-pr-skill-guidance.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify PR preparation guidance for required checks, Changeset status, and stacked cleanup branches.


### PR DESCRIPTION
## Summary

- Clarify that PR prep should inspect required workflows and commitlint scopes before choosing titles.
- Require empty changesets for non-package PRs when the Changeset status workflow is required.
- Add post-open check inspection guidance and note stacked cleanup PRs should avoid duplicate fix commits.

## Release Impact

- Packages/API: None.
- Docs/demos: Repo-local agent guidance only.
- Breaking changes: None.
- Checklist areas reviewed: 6, 7.

## Validation

- `printf '%s\n' "docs(config): tighten PR validation guidance" | vp exec commitlint --verbose`
- `vp fmt --check .agents/skills/canvas-timeline-pr/SKILL.md .changeset/update-pr-skill-guidance.md`
- `vp check`
- `vp exec changeset status --since=origin/fix/www/quality-type-analysis`
