### PR TITLE
docs(www): clarify docs markdown index

### DIFF
--- a/.changeset/clarify-docs-markdown-index.md
+++ b/.changeset/clarify-docs-markdown-index.md
@@ -1,0 +1,4 @@
+---
+---
+
+Clarify the docs Markdown copy action and generated docs index output.

--- a/apps/www/src/layouts/DocsLayout.astro
+++ b/apps/www/src/layouts/DocsLayout.astro
@@ -22,6 +22,9 @@ interface Props {
   previous?: PagerLink;
   next?: PagerLink;
   markdownHref?: string;
+  markdownLabel?: string;
+  markdownAriaLabel?: string;
+  markdownTooltip?: string;
   structuredData?: StructuredDataInput;
 }
 
@@ -34,6 +37,9 @@ const {
   previous,
   next,
   markdownHref,
+  markdownLabel,
+  markdownAriaLabel,
+  markdownTooltip,
   structuredData,
 } = Astro.props;
 const tocHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
@@ -63,7 +69,13 @@ const breadcrumbs = [
       </div>
       {
         markdownHref ? (
-          <MarkdownCopyButton href={markdownHref} class="docs-markdown-copy" />
+          <MarkdownCopyButton
+            href={markdownHref}
+            label={markdownLabel}
+            ariaLabel={markdownAriaLabel}
+            tooltip={markdownTooltip}
+            class="docs-markdown-copy"
+          />
         ) : null
       }
     </div>

--- a/apps/www/src/lib/docs-markdown.test.ts
+++ b/apps/www/src/lib/docs-markdown.test.ts
@@ -92,19 +92,47 @@ const value = '<Timeline.Root />';
 
   test('builds docs index Markdown with canonical sibling md links', () => {
     const markdown = buildDocsIndexMarkdown([
-      entry('getting-started', 'Getting Started', 'Install and render your first timeline.', 10),
-      entry('architecture', 'System Architecture', 'Understand the rendering layers.', 20),
+      entry(
+        'architecture',
+        'System Architecture',
+        'Understand the rendering layers.',
+        'concepts',
+        20
+      ),
+      entry(
+        'getting-started',
+        'Getting Started',
+        'Install and render your first timeline.',
+        'intro',
+        10
+      ),
     ]);
 
     expect(markdown).toContain('# Canvas Timeline documentation');
     expect(markdown).toContain('Source: https://canvastimeline.com/docs');
     expect(markdown).toContain('Markdown: https://canvastimeline.com/docs.md');
-    expect(markdown).toContain('[Getting Started](/docs/getting-started)');
+    expect(markdown).toContain('This Markdown file is a generated documentation index.');
+    expect(markdown).toContain(
+      '- **Getting Started** - Install and render your first timeline. [Page](/docs/getting-started) | [Markdown](/docs/getting-started.md)'
+    );
+    expect(markdown).toContain(
+      '- **System Architecture** - Understand the rendering layers. [Page](/docs/architecture) | [Markdown](/docs/architecture.md)'
+    );
+    expect(markdown.indexOf('### Start here')).toBeLessThan(markdown.indexOf('### Concepts'));
+    expect(markdown.indexOf('**Getting Started**')).toBeLessThan(
+      markdown.indexOf('**System Architecture**')
+    );
     expect(markdown).not.toContain('/docs/getting-started/index.md');
   });
 });
 
-function entry(id: string, title: string, description: string, order: number): DocsMarkdownEntry {
+function entry(
+  id: string,
+  title: string,
+  description: string,
+  section: DocsMarkdownEntry['data']['section'],
+  order: number
+): DocsMarkdownEntry {
   return {
     id,
     body: '',
@@ -112,7 +140,7 @@ function entry(id: string, title: string, description: string, order: number): D
       title,
       description,
       order,
-      section: 'intro',
+      section,
     },
   };
 }

--- a/apps/www/src/lib/docs-markdown.ts
+++ b/apps/www/src/lib/docs-markdown.ts
@@ -81,6 +81,8 @@ export function buildDocsIndexMarkdown(
   const body = [
     'Welcome to the documentation for **Canvas Timeline**. This library helps you build high-performance, frame-accurate, and customizable video, audio, or animation timelines in React.',
     '',
+    'This Markdown file is a generated documentation index. Each listed page also has its own Markdown endpoint for copying or LLM-assisted lookup.',
+    '',
     '```shell',
     'pnpm add @techsquidtv/canvas-timeline',
     '```',
@@ -144,7 +146,10 @@ function sectionMarkdown(sectionId: DocsSectionId, title: string, docs: readonly
   return [
     `### ${title}`,
     '',
-    ...sectionDocs.map((doc) => `- [${doc.data.title}](/docs/${doc.id}) - ${doc.data.description}`),
+    ...sectionDocs.map(
+      (doc) =>
+        `- **${doc.data.title}** - ${doc.data.description} [Page](/docs/${doc.id}) | [Markdown](/docs/${doc.id}.md)`
+    ),
     '',
   ];
 }

--- a/apps/www/src/pages/docs/index.astro
+++ b/apps/www/src/pages/docs/index.astro
@@ -18,6 +18,9 @@ const structuredData = createDocsArticleStructuredData({
   description={description}
   currentSlug=""
   markdownHref="/docs.md"
+  markdownLabel="Copy Docs Index"
+  markdownAriaLabel="Copy the documentation index as Markdown"
+  markdownTooltip="Copies a generated Markdown map of docs pages, with links to each page and its Markdown endpoint."
   structuredData={structuredData}
 >
   <div class="docs-home">


### PR DESCRIPTION
## Summary

- Clarifies `/docs.md` as a generated Markdown docs index rather than a full docs export.
- Adds page and Markdown endpoint links for each generated docs entry.
- Updates the `/docs/` copy button to say `Copy Docs Index` while individual docs pages keep page-level Markdown copying.

## Release Impact

- Packages/API: None
- Docs/demos: Docs site copy behavior clarified
- Breaking changes: None
- Checklist areas reviewed: 8 and 9

## Validation

- `vp test apps/www/src/lib/docs-markdown.test.ts`
- `vp run build:packages`
- `vp check` (passes with one existing warning in `apps/www/src/lib/api-reference.ts`)
- `vp run --filter @techsquidtv/canvas-timeline-www build`
