### PR TITLE
ci(release): gate prepublish versioning

### DIFF
--- a/.changeset/organize-react-package-map.md
+++ b/.changeset/organize-react-package-map.md
@@ -1,7 +1,4 @@
 ---
-'@techsquidtv/canvas-timeline-react': patch
-'@techsquidtv/canvas-timeline-html-media-adapter': patch
-'@techsquidtv/canvas-timeline-mediabunny-adapter': patch
 ---
 
 Expose React docs metadata as a package subpath and update package repository metadata after source layout cleanup.

--- a/.changeset/quiet-ci.md
+++ b/.changeset/quiet-ci.md
@@ -1,11 +1,4 @@
 ---
-'@techsquidtv/canvas-timeline': patch
-'@techsquidtv/canvas-timeline-core': patch
-'@techsquidtv/canvas-timeline-html-media-adapter': patch
-'@techsquidtv/canvas-timeline-mediabunny-adapter': patch
-'@techsquidtv/canvas-timeline-react': patch
-'@techsquidtv/canvas-timeline-renderer': patch
-'@techsquidtv/canvas-timeline-utils': patch
 ---
 
 Add CI, release, package validation, and repository metadata required for npm trusted publishing.

--- a/.changeset/tidy-timeline-theme-contract.md
+++ b/.changeset/tidy-timeline-theme-contract.md
@@ -1,6 +1,4 @@
 ---
-'@techsquidtv/canvas-timeline': major
-'@techsquidtv/canvas-timeline-renderer': major
 ---
 
 Tighten the renderer theme contract to resolve only documented timeline tokens,

--- a/.changeset/track-lock-controls.md
+++ b/.changeset/track-lock-controls.md
@@ -1,6 +1,4 @@
 ---
-'@techsquidtv/canvas-timeline-react': patch
-'@techsquidtv/canvas-timeline-renderer': patch
 ---
 
 Add a track lock control hook, locked clip cursor affordance, and theme-driven locked track canvas overlay.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       tag:
@@ -30,7 +27,7 @@ jobs:
     name: Version or publish packages
     runs-on: ubuntu-latest
     environment: npm-publish
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' && !inputs.snapshot && vars.ENABLE_PACKAGE_PUBLISH == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -88,7 +85,7 @@ jobs:
     name: Publish snapshot packages
     runs-on: ubuntu-latest
     environment: npm-publish
-    if: github.event_name == 'workflow_dispatch' && inputs.snapshot
+    if: github.event_name == 'workflow_dispatch' && inputs.snapshot && vars.ENABLE_PACKAGE_PUBLISH == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- Disable automatic release/version PR creation on pushes to main while packages remain unpublished.
- Gate manual package publishing behind ENABLE_PACKAGE_PUBLISH.
- Convert queued package Changesets to empty status-only entries so the first real publish can remain at 0.0.1.

## Release Impact

- Packages/API: Prevents unintended package version bumps before first publish.
- Docs/demos: Not applicable.
- Breaking changes: None.
- Checklist areas reviewed: 5 and 6.

## Validation

- `vp exec changeset status --since=origin/main`
- `printf '%s\n' "ci(release): gate prepublish versioning" | vp exec commitlint --verbose`