### PR TITLE
fix(react): improve keyframe and Bezier curve handle interactivity

### DIFF
--- a/.changeset/keyframe-bezier-interactions.md
+++ b/.changeset/keyframe-bezier-interactions.md
@@ -1,0 +1,6 @@
+---
+'@techsquidtv/canvas-timeline-core': patch
+'@techsquidtv/canvas-timeline-react': patch
+---
+
+Improve keyframe and Bezier curve handle interactions. Keyframe and curve handles now render invisible padded hit targets (new `hitPadding` prop) around their visual shapes so near-miss presses grab the handle instead of falling through to the clip interaction layer. The curve layer gained guarded pointer capture with document-level fallback listeners and now selects the anchor keyframe on drag start. Keyframe drag previews are non-destructive: colliding neighbors are no longer deleted during `{ commit: false }` updates, only on committed edits. New keyframes created without an explicit `interpolation` inherit the previous keyframe's interpolation mode and Bezier easing.

--- a/apps/www/src/content/docs/keyframes.mdx
+++ b/apps/www/src/content/docs/keyframes.mdx
@@ -71,7 +71,9 @@ engine.setClipKeyframe({
 const opacity = engine.getClipPropertyValueAtTime('intro', 'opacity', fromSeconds(3.5));
 ```
 
-`setClipKeyframe()` adds or updates a keyframe at an exact clip/property/time. Use `updateClipKeyframe()` when you already have a keyframe id, and `removeClipKeyframe()` when your application decides a keyframe should be deleted.
+`setClipKeyframe()` adds or updates a keyframe at an exact clip/property/time. When you omit `interpolation` for a brand-new keyframe, it inherits the interpolation mode (and Bezier easing) of the previous keyframe in the same property lane, so placing a keyframe mid-segment keeps the segment's easing character instead of resetting it to linear. Use `updateClipKeyframe()` when you already have a keyframe id, and `removeClipKeyframe()` when your application decides a keyframe should be deleted.
+
+`updateClipKeyframe()` merges keyframes that land on the same property/time only for committed edits. Preview updates (`{ commit: false }`, used by drag hooks) never delete a colliding neighbor; the dragged keyframe holds its last non-colliding time instead, so scrubbing a keyframe across another one is non-destructive.
 
 <Callout kind="tip" title="App-owned editing policy">
   Canvas Timeline exposes the primitives for adding, updating, dragging, and removing keyframes, but
@@ -189,7 +191,7 @@ import { CanvasRenderer, Timeline } from '@techsquidtv/canvas-timeline';
 </Timeline.Root>;
 ```
 
-The interaction layer keeps its root `pointer-events: none` and only enables pointer events on visible keyframe handles, so clips remain interactive between handles. Use `keyframeSize`, `keyframeValuePadding`, `getKeyframeAriaLabel`, `onKeyframeDoubleClick`, `onKeyframeDelete`, and `onKeyDown` to adapt the layer for your editor.
+The interaction layer keeps its root `pointer-events: none` and only enables pointer events on visible keyframe handles, so clips remain interactive between handles. Each handle wraps its visual shape in an invisible padded hit target (`hitPadding`, 8px by default) so near-miss presses grab the keyframe instead of starting a clip move or trim on the clip layer underneath. Use `keyframeSize`, `hitPadding`, `keyframeValuePadding`, `getKeyframeAriaLabel`, `onKeyframeDoubleClick`, `onKeyframeDelete`, and `onKeyDown` to adapt the layer for your editor.
 
 Add `Timeline.KeyframeCurveInteractionLayer` when you want optional inline Bezier handles for selected curve segments:
 
@@ -204,7 +206,7 @@ Add `Timeline.KeyframeCurveInteractionLayer` when you want optional inline Bezie
 />
 ```
 
-The curve layer edits only existing Bezier easing data. Apps still decide when to convert a segment to Bezier, when to reset handles, and whether to expose presets, inspector fields, or a separate graph editor.
+The curve layer edits only existing Bezier easing data. Its handles use the same padded hit targets (`hitPadding`), pointer capture with document-level fallback listeners, and select their anchor keyframe when a drag starts. Apps still decide when to convert a segment to Bezier, when to reset handles, and whether to expose presets, inspector fields, or a separate graph editor.
 
 ## Custom Renderers
 

--- a/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
+++ b/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
@@ -278,7 +278,6 @@ function KeyframeOpacitySurface({ metrics }: { metrics?: DemoMetrics }) {
       property: 'opacity',
       time: playheadTime,
       value: evaluatedOpacity,
-      interpolation: 'linear',
     });
   }, [evaluatedOpacity, keyframes, playheadTime]);
 
@@ -352,7 +351,6 @@ function KeyframeOpacitySurface({ metrics }: { metrics?: DemoMetrics }) {
         property: 'opacity',
         time: playheadTime,
         value,
-        interpolation: 'linear',
       });
     },
     [keyframes, playheadTime, selectedKeyframe]

--- a/apps/www/src/demos/keyframe-opacity/keyframe-opacity-utils.ts
+++ b/apps/www/src/demos/keyframe-opacity/keyframe-opacity-utils.ts
@@ -63,13 +63,14 @@ export function toggleOpacityKeyframeAtTime(
     return engine.removeClipKeyframe(clipId, existing.id);
   }
 
+  // Omitting interpolation lets new keyframes inherit the previous keyframe's
+  // interpolation mode and easing, keeping the segment's curve character.
   return Boolean(
     engine.setClipKeyframe({
       clipId,
       property: 'opacity',
       time,
       value,
-      interpolation: 'linear',
     })
   );
 }

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -2164,6 +2164,71 @@ describe('TimelineEngine', () => {
       expect(updateEvent).toHaveBeenCalledTimes(4);
     });
 
+    it('inherits interpolation and easing from the previous keyframe when placing new keyframes', () => {
+      const easing = { x1: 0.2, y1: 0.8, x2: 0.8, y2: 0.2 };
+      const first = engine.setClipKeyframe({
+        clipId: 'clip1',
+        property: 'opacity',
+        time: fromSeconds(4),
+        value: 1,
+      });
+      expect(first?.interpolation).toBe('linear');
+
+      engine.setClipKeyframe({
+        clipId: 'clip1',
+        property: 'opacity',
+        time: fromSeconds(1),
+        value: 0,
+        interpolation: 'bezier',
+        easing,
+      });
+
+      const inherited = engine.setClipKeyframe({
+        clipId: 'clip1',
+        property: 'opacity',
+        time: fromSeconds(2),
+        value: 0.5,
+      });
+      expect(inherited?.interpolation).toBe('bezier');
+      expect(inherited?.easing).toEqual(easing);
+
+      const explicit = engine.setClipKeyframe({
+        clipId: 'clip1',
+        property: 'opacity',
+        time: fromSeconds(3),
+        value: 0.75,
+        interpolation: 'linear',
+      });
+      expect(explicit?.interpolation).toBe('linear');
+      expect(explicit?.easing).toBeUndefined();
+    });
+
+    it('keeps neighboring keyframes when preview updates collide', () => {
+      const track = createKeyframeTrack([createKeyframeClip('kf-clip', 0, 10, [2, 3])]);
+      const previewEngine = new TimelineEngine({ tracks: [track] });
+      const dragged = expectDefined(
+        previewEngine.getClipKeyframes('kf-clip')[1],
+        'dragged keyframe'
+      );
+
+      const preview = previewEngine.updateClipKeyframe(
+        { clipId: 'kf-clip', keyframeId: dragged.id, time: fromSeconds(2) },
+        { commit: false }
+      );
+
+      expect(toSeconds(expectDefined(preview, 'preview keyframe').time)).toBe(3);
+      expect(keyframeSeconds(previewEngine.getClip('kf-clip')?.clip)).toEqual([2, 3]);
+
+      const committed = previewEngine.updateClipKeyframe({
+        clipId: 'kf-clip',
+        keyframeId: dragged.id,
+        time: fromSeconds(2),
+      });
+
+      expect(toSeconds(expectDefined(committed, 'committed keyframe').time)).toBe(2);
+      expect(keyframeSeconds(previewEngine.getClip('kf-clip')?.clip)).toEqual([2]);
+    });
+
     it('keeps bezier easing scoped to bezier keyframes when cloning state', () => {
       const easingEngine = new TimelineEngine({
         tracks: [

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1319,6 +1319,11 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
   /**
    * Adds or updates one keyframe by clip, property, and exact timeline time.
+   *
+   * New keyframes created without an explicit `interpolation` inherit the
+   * interpolation mode and Bezier easing of the previous keyframe in the same
+   * property lane, so splitting a segment keeps its easing character. Linear
+   * is used when no previous keyframe exists.
    */
   setClipKeyframe(
     input: TimelineSetClipKeyframeOptions,
@@ -1352,7 +1357,11 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     if (input.interpolation !== undefined) {
       keyframe.interpolation = normalizeTimelineKeyframeInterpolation(input.interpolation);
     } else if (existing === undefined) {
-      keyframe.interpolation = 'linear';
+      const previous = this.getPreviousClipKeyframe(found.clip, input.property, time);
+      keyframe.interpolation = normalizeTimelineKeyframeInterpolation(previous?.interpolation);
+      if (keyframe.interpolation === 'bezier' && input.easing === undefined) {
+        keyframe.easing = normalizeTimelineCubicBezier(previous?.easing);
+      }
     }
     if (input.easing !== undefined) {
       keyframe.easing = normalizeTimelineCubicBezier(input.easing);
@@ -1377,6 +1386,11 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
   /**
    * Updates an existing keyframe.
+   *
+   * Committed updates merge keyframes that land on the same property and
+   * time. Preview updates (`{ commit: false }`) never delete a colliding
+   * neighbor; the keyframe keeps its current time instead, so drag previews
+   * stay non-destructive.
    */
   updateClipKeyframe(
     input: TimelineUpdateClipKeyframeOptions,
@@ -1392,7 +1406,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       return null;
     }
 
-    const nextTime =
+    let nextTime =
       input.time === undefined
         ? keyframe.time
         : this.clampKeyframeTimeToClip(found.clip, input.time);
@@ -1407,7 +1421,12 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
         isSameRationalTime(candidate.time, nextTime)
     );
     if (collision !== undefined) {
-      found.clip.keyframes = found.clip.keyframes.filter((candidate) => candidate !== collision);
+      if (options.commit === false) {
+        // Preview updates (drags) must not destroy neighboring keyframes.
+        nextTime = keyframe.time;
+      } else {
+        found.clip.keyframes = found.clip.keyframes.filter((candidate) => candidate !== collision);
+      }
     }
 
     keyframe.time = cloneRationalTime(nextTime);
@@ -2358,6 +2377,23 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
   private clampKeyframeTimeToClip(clip: Clip, time: RationalTime): RationalTime {
     return minRational(maxRational(time, clip.timelineStart), clip.timelineEnd);
+  }
+
+  private getPreviousClipKeyframe(
+    clip: Clip,
+    property: TimelineKeyframeProperty,
+    time: RationalTime
+  ): TimelineKeyframe | undefined {
+    let previous: TimelineKeyframe | undefined;
+    for (const keyframe of clip.keyframes ?? []) {
+      if (keyframe.property !== property || compareRational(keyframe.time, time) >= 0) {
+        continue;
+      }
+      if (previous === undefined || compareRational(keyframe.time, previous.time) > 0) {
+        previous = keyframe;
+      }
+    }
+    return previous;
   }
 
   private normalizeClipKeyframes(clip: Clip) {

--- a/packages/react/src/base.css
+++ b/packages/react/src/base.css
@@ -353,6 +353,15 @@
   will-change: transform;
 }
 
+.timeline-keyframe-handle-shape {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  box-sizing: border-box;
+  pointer-events: none;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
 .timeline-keyframe-curve-interaction-layer {
   position: absolute;
   right: 0;
@@ -384,6 +393,15 @@
   box-sizing: border-box;
   pointer-events: auto;
   will-change: transform;
+}
+
+.timeline-keyframe-curve-handle-shape {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  box-sizing: border-box;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
 }
 
 .timeline-clip-interaction-overlay {

--- a/packages/react/src/components/interactions/KeyframeCurveInteractionLayer.test.tsx
+++ b/packages/react/src/components/interactions/KeyframeCurveInteractionLayer.test.tsx
@@ -162,6 +162,90 @@ describe('KeyframeCurveInteractionLayer', () => {
     expect(updatedEasing?.y2).toBeCloseTo(0.4);
   });
 
+  it('renders padded hit targets around exact-size handle shapes', () => {
+    const engine = createEngine();
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <KeyframeCurveInteractionLayer curveHandleSize={8} hitPadding={10} />
+      </TimelineProvider>
+    );
+
+    const segment = engine.getKeyframeCurveSegments({ curveHandleSize: 8 })[0];
+    const handle = container.querySelector('[data-handle="outgoing"]') as HTMLElement;
+    const shape = handle.querySelector('.timeline-keyframe-curve-handle-shape') as HTMLElement;
+    const rect = segment.handles[0].rect;
+
+    expect(handle.style.width).toBe(`${rect.width + 20}px`);
+    expect(handle.style.height).toBe(`${rect.height + 20}px`);
+    expect(handle.style.transform).toContain(`translate(${rect.x - 10}px,`);
+    expect(shape.style.width).toBe(`${rect.width}px`);
+    expect(shape.style.height).toBe(`${rect.height}px`);
+  });
+
+  it('selects the anchor keyframe when a handle drag starts', () => {
+    const engine = createEngine();
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <KeyframeCurveInteractionLayer />
+      </TimelineProvider>
+    );
+
+    const handle = container.querySelector('[data-handle="incoming"]') as HTMLElement;
+    fireEvent.pointerDown(handle, {
+      clientX: 200,
+      clientY: 60,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+    });
+
+    const keyframes = engine.getClipKeyframes('clip-1');
+    expect(keyframes.find((keyframe) => keyframe.id === 'opacity-end')?.selected).toBe(true);
+    expect(keyframes.find((keyframe) => keyframe.id === 'opacity-start')?.selected).toBe(false);
+
+    fireEvent.pointerUp(handle, { pointerType: 'mouse', pointerId: 1 });
+  });
+
+  it('keeps dragging through document listeners when pointer capture is unavailable', () => {
+    const engine = createEngine();
+    Element.prototype.setPointerCapture = () => {
+      throw new Error('capture unavailable');
+    };
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <KeyframeCurveInteractionLayer curveHandleSize={8} />
+      </TimelineProvider>
+    );
+
+    const segment = engine.getKeyframeCurveSegments({ curveHandleSize: 8 })[0];
+    const handle = container.querySelector('[data-handle="incoming"]') as HTMLElement;
+
+    fireEvent.pointerDown(handle, {
+      clientX: segment.handles[1].point.x,
+      clientY: segment.handles[1].point.y,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(document, {
+      clientX: segment.startPoint.x + (segment.endPoint.x - segment.startPoint.x) * 0.5,
+      clientY: segment.startPoint.y + (segment.endPoint.y - segment.startPoint.y) * 0.5,
+      pointerType: 'mouse',
+      pointerId: 1,
+    });
+    fireEvent.pointerUp(document, {
+      pointerType: 'mouse',
+      pointerId: 1,
+    });
+
+    const updatedEasing = engine.getClipKeyframes('clip-1')[0].easing;
+    expect(updatedEasing?.x2).toBeCloseTo(0.5);
+    expect(updatedEasing?.y2).toBeCloseTo(0.5);
+  });
+
   it('reports curve handle double-click gestures without built-in policy', () => {
     const engine = createEngine();
     const onCurveHandleDoubleClick = vi.fn();

--- a/packages/react/src/components/interactions/KeyframeCurveInteractionLayer.tsx
+++ b/packages/react/src/components/interactions/KeyframeCurveInteractionLayer.tsx
@@ -51,6 +51,13 @@ export interface KeyframeCurveInteractionLayerProps
   keyframeSize?: number;
   /** Bezier control handle square size in CSS pixels. */
   curveHandleSize?: number;
+  /**
+   * Invisible pointer padding in CSS pixels added around each Bezier handle.
+   *
+   * Presses inside the padded area target the curve handle instead of falling
+   * through to lower interaction layers such as the clip layer. Defaults to 8.
+   */
+  hitPadding?: number;
   /** Vertical padding used when mapping keyframe values into a clip row. */
   keyframeValuePadding?: number;
   /** Optional handler for double-click or double-tap gestures on curve handles. */
@@ -105,6 +112,7 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
       overscanPixels,
       keyframeSize,
       curveHandleSize,
+      hitPadding = 8,
       keyframeValuePadding,
       onCurveHandleDoubleClick,
       getCurveHandleAriaLabel,
@@ -121,6 +129,7 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
     const { engine } = useTimeline();
     const internalRef = useRef<HTMLDivElement>(null);
     const activeHandleRef = useRef<ActiveCurveHandle | null>(null);
+    const fallbackListenersRef = useRef<(() => void) | null>(null);
     const [hoveredHandle, setHoveredHandle] = useState<HoveredCurveHandle | null>(null);
     const geometry = useMemo(
       () => ({
@@ -187,19 +196,26 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
       [rulerHeight]
     );
 
+    const removeFallbackListeners = useCallback(() => {
+      fallbackListenersRef.current?.();
+      fallbackListenersRef.current = null;
+    }, []);
+
     useEffect(() => {
       return () => {
+        removeFallbackListeners();
         if (activeHandleRef.current) {
           activeHandleRef.current = null;
           cancelKeyframeCurveDrag();
         }
       };
-    }, [cancelKeyframeCurveDrag]);
+    }, [cancelKeyframeCurveDrag, removeFallbackListeners]);
 
     const stopActiveDrag = useCallback(
       (event: PointerEvent | React.PointerEvent, target: HTMLElement) => {
         const active = activeHandleRef.current;
         activeHandleRef.current = null;
+        removeFallbackListeners();
 
         try {
           target.releasePointerCapture(event.pointerId);
@@ -211,7 +227,7 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
           endKeyframeCurveDrag();
         }
       },
-      [endKeyframeCurveDrag]
+      [endKeyframeCurveDrag, removeFallbackListeners]
     );
 
     const moveActiveDrag = useCallback(
@@ -232,7 +248,11 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
     const handlePointerDown = useCallback(
       (event: React.PointerEvent<HTMLDivElement>, handle: TimelineKeyframeCurveHandle) => {
         onPointerDown?.(event);
-        if (event.defaultPrevented || !handle.canEdit) {
+        if (
+          event.defaultPrevented ||
+          !handle.canEdit ||
+          (event.pointerType !== 'touch' && event.button !== 0)
+        ) {
           return;
         }
 
@@ -253,16 +273,55 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
         }
 
         event.preventDefault();
-        event.currentTarget.setPointerCapture(event.pointerId);
+        event.stopPropagation();
+        engine.selectClipKeyframe(handle.clip.id, handle.anchorKeyframe.id);
+
+        const target = event.currentTarget;
         activeHandleRef.current = {
           clipId: handle.clip.id,
           segmentId: handle.segmentId,
           keyframeId: handle.keyframe.id,
           handle: handle.handle,
-          target: event.currentTarget,
+          target,
+        };
+        try {
+          target.setPointerCapture(event.pointerId);
+        } catch {
+          // Document listeners below keep dragging functional if capture is unavailable.
+        }
+
+        removeFallbackListeners();
+        const ownerDocument = target.ownerDocument;
+        const handleDocumentPointerMove = (nativeEvent: PointerEvent) => {
+          if (!activeHandleRef.current) {
+            return;
+          }
+          moveActiveDrag(nativeEvent);
+        };
+        const handleDocumentPointerEnd = (nativeEvent: PointerEvent) => {
+          if (!activeHandleRef.current) {
+            return;
+          }
+          stopActiveDrag(nativeEvent, target);
+        };
+        ownerDocument.addEventListener('pointermove', handleDocumentPointerMove);
+        ownerDocument.addEventListener('pointerup', handleDocumentPointerEnd);
+        ownerDocument.addEventListener('pointercancel', handleDocumentPointerEnd);
+        fallbackListenersRef.current = () => {
+          ownerDocument.removeEventListener('pointermove', handleDocumentPointerMove);
+          ownerDocument.removeEventListener('pointerup', handleDocumentPointerEnd);
+          ownerDocument.removeEventListener('pointercancel', handleDocumentPointerEnd);
         };
       },
-      [engine, onCurveHandleDoubleClick, onPointerDown, startKeyframeCurveDrag]
+      [
+        engine,
+        moveActiveDrag,
+        onCurveHandleDoubleClick,
+        onPointerDown,
+        removeFallbackListeners,
+        startKeyframeCurveDrag,
+        stopActiveDrag,
+      ]
     );
 
     const handlePointerMove = useCallback(
@@ -292,10 +351,11 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
         onPointerCancel?.(event);
         if (activeHandleRef.current) {
           activeHandleRef.current = null;
+          removeFallbackListeners();
           cancelKeyframeCurveDrag();
         }
       },
-      [cancelKeyframeCurveDrag, onPointerCancel]
+      [cancelKeyframeCurveDrag, onPointerCancel, removeFallbackListeners]
     );
 
     const handleLostPointerCapture = useCallback(
@@ -338,6 +398,7 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
         {visibleHandles.map((handle) => {
           const active = isSameCurveHandle(activeHandleRef.current, handle);
           const hovered = isSameCurveHandle(hoveredHandle, handle);
+          const pad = Math.max(0, hitPadding);
 
           return (
             <div
@@ -355,9 +416,9 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
               data-hovered={hovered ? 'true' : undefined}
               data-editable={handle.canEdit ? 'true' : undefined}
               style={{
-                transform: `translate(${handle.rect.x}px, ${handle.rect.y - rulerHeight}px)`,
-                width: `${handle.rect.width}px`,
-                height: `${handle.rect.height}px`,
+                transform: `translate(${handle.rect.x - pad}px, ${handle.rect.y - rulerHeight - pad}px)`,
+                width: `${handle.rect.width + pad * 2}px`,
+                height: `${handle.rect.height + pad * 2}px`,
               }}
               onFocus={() => {
                 engine.selectClipKeyframe(handle.clip.id, handle.anchorKeyframe.id);
@@ -381,7 +442,16 @@ export const KeyframeCurveInteractionLayer = React.forwardRef<
               onPointerUp={handlePointerUp}
               onPointerCancel={handlePointerCancel}
               onLostPointerCapture={handleLostPointerCapture}
-            />
+            >
+              <div
+                className="timeline-keyframe-curve-handle-shape"
+                aria-hidden="true"
+                style={{
+                  width: `${handle.rect.width}px`,
+                  height: `${handle.rect.height}px`,
+                }}
+              />
+            </div>
           );
         })}
       </div>

--- a/packages/react/src/components/interactions/KeyframeInteractionLayer.test.tsx
+++ b/packages/react/src/components/interactions/KeyframeInteractionLayer.test.tsx
@@ -121,6 +121,35 @@ describe('KeyframeInteractionLayer', () => {
     expect(startDrag).not.toHaveBeenCalled();
   });
 
+  it('renders padded hit targets around exact-size keyframe shapes', () => {
+    const engine = createEngine();
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <KeyframeInteractionLayer
+          property="opacity"
+          selectedClipOnly
+          keyframeSize={6}
+          hitPadding={9}
+        />
+      </TimelineProvider>
+    );
+
+    const rect = engine
+      .getKeyframeRects({ keyframeSize: 6 })
+      .find((entry) => entry.keyframe.id === 'opacity-middle')?.rect;
+    const handle = container.querySelector('[data-keyframe-id="opacity-middle"]') as HTMLElement;
+    const shape = handle.querySelector('.timeline-keyframe-handle-shape') as HTMLElement;
+
+    expect(rect).toBeDefined();
+    expect(handle.style.width).toBe(`${(rect?.width ?? 0) + 18}px`);
+    expect(handle.style.height).toBe(`${(rect?.height ?? 0) + 18}px`);
+    expect(handle.style.transform).toContain(`translate(${(rect?.x ?? 0) - 9}px,`);
+    expect(handle.style.transform).not.toContain('rotate');
+    expect(shape.style.width).toBe(`${rect?.width ?? 0}px`);
+    expect(shape.style.height).toBe(`${rect?.height ?? 0}px`);
+  });
+
   it('drags a clamped edge keyframe from its actual timeline time', () => {
     const engine = createEngine();
 

--- a/packages/react/src/components/interactions/KeyframeInteractionLayer.tsx
+++ b/packages/react/src/components/interactions/KeyframeInteractionLayer.tsx
@@ -55,6 +55,13 @@ export interface KeyframeInteractionLayerProps
   overscanPixels?: number;
   /** Keyframe affordance square size in CSS pixels. */
   keyframeSize?: number;
+  /**
+   * Invisible pointer padding in CSS pixels added around each keyframe handle.
+   *
+   * Presses inside the padded area target the keyframe instead of falling
+   * through to lower interaction layers such as the clip layer. Defaults to 8.
+   */
+  hitPadding?: number;
   /** Vertical padding used when mapping keyframe values into a clip row. */
   keyframeValuePadding?: number;
   /** Keyboard nudge amount in seconds for left/right arrow keys. Defaults to one 30fps frame. */
@@ -98,6 +105,7 @@ export const KeyframeInteractionLayer = React.forwardRef<
       selectedClipOnly = false,
       overscanPixels,
       keyframeSize,
+      hitPadding = 8,
       keyframeValuePadding,
       keyboardStepSeconds = 1 / 30,
       onKeyframeDoubleClick,
@@ -439,6 +447,7 @@ export const KeyframeInteractionLayer = React.forwardRef<
           const hovered =
             hoveredKeyframe?.clipId === entry.clip.id &&
             hoveredKeyframe.keyframeId === entry.keyframe.id;
+          const pad = Math.max(0, hitPadding);
 
           return (
             <div
@@ -455,9 +464,9 @@ export const KeyframeInteractionLayer = React.forwardRef<
               data-hovered={hovered ? 'true' : undefined}
               data-editable={entry.canEdit ? 'true' : undefined}
               style={{
-                transform: `translate(${entry.rect.x}px, ${entry.rect.y - rulerHeight}px) rotate(45deg)`,
-                width: `${entry.rect.width}px`,
-                height: `${entry.rect.height}px`,
+                transform: `translate(${entry.rect.x - pad}px, ${entry.rect.y - rulerHeight - pad}px)`,
+                width: `${entry.rect.width + pad * 2}px`,
+                height: `${entry.rect.height + pad * 2}px`,
               }}
               onFocus={() => {
                 keyframes.selectKeyframe(entry.clip.id, entry.keyframe.id);
@@ -478,7 +487,16 @@ export const KeyframeInteractionLayer = React.forwardRef<
               onPointerUp={handlePointerUp}
               onPointerCancel={handlePointerCancel}
               onLostPointerCapture={handleLostPointerCapture}
-            />
+            >
+              <div
+                className="timeline-keyframe-handle-shape"
+                aria-hidden="true"
+                style={{
+                  width: `${entry.rect.width}px`,
+                  height: `${entry.rect.height}px`,
+                }}
+              />
+            </div>
           );
         })}
       </div>

--- a/packages/react/src/theme.css
+++ b/packages/react/src/theme.css
@@ -383,7 +383,7 @@
   outline-offset: -1.5px;
 }
 
-.timeline-keyframe-handle {
+.timeline-keyframe-handle-shape {
   border: 1px solid var(--timeline-keyframe-stroke);
   background: var(--timeline-keyframe-fill);
   box-shadow: 0 0 0 1px color-mix(in oklch, var(--background) 34%, transparent);
@@ -394,16 +394,16 @@
     opacity 150ms ease;
 }
 
-.timeline-keyframe-handle[data-hovered='true'],
-.timeline-keyframe-handle:focus-visible {
+.timeline-keyframe-handle[data-hovered='true'] .timeline-keyframe-handle-shape,
+.timeline-keyframe-handle:focus-visible .timeline-keyframe-handle-shape {
   border-color: var(--timeline-keyframe-stroke-selected);
   box-shadow:
     0 0 0 1px var(--timeline-keyframe-stroke-selected),
     0 0 0 4px color-mix(in oklch, var(--timeline-keyframe-stroke-selected) 22%, transparent);
 }
 
-.timeline-keyframe-handle[data-selected='true'],
-.timeline-keyframe-handle[data-active='true'] {
+.timeline-keyframe-handle[data-selected='true'] .timeline-keyframe-handle-shape,
+.timeline-keyframe-handle[data-active='true'] .timeline-keyframe-handle-shape {
   border-color: var(--timeline-keyframe-stroke-selected);
   background: var(--timeline-keyframe-fill-selected);
 }
@@ -423,7 +423,7 @@
   opacity: 0.75;
 }
 
-.timeline-keyframe-curve-handle {
+.timeline-keyframe-curve-handle-shape {
   border: 1px solid var(--timeline-keyframe-stroke-selected);
   border-radius: var(--timeline-radius-full);
   background: var(--timeline-panel);
@@ -437,15 +437,15 @@
     opacity 150ms ease;
 }
 
-.timeline-keyframe-curve-handle[data-hovered='true'],
-.timeline-keyframe-curve-handle:focus-visible {
+.timeline-keyframe-curve-handle[data-hovered='true'] .timeline-keyframe-curve-handle-shape,
+.timeline-keyframe-curve-handle:focus-visible .timeline-keyframe-curve-handle-shape {
   background: var(--timeline-keyframe-fill-selected);
   box-shadow:
     0 0 0 1px var(--timeline-keyframe-stroke-selected),
     0 0 0 4px color-mix(in oklch, var(--timeline-keyframe-stroke-selected) 22%, transparent);
 }
 
-.timeline-keyframe-curve-handle[data-active='true'] {
+.timeline-keyframe-curve-handle[data-active='true'] .timeline-keyframe-curve-handle-shape {
   background: var(--timeline-keyframe-fill-selected);
 }
 


### PR DESCRIPTION
## Summary

- Keyframe and Bezier curve handles rendered as exact-size DOM nodes, so a press missing by a pixel fell through to the full-surface `ClipInteractionLayer` and started a clip move/trim instead of grabbing the handle. Handles now wrap their visual shape in an invisible padded hit target via a new `hitPadding` prop (default 8px).
- `KeyframeCurveInteractionLayer` now mirrors the keyframe layer's robustness: guarded pointer capture with document-level fallback listeners, ignores non-primary buttons, and selects the anchor keyframe on drag start (the old `onFocus` path never fired because `preventDefault` suppresses focus).
- `updateClipKeyframe` no longer deletes colliding neighbors during `{ commit: false }` drag previews — dragging a keyframe across another was silently destroying it. The dragged keyframe holds its last non-colliding time; merges happen only on committed edits.
- `setClipKeyframe` inherits interpolation mode and Bezier easing from the previous keyframe when `interpolation` is omitted, so placing a keyframe on a bezier segment keeps its curve character. The opacity demo's placement paths were updated to rely on this.

## Release Impact

- Packages/API: `@techsquidtv/canvas-timeline-core` (patch) and `@techsquidtv/canvas-timeline-react` (patch). Additive `hitPadding` prop on both keyframe interaction layers; behavior fixes to core keyframe mutation. Changeset included.
- Docs/demos: `keyframes.mdx` documents the new behaviors; opacity demo placement simplified. `docs:demos` verified.
- Breaking changes: None. `hitPadding` is optional; new-keyframe interpolation inheritance only applies when `interpolation` is omitted.
- Checklist areas reviewed: 3 (React interactions), 4 (renderer/styling), 8 (docs/demos).

## Validation

- `vp check` (format, lint, types — 251 files clean)
- `vp test packages/core packages/react` (310 tests pass; 6 new: preview-collision safety, placement inheritance, padded hit targets, capture-failure fallback, anchor selection)
- `vp run --filter @techsquidtv/canvas-timeline-www docs:demos` (8 demos verified)
- Browser-driven check against the live opacity demo: a near-miss press 6px off a curve-handle dot grabs the handle and drags the curve while the clip overlay stays at `translate(0px, 0px)`; the same near-miss on a keyframe diamond moves the keyframe, not the clip; a keyframe placed mid-Ease-segment reads back Curve: Ease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)