### PR TITLE
docs(www): fix homepage code collapse range

### DIFF
--- a/.changeset/fix-homepage-code-collapse.md
+++ b/.changeset/fix-homepage-code-collapse.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the homepage App.tsx code block collapse range.

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -270,7 +270,7 @@ function App() {
             code={appExampleCode}
             lang="tsx"
             title="App.tsx"
-            collapse="12-43"
+            collapse="13-44"
             collapseStyle="collapsible-auto"
             class="homepage-code-block"
           />


### PR DESCRIPTION
## Summary

- Shift the homepage App.tsx code block collapsed range from 12-43 to 13-44.
- Add an empty changeset marker for the required PR Changeset status check.

## Release Impact

- Packages/API: None.
- Docs/demos: Docs-site homepage display metadata only.
- Breaking changes: None.
- Checklist areas reviewed: 0, 3, 8.

## Validation

- `vp run --filter @techsquidtv/canvas-timeline-www docs:registry`
- `printf '%s\n' "docs(www): fix homepage code collapse range" | vp exec commitlint --verbose`
- `vp exec changeset status --since=origin/main`
- `vp check` currently fails on existing unrelated repo type/lint issues outside this change, including unresolved internal package imports in tests and adapter/API test drift.