### PR TITLE
ci(www): deploy docs from Astro client output

### DIFF
--- a/.changeset/fix-www-pages-deploy-root.md
+++ b/.changeset/fix-www-pages-deploy-root.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the docs-site Cloudflare Pages deploy root.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/www
-          command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
+          command: pages deploy dist/client --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
 
       - name: Deploy preview docs to Cloudflare Pages
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
@@ -89,7 +89,7 @@ jobs:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/www
-          command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}
+          command: pages deploy dist/client --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}
 
       - name: Comment docs preview URL
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.deploy-preview.conclusion == 'success'


### PR DESCRIPTION
## Summary

- Deploy Cloudflare Pages from `apps/www/dist/client` instead of `apps/www/dist`.
- Apply the same output root to production and preview docs deploys.
- Add an empty changeset because this does not affect published package contents.

## Release Impact

- Packages/API: None.
- Docs/demos: Fixes docs-site deployment asset root for Cloudflare Pages.
- Breaking changes: None.
- Checklist areas reviewed: 6 and 9.

## Validation

- `vp exec changeset status --since=origin/main`
- `printf '%s\n' 'ci(www): deploy docs from Astro client output' | vp exec commitlint --verbose`