### PR TITLE
feat(timeline)!: add clip grouping API

### DIFF
--- a/.changeset/clip-grouping-api.md
+++ b/.changeset/clip-grouping-api.md
@@ -1,8 +1,4 @@
 ---
-'@techsquidtv/canvas-timeline': major
-'@techsquidtv/canvas-timeline-core': major
-'@techsquidtv/canvas-timeline-react': major
-'@techsquidtv/canvas-timeline-utils': patch
 ---
 
 Add first-class clip grouping support for linked timeline edits.

--- a/.changeset/clip-grouping-api.md
+++ b/.changeset/clip-grouping-api.md
@@ -1,0 +1,21 @@
+---
+'@techsquidtv/canvas-timeline': major
+'@techsquidtv/canvas-timeline-core': major
+'@techsquidtv/canvas-timeline-react': major
+'@techsquidtv/canvas-timeline-utils': patch
+---
+
+Add first-class clip grouping support for linked timeline edits.
+
+This is a breaking model/API change: `TimelineState` now owns `clipGroups`,
+selection supports primary-plus-many clip state, move results include
+`changedClips`, and split edits are represented as a command-layer operation.
+Grouped clips can be selected together, moved together, deleted/copied/pasted as
+groups, and split at the playhead with group repartitioning after the cut.
+
+React hooks now expose clip group state and commands through
+`useTimelineClipGroups`, multi-selection fields through selection and clip hooks,
+and split commands through `useTimelineEditCommands`.
+
+Rational time addition/subtraction now uses a reduced common integer rate to
+avoid denominator blow-ups during repeated mixed-rate edits.

--- a/apps/www/src/components/LiveDemoRenderer.tsx
+++ b/apps/www/src/components/LiveDemoRenderer.tsx
@@ -61,6 +61,7 @@ const liveDemoComponents: Record<
   'media-sync': createLazyDemo(liveDemoLoaders['media-sync']),
   'html-media-sync': createLazyDemo(liveDemoLoaders['html-media-sync']),
   'editor-controls': createLazyDemo(liveDemoLoaders['editor-controls']),
+  'clip-grouping-import': createLazyDemo(liveDemoLoaders['clip-grouping-import']),
   'keyframe-opacity': createLazyDemo(liveDemoLoaders['keyframe-opacity']),
   'stress-test': createLazyDemo(liveDemoLoaders['stress-test']),
   'react-dom-timeline': createLazyDemo(liveDemoLoaders['react-dom-timeline']),

--- a/apps/www/src/content/docs/architecture.mdx
+++ b/apps/www/src/content/docs/architecture.mdx
@@ -160,6 +160,7 @@ At the top level, `TimelineState` contains:
 | Field                  | Type                        | What it represents                                             |
 | :--------------------- | :-------------------------- | :------------------------------------------------------------- |
 | `tracks`               | `Track[]`                   | Ordered lanes and their clips.                                 |
+| `clipGroups`           | `TimelineClipGroup[]`       | Clip ids edited together as linked timeline groups.            |
 | `playheadTime`         | `RationalTime`              | The current edit or playback cursor.                           |
 | `zoomScale`            | `number`                    | Horizontal scale in pixels per second.                         |
 | `scrollLeft`           | `number`                    | Horizontal viewport offset in pixels.                          |

--- a/apps/www/src/content/docs/react-hooks.mdx
+++ b/apps/www/src/content/docs/react-hooks.mdx
@@ -26,8 +26,9 @@ Use the timeline hook registry groups as the source of truth:
 - **Timeline State**: engine context, state snapshots, active clips/layers,
   viewport data, ruler ticks, clip geometry, and visible clip queries.
 - **Editing Hooks**: edit mode, typed edit commands, shared edit previews,
-  range selection, clip, track, marker, selection, clipboard, history, track
-  header, edit consequences, and cross-track drag/drop interactions.
+  range selection, clip, clip group, track, marker, selection, clipboard,
+  history, track header, edit consequences, and cross-track drag/drop
+  interactions.
 - **Playback Controls**: transport state, live playhead time, snapping, media
   synchronization, and clip playback effects.
 - **Accessible Controls**: Base UI-compatible sliders, viewport scrollbar
@@ -59,6 +60,8 @@ Compose the focused hooks around it:
   guides and affected-clip affordances.
 - `useTimelineRangeSelection()` adapts In/Out points to `delete-range` and
   `lift-range` commands.
+- `useTimelineClipGroups()` reads timeline clip groups and exposes group,
+  ungroup, and selected-group commands for editor chrome.
 
 ```tsx
 import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';

--- a/apps/www/src/content/docs/tracks-and-clips.mdx
+++ b/apps/www/src/content/docs/tracks-and-clips.mdx
@@ -26,7 +26,7 @@ interface Track {
   collapsed?: boolean; // Minimizes the track row UI
   name?: string; // User-facing track label
   targeted: boolean; // Receives operations like insert or paste
-  groupId?: string; // Grouping identifier for multi-lane coordination
+  groupId?: string; // Optional visual/header grouping for tracks
 }
 ```
 
@@ -53,6 +53,40 @@ interface Clip {
   editPreview?: EditPreview; // Transient state details during an active edit gesture
 }
 ```
+
+### Grouping Clips
+
+Clip grouping is stored in top-level `TimelineState.clipGroups`, not on each
+clip. A group links arbitrary clip ids at their existing timeline positions, so
+clips can live on different tracks and still select, move, delete, copy, paste,
+and split together.
+
+```ts
+interface TimelineClipGroup {
+  id: string; // Stable group identifier
+  clipIds: string[]; // Ordered clip ids in the group
+  label?: string; // Optional app-facing group label
+}
+```
+
+Use `createClipGroup` when clips already exist on the timeline. Use
+`insertClipGroup` when your app has created multiple clips, such as video and
+audio clips from one imported media file, and wants to place them on chosen
+tracks in one history entry.
+
+```ts
+engine.insertClipGroup({
+  groupId: 'import-1',
+  placements: [
+    { clip: videoClip, targetTrackId: 'video-1', startTime },
+    { clip: audioClip, targetTrackId: 'audio-1', startTime },
+  ],
+});
+```
+
+Canvas Timeline owns the generic edit behavior for groups. Your application
+still owns file picking, media inspection, waveform and thumbnail data, source
+metadata, track choice, and deciding whether imported media should be grouped.
 
 ### Choosing Track Kinds
 

--- a/apps/www/src/data/demo-code.ts
+++ b/apps/www/src/data/demo-code.ts
@@ -9,6 +9,9 @@ import editorControlsTimelineSource from '../demos/timeline-editor-controls/Time
 import editorControlsDataSource from '../demos/timeline-editor-controls/timeline-demo-data.ts?raw';
 import editorControlsUtilitiesSource from '../demos/timeline-editor-controls/timeline-controls.tsx?raw';
 import editorControlsLocalStylesSource from '../demos/timeline-editor-controls/timeline-editor.css?raw';
+import clipGroupingTimelineSource from '../demos/clip-grouping-import/ClipGroupingImportTimeline.tsx?raw';
+import clipGroupingDataSource from '../demos/clip-grouping-import/timeline-demo-data.ts?raw';
+import clipGroupingLocalStylesSource from '../demos/clip-grouping-import/timeline-editor.css?raw';
 import keyframeOpacityTimelineSource from '../demos/keyframe-opacity/KeyframeOpacityTimeline.tsx?raw';
 import keyframeOpacityDataSource from '../demos/keyframe-opacity/timeline-demo-data.ts?raw';
 import keyframeOpacityUtilsSource from '../demos/keyframe-opacity/keyframe-opacity-utils.ts?raw';
@@ -76,6 +79,7 @@ const editorControlsStylesSource = inlineSharedTimelineEditorStyles(
 const keyframeOpacityStylesSource = inlineSharedTimelineEditorStyles(
   keyframeOpacityLocalStylesSource
 );
+const clipGroupingStylesSource = inlineSharedTimelineEditorStyles(clipGroupingLocalStylesSource);
 
 export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
   basic: {
@@ -136,6 +140,21 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
       ],
       data: 'apps/www/src/demos/timeline-editor-controls/timeline-demo-data.ts',
       styles: 'apps/www/src/demos/timeline-editor-controls/timeline-editor.css',
+    },
+  },
+  'clip-grouping-import': {
+    tsx: toCopyableDemoSource(clipGroupingTimelineSource),
+    css: clipGroupingStylesSource,
+    extraTabs: [demoClipColorsTab],
+    data: toCopyableDemoSource(clipGroupingDataSource),
+    sourceFiles: {
+      component: 'apps/www/src/demos/clip-grouping-import/ClipGroupingImportTimeline.tsx',
+      utilities: [
+        'apps/www/src/demos/demo-clip-colors.ts',
+        'apps/www/src/demos/shared-timeline-editor.css',
+      ],
+      data: 'apps/www/src/demos/clip-grouping-import/timeline-demo-data.ts',
+      styles: 'apps/www/src/demos/clip-grouping-import/timeline-editor.css',
     },
   },
   'keyframe-opacity': {

--- a/apps/www/src/data/demo-components.ts
+++ b/apps/www/src/data/demo-components.ts
@@ -18,6 +18,10 @@ export const liveDemoLoaders: Record<LiveDemoId, LiveDemoLoader> = {
     import('../demos/timeline-editor-controls/TimelineEditorControls').then(
       (module) => module.TimelineEditorControls
     ),
+  'clip-grouping-import': () =>
+    import('../demos/clip-grouping-import/ClipGroupingImportTimeline').then(
+      (module) => module.ClipGroupingImportTimeline
+    ),
   'keyframe-opacity': () =>
     import('../demos/keyframe-opacity/KeyframeOpacityTimeline').then(
       (module) => module.KeyframeOpacityTimeline

--- a/apps/www/src/data/demos.ts
+++ b/apps/www/src/data/demos.ts
@@ -12,6 +12,7 @@ export type LiveDemoId =
   | 'media-sync'
   | 'html-media-sync'
   | 'editor-controls'
+  | 'clip-grouping-import'
   | 'keyframe-opacity'
   | 'stress-test'
   | 'react-dom-timeline'
@@ -124,6 +125,22 @@ export const demoDocs: DemoDoc[] = [
     ],
     sourcePath: 'apps/www/src/demos/timeline-editor-controls/TimelineEditorControls.tsx',
     liveDemoId: 'editor-controls',
+  },
+  {
+    slug: 'clip-grouping-import',
+    title: 'Clip Grouping',
+    description:
+      'A two-track timeline with one video clip and one audio clip that can be selected, grouped, moved together, and ungrouped.',
+    status: 'Controls',
+    difficulty: 'Intermediate',
+    packageFocus: [
+      '@techsquidtv/canvas-timeline-core',
+      '@techsquidtv/canvas-timeline-react',
+      '@techsquidtv/canvas-timeline-renderer',
+      '@techsquidtv/canvas-timeline-utils',
+    ],
+    sourcePath: 'apps/www/src/demos/clip-grouping-import/ClipGroupingImportTimeline.tsx',
+    liveDemoId: 'clip-grouping-import',
   },
   {
     slug: 'keyframe-opacity',

--- a/apps/www/src/demos/clip-grouping-import/ClipGroupingImportTimeline.tsx
+++ b/apps/www/src/demos/clip-grouping-import/ClipGroupingImportTimeline.tsx
@@ -1,0 +1,187 @@
+import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import {
+  Timeline,
+  TimelineProvider,
+  useTimeline,
+  useTimelineClipGroups,
+  useTimelineEditCommands,
+  useTimelinePlayheadTime,
+  useTimelineSelection,
+} from '@techsquidtv/canvas-timeline-react';
+import { CanvasRenderer } from '@techsquidtv/canvas-timeline-renderer';
+import { compareRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { Link2, Scissors, Unlink } from 'lucide-react';
+import { useMemo } from 'react';
+import { demoMarkers, demoTracks, linkedClipGroupLabel } from './timeline-demo-data';
+import '@techsquidtv/canvas-timeline-react/styles.css';
+import './timeline-editor.css';
+
+function TrackHeaderColumn() {
+  const { state } = useTimeline();
+
+  return (
+    <Timeline.TrackHeaderList className="timeline-editor-track-headers">
+      {state.tracks.map((track) => (
+        <Timeline.TrackHeader key={track.id} trackId={track.id}>
+          {(header) => (
+            <div className="timeline-editor-track-header-content clip-grouping-track-header-content">
+              <span className="timeline-editor-track-header-label">{header.label}</span>
+            </div>
+          )}
+        </Timeline.TrackHeader>
+      ))}
+    </Timeline.TrackHeaderList>
+  );
+}
+
+function TimelineLayers() {
+  const { state } = useTimeline();
+
+  return (
+    <>
+      <Timeline.PlayheadArea />
+      <Timeline.PlayheadGrabber />
+      <Timeline.TrackList className="timeline-track-list-overlay">
+        {state.tracks.map((track) => (
+          <Timeline.Track key={track.id} trackId={track.id} />
+        ))}
+      </Timeline.TrackList>
+      <Timeline.ClipInteractionLayer />
+      <Timeline.RangeSelector />
+    </>
+  );
+}
+
+function GroupingToolbar() {
+  const playheadTime = useTimelinePlayheadTime();
+  const { splitSelectedClipsAtTime } = useTimelineEditCommands();
+  const { selectedClipIds, selectedClips } = useTimelineSelection();
+  const { getClipGroupClips, groupClips, selectedGroup, selectedGroupId, ungroupSelectedClips } =
+    useTimelineClipGroups();
+  const canGroup = selectedClipIds.length >= 2 && selectedGroupId === null;
+  const canUngroup = selectedGroupId !== null;
+  const selectedOverlappingClipCount = selectedClips.filter(
+    (clip) =>
+      compareRational(playheadTime, clip.timelineStart) > 0 &&
+      compareRational(playheadTime, clip.timelineEnd) < 0
+  ).length;
+  const selectedGroupMembers =
+    selectedGroup === null
+      ? []
+      : getClipGroupClips(selectedGroup.id).map((entry) => entry.clip.label ?? entry.clip.id);
+
+  return (
+    <div className="clip-grouping-toolbar">
+      <div className="clip-grouping-toolbar-actions">
+        <button
+          type="button"
+          className="timeline-control-button"
+          onClick={() => groupClips(selectedClipIds, linkedClipGroupLabel)}
+          disabled={!canGroup}
+          title={canGroup ? 'Group selected clips' : 'Select both clips to group them'}
+        >
+          <Link2 aria-hidden="true" />
+          Group selected
+        </button>
+        <button
+          type="button"
+          className="timeline-control-button"
+          onClick={() => ungroupSelectedClips()}
+          disabled={!canUngroup}
+          title={canUngroup ? 'Ungroup selected clips' : 'Select a grouped clip to ungroup it'}
+        >
+          <Unlink aria-hidden="true" />
+          Ungroup selected
+        </button>
+        <button
+          type="button"
+          className="timeline-control-button"
+          onClick={() => splitSelectedClipsAtTime(playheadTime)}
+          disabled={selectedOverlappingClipCount === 0}
+          title={
+            selectedOverlappingClipCount > 0
+              ? 'Cut selected clips at playhead'
+              : 'Select clips that overlap the playhead'
+          }
+        >
+          <Scissors aria-hidden="true" />
+          Cut selected
+        </button>
+      </div>
+
+      <div className="clip-grouping-selection-readout" aria-live="polite">
+        <span className="clip-grouping-readout-item">
+          <span className="clip-grouping-readout-label">Selected</span>
+          <strong>{selectedClipIds.length}</strong>
+        </span>
+        <span className="clip-grouping-readout-item">
+          <span className="clip-grouping-readout-label">Group</span>
+          <strong>{selectedGroup?.label ?? 'None'}</strong>
+        </span>
+        <span className="clip-grouping-readout-item clip-grouping-readout-item-wide">
+          <span className="clip-grouping-readout-label">Members</span>
+          <strong>
+            {selectedGroupMembers.length > 0 ? selectedGroupMembers.join(' + ') : 'None'}
+          </strong>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ClipGroupingImportTimeline() {
+  const engine = useMemo(
+    () =>
+      new TimelineEngine({
+        duration: fromSeconds(15),
+        playheadTime: fromSeconds(6.5),
+        zoomScale: 76,
+        tracks: demoTracks,
+        markers: demoMarkers,
+      }),
+    []
+  );
+
+  return (
+    <TimelineProvider engine={engine}>
+      <div className="timeline-shell timeline-controls-shell clip-grouping-shell">
+        <GroupingToolbar />
+
+        <div className="timeline-editor-body-with-headers clip-grouping-editor-grid">
+          <div className="timeline-editor-header-panel">
+            <div className="timeline-stage timeline-editor-header-stage">
+              <TrackHeaderColumn />
+            </div>
+          </div>
+
+          <div className="timeline-editor-timeline-panel">
+            <div className="timeline-editor-stage-row">
+              <div className="timeline-stage timeline-editor-timeline-stage">
+                <Timeline.Root className="timeline-fill timeline-editor-root-with-headers">
+                  <CanvasRenderer />
+                  <TimelineLayers />
+                </Timeline.Root>
+              </div>
+              <div className="timeline-editor-vertical-scrollbar-column">
+                <Timeline.VerticalScrollbar className="timeline-editor-vertical-scrollbar">
+                  <Timeline.VerticalScrollbarThumb className="timeline-editor-vertical-scrollbar-thumb">
+                    <Timeline.VerticalScrollbarHandle side="start" />
+                    <Timeline.VerticalScrollbarHandle side="end" />
+                  </Timeline.VerticalScrollbarThumb>
+                </Timeline.VerticalScrollbar>
+              </div>
+            </div>
+            <div className="timeline-scrollbar-row timeline-editor-scrollbar-row">
+              <Timeline.ViewportScrollbar>
+                <Timeline.ViewportScrollbarThumb>
+                  <Timeline.ViewportScrollbarHandle side="start" />
+                  <Timeline.ViewportScrollbarHandle side="end" />
+                </Timeline.ViewportScrollbarThumb>
+              </Timeline.ViewportScrollbar>
+            </div>
+          </div>
+        </div>
+      </div>
+    </TimelineProvider>
+  );
+}

--- a/apps/www/src/demos/clip-grouping-import/timeline-demo-data.ts
+++ b/apps/www/src/demos/clip-grouping-import/timeline-demo-data.ts
@@ -1,0 +1,56 @@
+import type { Marker, Track } from '@techsquidtv/canvas-timeline-core';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { getDemoClipColor } from '../demo-clip-colors';
+
+export type ClipGroupingTrackKind = 'visual' | 'audio';
+
+export const demoTracks: Track<ClipGroupingTrackKind>[] = [
+  {
+    id: 'video-main',
+    kind: 'visual',
+    name: 'Video',
+    locked: false,
+    muted: false,
+    visible: true,
+    selected: false,
+    height: 56,
+    clips: [
+      {
+        id: 'video-clip',
+        sourceId: 'shared-source',
+        timelineStart: fromSeconds(3),
+        timelineEnd: fromSeconds(9),
+        sourceStart: fromSeconds(0),
+        selected: false,
+        color: getDemoClipColor(1),
+        label: 'Video clip',
+      },
+    ],
+  },
+  {
+    id: 'audio-main',
+    kind: 'audio',
+    name: 'Audio',
+    locked: false,
+    muted: false,
+    visible: true,
+    selected: false,
+    height: 56,
+    clips: [
+      {
+        id: 'audio-clip',
+        sourceId: 'shared-source',
+        timelineStart: fromSeconds(3),
+        timelineEnd: fromSeconds(9),
+        sourceStart: fromSeconds(0),
+        selected: false,
+        color: getDemoClipColor(3),
+        label: 'Audio clip',
+      },
+    ],
+  },
+];
+
+export const demoMarkers: Marker[] = [];
+
+export const linkedClipGroupLabel = 'Linked pair';

--- a/apps/www/src/demos/clip-grouping-import/timeline-editor.css
+++ b/apps/www/src/demos/clip-grouping-import/timeline-editor.css
@@ -1,0 +1,112 @@
+@import '../shared-timeline-editor.css';
+
+.clip-grouping-shell {
+  --demo-editor-shell-height: 22rem;
+  width: 100%;
+  max-width: 100%;
+  height: var(--demo-editor-shell-height);
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.clip-grouping-toolbar {
+  display: grid;
+  min-width: 0;
+  gap: 0.75rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--background) 96%, var(--muted));
+}
+
+.clip-grouping-toolbar-actions {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.clip-grouping-toolbar .timeline-control-button {
+  gap: 0.45rem;
+  white-space: nowrap;
+}
+
+.clip-grouping-toolbar .timeline-control-button svg {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.clip-grouping-selection-readout {
+  display: grid;
+  min-width: 0;
+  gap: 0.5rem;
+  grid-template-columns: auto auto minmax(0, 1fr);
+}
+
+.clip-grouping-readout-item {
+  display: grid;
+  min-width: 5.25rem;
+  gap: 0.12rem;
+  align-content: center;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
+  border-radius: calc(var(--radius) - 0.125rem);
+  background: color-mix(in oklch, var(--background) 82%, transparent);
+}
+
+.clip-grouping-readout-item-wide {
+  min-width: 0;
+}
+
+.clip-grouping-readout-label {
+  color: var(--muted-foreground);
+  font-size: 0.64rem;
+  line-height: 1;
+}
+
+.clip-grouping-readout-item strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clip-grouping-editor-grid {
+  display: grid;
+  grid-template-columns: 7.75rem minmax(0, 1fr);
+}
+
+.clip-grouping-editor-grid .timeline-stage {
+  min-height: 0;
+}
+
+.clip-grouping-track-header-content {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (max-width: 720px) {
+  .clip-grouping-shell {
+    --demo-editor-shell-height: 26rem;
+  }
+
+  .clip-grouping-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .clip-grouping-selection-readout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .clip-grouping-readout-item-wide {
+    grid-column: 1 / -1;
+  }
+
+  .clip-grouping-editor-grid {
+    grid-template-columns: 6rem minmax(0, 1fr);
+  }
+}

--- a/packages/core/src/clipboard.ts
+++ b/packages/core/src/clipboard.ts
@@ -1,5 +1,5 @@
 import { type TimelineEngine, createLeanClip, shiftClipKeyframes } from './engine';
-import type { Clip } from './types';
+import type { Clip, TimelineState } from './types';
 import type { ClipCreatedEvent, ClipRemovedEvent } from './events';
 import {
   addRational,
@@ -11,6 +11,8 @@ import {
 export type ClipboardEntry = {
   clip: Clip;
   originClipId: string;
+  originGroupId?: string;
+  originGroupLabel?: string;
 };
 
 export class ClipboardManager {
@@ -41,9 +43,12 @@ export class ClipboardManager {
     for (const track of state.tracks) {
       for (const clip of track.clips) {
         if (clip.selected) {
+          const group = this.engine.getClipGroupForClip(clip.id);
           this.clipboard.push({
             clip: createLeanClip(clip),
             originClipId: clip.id,
+            ...(group !== undefined ? { originGroupId: group.id } : {}),
+            ...(group?.label !== undefined ? { originGroupLabel: group.label } : {}),
           });
         }
       }
@@ -64,6 +69,7 @@ export class ClipboardManager {
         return true;
       });
     }
+    cleanupClipGroups(state);
     for (const clip of removedClips) {
       this.engine.emit('clip:removed', {
         clip,
@@ -101,7 +107,9 @@ export class ClipboardManager {
       this.clipboard[0].clip.timelineStart
     );
 
-    this.clipboard.forEach(({ clip, originClipId }) => {
+    const pastedGroupClipIds = new Map<string, { clipIds: string[]; label?: string }>();
+
+    this.clipboard.forEach(({ clip, originClipId, originGroupId, originGroupLabel }) => {
       const offset = subRational(clip.timelineStart, earliestStart);
       const duration = subRational(clip.timelineEnd, clip.timelineStart);
       const newClip = createLeanClip(clip, {
@@ -112,6 +120,14 @@ export class ClipboardManager {
       });
       shiftClipKeyframes(newClip, subRational(newClip.timelineStart, clip.timelineStart));
       track.clips.push(newClip);
+      if (originGroupId !== undefined) {
+        const group = pastedGroupClipIds.get(originGroupId) ?? { clipIds: [] };
+        group.clipIds.push(newClip.id);
+        if (originGroupLabel !== undefined) {
+          group.label = originGroupLabel;
+        }
+        pastedGroupClipIds.set(originGroupId, group);
+      }
       this.engine.applyOverwrites(newClip.id);
       this.engine.emit('clip:created', {
         clip: createLeanClip(newClip),
@@ -120,9 +136,43 @@ export class ClipboardManager {
       } satisfies ClipCreatedEvent);
     });
 
+    for (const group of pastedGroupClipIds.values()) {
+      if (group.clipIds.length >= 2) {
+        state.clipGroups.push({
+          id: crypto.randomUUID(),
+          clipIds: group.clipIds,
+          ...(group.label !== undefined ? { label: group.label } : {}),
+        });
+      }
+    }
+    cleanupClipGroups(state);
+
     this.engine.invalidateContent();
     this.engine.snapshot();
     this.engine.emit('state:settled');
     this.engine.emit('render');
   }
+}
+
+function cleanupClipGroups(state: TimelineState) {
+  const existingClipIds = new Set<string>();
+  for (const track of state.tracks) {
+    for (const clip of track.clips) {
+      existingClipIds.add(clip.id);
+    }
+  }
+
+  const claimedClipIds = new Set<string>();
+  state.clipGroups = state.clipGroups.flatMap((group) => {
+    const clipIds = group.clipIds.filter((clipId) => {
+      if (!existingClipIds.has(clipId) || claimedClipIds.has(clipId)) {
+        return false;
+      }
+      claimedClipIds.add(clipId);
+      return true;
+    });
+    return clipIds.length >= 2
+      ? [{ id: group.id, clipIds, ...(group.label !== undefined ? { label: group.label } : {}) }]
+      : [];
+  });
 }

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -6,12 +6,16 @@ import {
 } from './keyframes';
 import type { Clip, Track } from './types';
 import type { ClipCreatedEvent, ClipMoveEvent, ClipRemovedEvent, ClipSplitEvent } from './events';
-import { fromSeconds, toSeconds } from '@techsquidtv/canvas-timeline-utils';
+import {
+  assertValidRationalTime,
+  fromSeconds,
+  toSeconds,
+} from '@techsquidtv/canvas-timeline-utils';
 import { expectDefined } from '../../../test-utils/assertions';
 
 type TimelineEngineInternals = {
   historyManager: {
-    history: { tracks: string; markers: string }[];
+    history: { tracks: string; markers: string; clipGroups: string }[];
   };
   dragSnapshot: string | null;
   clipboardManager: {
@@ -1631,6 +1635,29 @@ describe('TimelineEngine', () => {
   });
 
   describe('Editing constraints and preview', () => {
+    function createConstraintClip(id: string, start: number, end: number): Clip {
+      return {
+        id,
+        sourceId: `${id}-source`,
+        timelineStart: fromSeconds(start),
+        timelineEnd: fromSeconds(end),
+        sourceStart: fromSeconds(0),
+        selected: false,
+      };
+    }
+
+    function createConstraintTrack(id: string, clips: Clip[], kind = 'visual'): Track {
+      return {
+        id,
+        kind,
+        clips,
+        selected: false,
+        locked: false,
+        muted: false,
+        visible: true,
+      };
+    }
+
     it('should clamp start trims to minStart', () => {
       engine.getState().tracks[0].clips[0].minStart = fromSeconds(2);
 
@@ -1858,6 +1885,442 @@ describe('TimelineEngine', () => {
       expect(payload.right.id).not.toBe('clip1');
       expect(toSeconds(payload.left.timelineEnd)).toBeCloseTo(2);
       expect(toSeconds(payload.right.timelineStart)).toBeCloseTo(2);
+    });
+
+    it('groups arbitrary clips, expands selection, and moves linked clips together', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          {
+            id: 'video',
+            kind: 'visual',
+            clips: [
+              {
+                id: 'video-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(1),
+                timelineEnd: fromSeconds(5),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+          {
+            id: 'audio',
+            kind: 'audio',
+            clips: [
+              {
+                id: 'audio-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(2),
+                timelineEnd: fromSeconds(6),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+        ],
+      });
+
+      const group = expectDefined(
+        groupedEngine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] }),
+        'created clip group'
+      );
+      expect(group.clipIds).toEqual(['video-clip', 'audio-clip']);
+
+      groupedEngine.selectClip('video-clip');
+      expect(groupedEngine.getClip('video-clip')?.clip.selected).toBe(true);
+      expect(groupedEngine.getClip('audio-clip')?.clip.selected).toBe(true);
+
+      const move = groupedEngine.commitEdit({
+        type: 'move',
+        clipId: 'video-clip',
+        startTime: fromSeconds(4),
+      });
+      expect(move.committed).toBe(true);
+      expect(move.preview.changedClips.map((clip) => clip.id).sort()).toEqual([
+        'audio-clip',
+        'video-clip',
+      ]);
+      expect(
+        toSeconds(groupedEngine.getClip('video-clip')?.clip.timelineStart ?? fromSeconds(0))
+      ).toBeCloseTo(4);
+      expect(
+        toSeconds(groupedEngine.getClip('audio-clip')?.clip.timelineStart ?? fromSeconds(0))
+      ).toBeCloseTo(5);
+    });
+
+    it('rejects duplicate group ids in initial clip group state', () => {
+      expect(
+        () =>
+          new TimelineEngine({
+            tracks: [
+              createConstraintTrack('video', [
+                createConstraintClip('clip-a', 0, 2),
+                createConstraintClip('clip-b', 3, 5),
+                createConstraintClip('clip-c', 6, 8),
+                createConstraintClip('clip-d', 9, 11),
+              ]),
+            ],
+            clipGroups: [
+              { id: 'duplicate-group', clipIds: ['clip-a', 'clip-b'] },
+              { id: 'duplicate-group', clipIds: ['clip-c', 'clip-d'] },
+            ],
+          })
+      ).toThrow('duplicate clip group id "duplicate-group".');
+    });
+
+    it('rejects clips assigned to more than one initial clip group', () => {
+      expect(
+        () =>
+          new TimelineEngine({
+            tracks: [
+              createConstraintTrack('video', [
+                createConstraintClip('clip-a', 0, 2),
+                createConstraintClip('clip-b', 3, 5),
+                createConstraintClip('clip-c', 6, 8),
+              ]),
+            ],
+            clipGroups: [
+              { id: 'group-a', clipIds: ['clip-a', 'clip-b'] },
+              { id: 'group-b', clipIds: ['clip-b', 'clip-c'] },
+            ],
+          })
+      ).toThrow('clip "clip-b" belongs to more than one clip group.');
+    });
+
+    it('inserts clip groups atomically and shifts placed keyframes', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [createConstraintTrack('video', []), createConstraintTrack('audio', [], 'audio')],
+      });
+      const group = groupedEngine.insertClipGroup({
+        groupId: 'import-group',
+        placements: [
+          {
+            clip: {
+              ...createConstraintClip('video-clip', 0, 2),
+              keyframes: [
+                { id: 'video-opacity', property: 'opacity', time: fromSeconds(1), value: 1 },
+              ],
+            },
+            targetTrackId: 'video',
+            startTime: fromSeconds(5),
+          },
+          {
+            clip: createConstraintClip('audio-clip', 0, 2),
+            targetTrackId: 'audio',
+            startTime: fromSeconds(5),
+          },
+        ],
+      });
+
+      expect(group?.clipIds).toEqual(['video-clip', 'audio-clip']);
+      expect(
+        toSeconds(groupedEngine.getClip('video-clip')?.clip.timelineStart ?? fromSeconds(0))
+      ).toBe(5);
+      expect(
+        groupedEngine
+          .getClip('video-clip')
+          ?.clip.keyframes?.map((keyframe) => toSeconds(keyframe.time))
+      ).toEqual([6]);
+
+      const failed = groupedEngine.insertClipGroup({
+        placements: [
+          {
+            clip: createConstraintClip('valid-clip', 0, 2),
+            targetTrackId: 'video',
+            startTime: fromSeconds(8),
+          },
+          {
+            clip: {
+              ...createConstraintClip('invalid-clip', 0, 2),
+              timelineStart: { v: 0.5, r: 60000 },
+            },
+            targetTrackId: 'audio',
+            startTime: fromSeconds(8),
+          },
+        ],
+      });
+
+      expect(failed).toBeNull();
+      expect(groupedEngine.getClip('valid-clip')).toBeUndefined();
+      expect(groupedEngine.getClip('invalid-clip')).toBeUndefined();
+      expect(groupedEngine.clipGroups).toHaveLength(1);
+    });
+
+    it('applies overwrite cleanup for every grouped member during drag preview', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          createConstraintTrack('video', [createConstraintClip('video-clip', 0, 2)]),
+          createConstraintTrack(
+            'audio',
+            [createConstraintClip('audio-clip', 0, 2), createConstraintClip('audio-victim', 4, 6)],
+            'audio'
+          ),
+        ],
+      });
+      groupedEngine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+
+      groupedEngine.startDrag();
+      expect(
+        groupedEngine.moveClip({
+          clipId: 'video-clip',
+          startTime: fromSeconds(4),
+          snap: false,
+        })
+      ).toBe(true);
+
+      expect(groupedEngine.getClip('audio-victim')).toBeUndefined();
+      groupedEngine.endDrag();
+    });
+
+    it('splits selected grouped clips and repartitions the group at the blade time', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          {
+            id: 'video',
+            kind: 'visual',
+            clips: [
+              {
+                id: 'video-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(0),
+                timelineEnd: fromSeconds(10),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+          {
+            id: 'audio',
+            kind: 'audio',
+            clips: [
+              {
+                id: 'audio-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(0),
+                timelineEnd: fromSeconds(10),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+        ],
+      });
+      groupedEngine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+      groupedEngine.selectClip('video-clip');
+
+      const split = groupedEngine.commitEdit({
+        type: 'split',
+        clipIds: ['video-clip', 'audio-clip'],
+        time: fromSeconds(4),
+      });
+
+      expect(split.committed).toBe(true);
+      expect(split.preview.createdClips).toHaveLength(2);
+      expect(groupedEngine.clipGroups).toHaveLength(2);
+      expect(groupedEngine.getClipGroup('linked-av')?.clipIds).toEqual([
+        'video-clip',
+        'audio-clip',
+      ]);
+      const rightGroup = expectDefined(
+        groupedEngine.clipGroups.find((group) => group.id !== 'linked-av'),
+        'right-side group'
+      );
+      expect(rightGroup.clipIds).toHaveLength(2);
+      expect(
+        rightGroup.clipIds.every((clipId) => groupedEngine.getClip(clipId) !== undefined)
+      ).toBe(true);
+    });
+
+    it('keeps grouped split pieces valid across repeated mixed-rate moves', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          {
+            id: 'video',
+            kind: 'visual',
+            clips: [
+              {
+                id: 'video-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(3),
+                timelineEnd: fromSeconds(9),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+          {
+            id: 'audio',
+            kind: 'audio',
+            clips: [
+              {
+                id: 'audio-clip',
+                sourceId: 'source',
+                timelineStart: fromSeconds(3),
+                timelineEnd: fromSeconds(9),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+        ],
+      });
+      groupedEngine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+      groupedEngine.selectClip('video-clip');
+      groupedEngine.commitEdit({
+        type: 'split',
+        clipIds: ['video-clip', 'audio-clip'],
+        time: fromSeconds(6.5),
+      });
+
+      for (let index = 0; index < 8; index += 1) {
+        expect(
+          groupedEngine.moveClip({
+            clipId: 'video-clip',
+            startTime: fromSeconds(4 + index * 0.01, 24000),
+          })
+        ).toBe(true);
+      }
+
+      const videoClip = expectDefined(groupedEngine.getClip('video-clip')?.clip, 'video clip');
+      const audioClip = expectDefined(groupedEngine.getClip('audio-clip')?.clip, 'audio clip');
+      assertValidRationalTime(videoClip.timelineStart, 'videoClip.timelineStart');
+      assertValidRationalTime(audioClip.timelineStart, 'audioClip.timelineStart');
+      expect(videoClip.timelineStart.r).toBeLessThanOrEqual(120000);
+      expect(audioClip.timelineStart.r).toBeLessThanOrEqual(120000);
+      expect(toSeconds(audioClip.timelineStart)).toBeCloseTo(toSeconds(videoClip.timelineStart));
+    });
+
+    it('rejects grouped splits when an overlapping linked member cannot be split', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          createConstraintTrack('video', [createConstraintClip('video-clip', 0, 10)]),
+          createConstraintTrack(
+            'audio',
+            [
+              {
+                ...createConstraintClip('audio-clip', 0, 10),
+                resizable: false,
+              },
+            ],
+            'audio'
+          ),
+        ],
+      });
+      groupedEngine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+
+      const split = groupedEngine.commitEdit({
+        type: 'split',
+        clipIds: ['video-clip'],
+        time: fromSeconds(4),
+      });
+
+      expect(split.committed).toBe(false);
+      expect(split.preview.reason).toBe('locked');
+      expect(groupedEngine.getClip('video-clip')?.track.clips).toHaveLength(1);
+      expect(groupedEngine.getClip('audio-clip')?.track.clips).toHaveLength(1);
+      expect(groupedEngine.getClipGroup('linked-av')?.clipIds).toEqual([
+        'video-clip',
+        'audio-clip',
+      ]);
+    });
+
+    it('skips non-overlapping selected clips when splitting at a blade time', () => {
+      const splitEngine = new TimelineEngine({
+        tracks: [
+          createConstraintTrack('track1', [
+            createConstraintClip('selected-overlap', 0, 10),
+            {
+              ...createConstraintClip('selected-later', 20, 30),
+              resizable: false,
+            },
+          ]),
+        ],
+      });
+
+      const split = splitEngine.commitEdit({
+        type: 'split',
+        clipIds: ['selected-overlap', 'selected-later'],
+        time: fromSeconds(4),
+      });
+
+      expect(split.committed).toBe(true);
+      expect(split.preview.createdClips).toHaveLength(1);
+      expect(splitEngine.getClip('selected-overlap')?.track.clips).toHaveLength(3);
+    });
+
+    it('preserves copied group membership on paste and restores groups through history', () => {
+      const groupedEngine = new TimelineEngine({
+        tracks: [
+          {
+            id: 'track1',
+            kind: 'visual',
+            clips: [
+              {
+                id: 'clip-a',
+                sourceId: 'source-a',
+                timelineStart: fromSeconds(0),
+                timelineEnd: fromSeconds(2),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+              {
+                id: 'clip-b',
+                sourceId: 'source-b',
+                timelineStart: fromSeconds(3),
+                timelineEnd: fromSeconds(5),
+                sourceStart: fromSeconds(0),
+                selected: false,
+              },
+            ],
+            selected: false,
+            locked: false,
+            muted: false,
+            visible: true,
+          },
+        ],
+      });
+
+      groupedEngine.createClipGroup({ id: 'copy-group', clipIds: ['clip-a', 'clip-b'] });
+      groupedEngine.undo();
+      expect(groupedEngine.clipGroups).toEqual([]);
+      groupedEngine.redo();
+      expect(groupedEngine.getClipGroup('copy-group')?.clipIds).toEqual(['clip-a', 'clip-b']);
+
+      groupedEngine.selectClip('clip-a');
+      groupedEngine.copySelection();
+      groupedEngine.pasteSelection(fromSeconds(10));
+
+      expect(groupedEngine.clipGroups).toHaveLength(2);
+      const pastedGroup = expectDefined(
+        groupedEngine.clipGroups.find((group) => group.id !== 'copy-group'),
+        'pasted group'
+      );
+      expect(pastedGroup.clipIds).toHaveLength(2);
     });
 
     it('emits clip lifecycle events for committed overwrite edits', () => {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -38,6 +38,9 @@ import type {
   TimelineEditValidationResult,
   TimelineInsertEditCommand,
   TimelineInteractionGeometry,
+  TimelineClipGroup,
+  TimelineCreateClipGroupOptions,
+  TimelineInsertClipGroupOptions,
   TimelineKeyframe,
   TimelineKeyframeCurveGeometryOptions,
   TimelineKeyframeCurveHandle,
@@ -58,6 +61,7 @@ import type {
   TimelineRippleTrimEditCommand,
   TimelineRollTrimEditCommand,
   TimelineSlideEditCommand,
+  TimelineSplitEditCommand,
   TimelineSlipEditCommand,
   TimelineState,
   TimelineSetClipKeyframeOptions,
@@ -160,6 +164,7 @@ const minimumTimelineEditDurationSeconds = 0.01;
 interface TimelineResolvedEdit {
   preview: TimelineEditPreview;
   tracks: Track[];
+  clipGroups?: TimelineClipGroup[];
   commandFingerprint: string;
   moveResult?: TimelineClipMoveResult;
   createdClipEvents: TimelineCreatedClipEvent[];
@@ -534,6 +539,43 @@ export function createLeanMarkers(markers: Marker[] | undefined): Marker[] {
   });
 }
 
+/**
+ * Creates a sanitized clip group array for timeline state and history snapshots.
+ *
+ * @param clipGroups - Optional clip group array to sanitize.
+ * @returns A sanitized clip group array.
+ */
+export function createLeanClipGroups(
+  clipGroups: TimelineClipGroup[] | undefined
+): TimelineClipGroup[] {
+  const groupIds = new Set<string>();
+  const groupedClipIds = new Set<string>();
+  return (clipGroups ?? []).map((group) => {
+    if (groupIds.has(group.id)) {
+      throw new RangeError(`duplicate clip group id "${group.id}".`);
+    }
+    groupIds.add(group.id);
+    if (group.clipIds.length < 2) {
+      throw new RangeError(`clip group "${group.id}" must contain at least two clips.`);
+    }
+    const uniqueClipIds = new Set(group.clipIds);
+    if (uniqueClipIds.size !== group.clipIds.length) {
+      throw new RangeError(`clip group "${group.id}" contains duplicate clip ids.`);
+    }
+    for (const clipId of group.clipIds) {
+      if (groupedClipIds.has(clipId)) {
+        throw new RangeError(`clip "${clipId}" belongs to more than one clip group.`);
+      }
+      groupedClipIds.add(clipId);
+    }
+    return {
+      id: group.id,
+      clipIds: [...group.clipIds],
+      ...(group.label !== undefined ? { label: group.label } : {}),
+    };
+  });
+}
+
 function cloneRationalTime(time: RationalTime): RationalTime {
   assertValidRationalTime(time);
   return { v: time.v, r: time.r };
@@ -661,6 +703,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    */
   constructor(initialState: {
     tracks: Track[];
+    clipGroups?: TimelineClipGroup[];
     markers?: Marker[];
     zoomScale?: number;
     scrollLeft?: number;
@@ -690,6 +733,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     this.editPolicy = initialState.editPolicy;
     this.state = {
       tracks: createLeanTracks(initialState.tracks),
+      clipGroups: createLeanClipGroups(initialState.clipGroups),
       contentRevision: 0,
       playheadTime: initialState.playheadTime ?? { v: 0, r: 24000 },
       zoomScale: initialState.zoomScale ?? 100, // 100 px per second
@@ -707,6 +751,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     this.playbackManager = new PlaybackManager(this);
     this.historyManager = new HistoryManager(this);
     this.clipboardManager = new ClipboardManager(this);
+    this.normalizeClipGroups();
 
     if (this.state.duration !== undefined || this.hasZoomConstraints()) {
       this.state.zoomScale = this.clampZoomScale(this.state.zoomScale);
@@ -721,6 +766,13 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    */
   get tracks() {
     return this.state.tracks;
+  }
+
+  /**
+   * Current clip groups owned by the engine.
+   */
+  get clipGroups() {
+    return this.state.clipGroups;
   }
 
   /**
@@ -2769,6 +2821,10 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     }
 
     this.state.tracks = resolved.tracks;
+    if (resolved.clipGroups !== undefined) {
+      this.state.clipGroups = resolved.clipGroups;
+    }
+    this.normalizeClipGroups();
     for (const track of this.state.tracks) {
       this.sortTrackClips(track);
     }
@@ -2849,6 +2905,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       case 'slip':
       case 'slide':
         return command.clipId;
+      case 'split':
+        return command.clipIds[0];
       case 'roll-trim':
         return command.leftClipId;
       case 'insert':
@@ -2869,6 +2927,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     }
 
     for (const created of resolved.createdClipEvents) {
+      if (created.reason === 'split') {
+        continue;
+      }
       const event: ClipCreatedEvent = {
         clip: created.clip,
         reason: created.reason,
@@ -2893,6 +2954,21 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     if (command.type === 'slip') {
       for (const clip of preview.changedClips) {
         this.emit('clip:slip', { clip });
+      }
+    }
+    if (command.type === 'split') {
+      for (const created of resolved.createdClipEvents) {
+        if (created.originClipId === undefined) {
+          continue;
+        }
+        const left = preview.changedClips.find((clip) => clip.id === created.originClipId);
+        if (left !== undefined) {
+          this.emit('clip:split', {
+            originalId: created.originClipId,
+            left,
+            right: created.clip,
+          } satisfies ClipSplitEvent);
+        }
       }
     }
   }
@@ -2920,6 +2996,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
         return this.resolveSlipEdit(command);
       case 'slide':
         return this.resolveSlideEdit(command);
+      case 'split':
+        return this.resolveSplitEdit(command);
       case 'insert':
         return this.resolveInsertEdit(command);
       case 'overwrite':
@@ -3020,6 +3098,12 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
           deltaTime: timeKey(command.deltaTime),
           snap: command.snap ?? null,
         });
+      case 'split':
+        return JSON.stringify({
+          type: command.type,
+          time: timeKey(command.time),
+          clipIds: [...command.clipIds],
+        });
       case 'insert':
       case 'overwrite':
         return JSON.stringify({
@@ -3076,6 +3160,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     tracks: Track[],
     preview: TimelineEditPreview,
     options: {
+      clipGroups?: TimelineClipGroup[];
       moveResult?: TimelineClipMoveResult;
       createdClipEvents?: TimelineCreatedClipEvent[];
       removedClipEvents?: TimelineRemovedClipEvent[];
@@ -3084,6 +3169,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     return {
       tracks,
       preview,
+      ...(options.clipGroups !== undefined ? { clipGroups: options.clipGroups } : {}),
       commandFingerprint: this.createEditCommandFingerprint(command),
       ...(options.moveResult !== undefined ? { moveResult: options.moveResult } : {}),
       createdClipEvents: options.createdClipEvents ?? [],
@@ -3171,6 +3257,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
         return this.validateClipEditCommand(command.clipId, 'resizable');
       case 'slide':
         return this.validateClipEditCommand(command.clipId, 'movable');
+      case 'split':
+        return this.validateSplitEditCommand(command);
       case 'insert':
       case 'overwrite':
         return this.validatePlaceClipCommand(command);
@@ -3196,6 +3284,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
         case 'slip':
         case 'slide':
           assertValidRationalTime(command.deltaTime, 'command.deltaTime');
+          break;
+        case 'split':
+          assertValidRationalTime(command.time, 'command.time');
           break;
         case 'insert':
         case 'overwrite':
@@ -3237,6 +3328,19 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     }
     if (targetTrack.kind !== found.track.kind && command.allowCrossKindTrackMove !== true) {
       return this.rejectEdit('incompatible-track-kind');
+    }
+    const linkedClipIds = this.getLinkedClipIds(command.clipId);
+    if (linkedClipIds.length > 1 && targetTrack.id !== found.track.id) {
+      return this.rejectEdit('unsupported');
+    }
+    for (const linkedClipId of linkedClipIds) {
+      const linked = this.getClip(linkedClipId);
+      if (!linked) {
+        return this.rejectEdit('not-found');
+      }
+      if (linked.track.locked || linked.clip.movable === false) {
+        return this.rejectEdit('locked');
+      }
     }
     return defaultTimelineEditValidationResult;
   }
@@ -3322,6 +3426,35 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       return this.rejectEdit('locked');
     }
     return defaultTimelineEditValidationResult;
+  }
+
+  private validateSplitEditCommand(
+    command: TimelineSplitEditCommand
+  ): TimelineEditValidationResult {
+    if (command.clipIds.length === 0) {
+      return this.rejectEdit('not-found');
+    }
+    const requestedClipIds = this.getLinkedCommandClipIds(command.clipIds);
+    let hasOverlappingClip = false;
+    for (const clipId of requestedClipIds) {
+      const found = this.getClip(clipId);
+      if (!found) {
+        return this.rejectEdit('not-found');
+      }
+      const overlaps =
+        compareRational(command.time, found.clip.timelineStart) > 0 &&
+        compareRational(command.time, found.clip.timelineEnd) < 0;
+      if (!overlaps) {
+        continue;
+      }
+      if (found.track.locked || found.clip.resizable === false) {
+        return this.rejectEdit('locked');
+      }
+      hasOverlappingClip ||= overlaps;
+    }
+    return hasOverlappingClip
+      ? defaultTimelineEditValidationResult
+      : this.rejectEdit('invalid-range');
   }
 
   private validatePlaceClipCommand(
@@ -3442,15 +3575,45 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       startTime = subRational(endTime, duration);
     }
 
-    const movedClip = createLeanClip(found.clip, {
-      timelineStart: startTime,
-      timelineEnd: endTime,
-    });
-    shiftClipKeyframes(movedClip, subRational(startTime, previousStartTime));
-    found.track.clips.splice(found.clipIndex, 1);
-    targetTrack.clips.push(movedClip);
-    this.sortTrackClips(found.track);
-    this.sortTrackClips(targetTrack);
+    const linkedClipIds = this.getLinkedClipIds(command.clipId);
+    if (linkedClipIds.length > 1 && targetTrack.id !== found.track.id) {
+      return this.createRejectedResolvedEdit(command, tracks, this.rejectEdit('unsupported'));
+    }
+
+    const deltaTime = subRational(startTime, previousStartTime);
+    const changedClips: Clip[] = [];
+    for (const linkedClipId of linkedClipIds) {
+      const linked = this.getClipInTracks(tracks, linkedClipId);
+      if (!linked) {
+        return this.createRejectedResolvedEdit(command, tracks, this.rejectEdit('not-found'));
+      }
+      const nextStart = addRational(linked.clip.timelineStart, deltaTime);
+      const nextEnd = addRational(linked.clip.timelineEnd, deltaTime);
+      if (
+        (linked.clip.minStart !== undefined &&
+          compareRational(nextStart, linked.clip.minStart) < 0) ||
+        (linked.clip.maxEnd !== undefined && compareRational(nextEnd, linked.clip.maxEnd) > 0)
+      ) {
+        return this.createRejectedResolvedEdit(command, tracks, this.rejectEdit('source-bounds'));
+      }
+
+      const movedClip = createLeanClip(linked.clip, {
+        timelineStart: nextStart,
+        timelineEnd: nextEnd,
+      });
+      shiftClipKeyframes(movedClip, deltaTime);
+      if (linkedClipId === command.clipId && targetTrack.id !== linked.track.id) {
+        linked.track.clips.splice(linked.clipIndex, 1);
+        targetTrack.clips.push(movedClip);
+      } else {
+        linked.track.clips.splice(linked.clipIndex, 1, movedClip);
+      }
+      changedClips.push(createLeanClip(movedClip));
+    }
+
+    for (const track of tracks) {
+      this.sortTrackClips(track);
+    }
     const moved = this.getClipInTracks(tracks, command.clipId);
     if (!moved) {
       return this.createRejectedResolvedEdit(command, tracks, this.rejectEdit('not-found'));
@@ -3458,7 +3621,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
     const preview = this.createResolvedEditPreview(command, {
       snap: snap?.result ?? null,
-      changedClips: [createLeanClip(moved.clip)],
+      changedClips,
       createdClips: [],
       removedClips: [],
       affectedRanges: [
@@ -3484,6 +3647,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       previousEndTime,
       startTime: cloneRationalTime(moved.clip.timelineStart),
       endTime: cloneRationalTime(moved.clip.timelineEnd),
+      changedClips,
     };
 
     return this.createResolvedEdit(command, tracks, preview, { moveResult });
@@ -3704,6 +3868,88 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
         createdClipEvents: resolved.createdClipEvents,
         removedClipEvents: resolved.removedClipEvents,
       }
+    );
+  }
+
+  private resolveSplitEdit(command: TimelineSplitEditCommand): TimelineResolvedEdit {
+    const tracks = createLeanTracks(this.state.tracks);
+    const requestedClipIds = new Set(this.getLinkedCommandClipIds(command.clipIds));
+
+    const changedClips: Clip[] = [];
+    const createdClips: Clip[] = [];
+    const createdClipEvents: TimelineCreatedClipEvent[] = [];
+    const impacts: TimelineEditImpact[] = [];
+    const splitRightClipIds = new Map<string, string>();
+
+    for (const track of tracks) {
+      const nextClips: Clip[] = [];
+      for (const clip of track.clips) {
+        const shouldSplit =
+          requestedClipIds.has(clip.id) &&
+          compareRational(command.time, clip.timelineStart) > 0 &&
+          compareRational(command.time, clip.timelineEnd) < 0;
+        if (!shouldSplit) {
+          nextClips.push(clip);
+          continue;
+        }
+
+        const originalClip = createLeanClip(clip);
+        const leftClip = createLeanClip(clip, { timelineEnd: command.time });
+        const rightClip = createLeanClip(clip, {
+          id: crypto.randomUUID(),
+          timelineStart: command.time,
+          sourceStart: addRational(clip.sourceStart, subRational(command.time, clip.timelineStart)),
+          selected: false,
+        });
+        filterClipKeyframesToClipRange(leftClip);
+        filterClipKeyframesToClipRange(rightClip);
+        nextClips.push(leftClip, rightClip);
+        splitRightClipIds.set(clip.id, rightClip.id);
+        changedClips.push(createLeanClip(leftClip), createLeanClip(rightClip));
+        createdClips.push(createLeanClip(rightClip));
+        createdClipEvents.push({
+          clip: createLeanClip(rightClip),
+          reason: 'split',
+          originClipId: clip.id,
+        });
+        impacts.push({
+          clipId: clip.id,
+          trackId: track.id,
+          originalClip,
+          resultClips: [createLeanClip(leftClip), createLeanClip(rightClip)],
+          effect: 'split',
+          affectedStartTime: command.time,
+          affectedEndTime: command.time,
+          cutStart: true,
+          cutEnd: true,
+        });
+      }
+      track.clips = nextClips;
+      this.sortTrackClips(track);
+    }
+
+    if (splitRightClipIds.size === 0) {
+      return this.createRejectedResolvedEdit(command, tracks, this.rejectEdit('invalid-range'));
+    }
+
+    const nextClipGroups = this.repartitionClipGroupsAfterSplit(
+      tracks,
+      command.time,
+      splitRightClipIds
+    );
+
+    return this.createResolvedEdit(
+      command,
+      tracks,
+      this.createResolvedEditPreview(command, {
+        snap: null,
+        changedClips,
+        createdClips,
+        removedClips: [],
+        affectedRanges: [{ startTime: command.time, endTime: command.time }],
+        impacts,
+      }),
+      { clipGroups: nextClipGroups, createdClipEvents }
     );
   }
 
@@ -3936,6 +4182,320 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       }),
       { createdClipEvents, removedClipEvents }
     );
+  }
+
+  private createValidatedClipGroup(
+    options: TimelineCreateClipGroupOptions
+  ): TimelineClipGroup | null {
+    if (options.clipIds.length < 2) {
+      return null;
+    }
+    const uniqueClipIds = new Set(options.clipIds);
+    if (uniqueClipIds.size !== options.clipIds.length) {
+      return null;
+    }
+    if (options.id !== undefined && this.getClipGroup(options.id) !== undefined) {
+      return null;
+    }
+
+    for (const clipId of options.clipIds) {
+      if (this.getClip(clipId) === undefined || this.getClipGroupForClip(clipId) !== undefined) {
+        return null;
+      }
+    }
+
+    return createLeanClipGroups([
+      {
+        id: options.id ?? crypto.randomUUID(),
+        clipIds: [...options.clipIds],
+        ...(options.label !== undefined ? { label: options.label } : {}),
+      },
+    ])[0];
+  }
+
+  private normalizeClipGroups() {
+    const existingClipIds = new Set<string>();
+    for (const track of this.state.tracks) {
+      for (const clip of track.clips) {
+        existingClipIds.add(clip.id);
+      }
+    }
+
+    const claimedClipIds = new Set<string>();
+    const nextGroups: TimelineClipGroup[] = [];
+    for (const group of this.state.clipGroups) {
+      const clipIds = group.clipIds.filter((clipId) => {
+        if (!existingClipIds.has(clipId) || claimedClipIds.has(clipId)) {
+          return false;
+        }
+        claimedClipIds.add(clipId);
+        return true;
+      });
+      if (clipIds.length >= 2) {
+        nextGroups.push({
+          id: group.id,
+          clipIds,
+          ...(group.label !== undefined ? { label: group.label } : {}),
+        });
+      }
+    }
+    this.state.clipGroups = nextGroups;
+  }
+
+  private getLinkedClipIds(clipId: string): string[] {
+    return this.getClipGroupForClip(clipId)?.clipIds ?? [clipId];
+  }
+
+  private getLinkedCommandClipIds(clipIds: readonly string[]) {
+    const linkedClipIds = new Set<string>();
+    for (const clipId of clipIds) {
+      for (const linkedClipId of this.getLinkedClipIds(clipId)) {
+        linkedClipIds.add(linkedClipId);
+      }
+    }
+    return [...linkedClipIds];
+  }
+
+  private getSelectedClipIds() {
+    const clipIds: string[] = [];
+    for (const track of this.state.tracks) {
+      for (const clip of track.clips) {
+        if (clip.selected) {
+          clipIds.push(clip.id);
+        }
+      }
+    }
+    return clipIds;
+  }
+
+  private repartitionClipGroupsAfterSplit(
+    tracks: Track[],
+    splitTime: RationalTime,
+    splitRightClipIds: ReadonlyMap<string, string>
+  ): TimelineClipGroup[] {
+    const clipById = new Map<string, Clip>();
+    for (const track of tracks) {
+      for (const clip of track.clips) {
+        clipById.set(clip.id, clip);
+      }
+    }
+
+    const nextGroups: TimelineClipGroup[] = [];
+    for (const group of this.state.clipGroups) {
+      const groupWasSplit = group.clipIds.some((clipId) => splitRightClipIds.has(clipId));
+      if (!groupWasSplit) {
+        nextGroups.push({
+          id: group.id,
+          clipIds: [...group.clipIds],
+          ...(group.label !== undefined ? { label: group.label } : {}),
+        });
+        continue;
+      }
+
+      const leftClipIds: string[] = [];
+      const rightClipIds: string[] = [];
+      for (const clipId of group.clipIds) {
+        const rightClipId = splitRightClipIds.get(clipId);
+        if (rightClipId !== undefined) {
+          leftClipIds.push(clipId);
+          rightClipIds.push(rightClipId);
+          continue;
+        }
+
+        const clip = clipById.get(clipId);
+        if (clip === undefined) {
+          continue;
+        }
+        if (compareRational(clip.timelineEnd, splitTime) <= 0) {
+          leftClipIds.push(clip.id);
+        } else if (compareRational(clip.timelineStart, splitTime) >= 0) {
+          rightClipIds.push(clip.id);
+        }
+      }
+
+      if (leftClipIds.length >= 2) {
+        nextGroups.push({
+          id: group.id,
+          clipIds: leftClipIds,
+          ...(group.label !== undefined ? { label: group.label } : {}),
+        });
+      }
+      if (rightClipIds.length >= 2) {
+        nextGroups.push({
+          id: crypto.randomUUID(),
+          clipIds: rightClipIds,
+          ...(group.label !== undefined ? { label: group.label } : {}),
+        });
+      }
+    }
+
+    return createLeanClipGroups(nextGroups);
+  }
+
+  /**
+   * Returns a clip group by id.
+   *
+   * @param groupId - Clip group id to inspect.
+   * @returns The matching group, or undefined when missing.
+   */
+  getClipGroup(groupId: string): TimelineClipGroup | undefined {
+    return this.state.clipGroups.find((group) => group.id === groupId);
+  }
+
+  /**
+   * Returns the group containing a clip.
+   *
+   * @param clipId - Clip id to inspect.
+   * @returns The containing group, or undefined when the clip is ungrouped.
+   */
+  getClipGroupForClip(clipId: string): TimelineClipGroup | undefined {
+    return this.state.clipGroups.find((group) => group.clipIds.includes(clipId));
+  }
+
+  /**
+   * Returns clips contained by a group in group order.
+   *
+   * @param groupId - Clip group id to inspect.
+   * @returns Group clip entries, or an empty array when the group is missing.
+   */
+  getClipGroupClips(groupId: string) {
+    const group = this.getClipGroup(groupId);
+    if (group === undefined) {
+      return [];
+    }
+
+    return group.clipIds.flatMap((clipId) => {
+      const found = this.getClip(clipId);
+      return found === undefined ? [] : [found];
+    });
+  }
+
+  /**
+   * Creates a clip group from existing clips.
+   *
+   * @param options - Existing clip ids and optional group metadata.
+   * @returns The created group, or null when validation fails.
+   */
+  createClipGroup(options: TimelineCreateClipGroupOptions): TimelineClipGroup | null {
+    const group = this.createValidatedClipGroup(options);
+    if (group === null) {
+      return null;
+    }
+
+    this.state.clipGroups.push(group);
+    this.selectClips(group.clipIds);
+    this.snapshot();
+    this.emit('state:settled');
+    this.emit('render');
+    return group;
+  }
+
+  /**
+   * Removes one clip group.
+   *
+   * @param groupId - Clip group id to remove.
+   * @returns Whether a group was removed.
+   */
+  ungroupClipGroup(groupId: string) {
+    const groupIndex = this.state.clipGroups.findIndex((group) => group.id === groupId);
+    if (groupIndex === -1) {
+      return false;
+    }
+
+    this.state.clipGroups.splice(groupIndex, 1);
+    this.snapshot();
+    this.emit('state:settled');
+    this.emit('render');
+    return true;
+  }
+
+  /**
+   * Removes groups containing any of the supplied clips.
+   *
+   * @param clipIds - Clip ids whose groups should be removed.
+   * @returns Whether any groups were removed.
+   */
+  ungroupClips(clipIds: readonly string[]) {
+    const clipIdSet = new Set(clipIds);
+    const previousLength = this.state.clipGroups.length;
+    this.state.clipGroups = this.state.clipGroups.filter(
+      (group) => !group.clipIds.some((clipId) => clipIdSet.has(clipId))
+    );
+    if (this.state.clipGroups.length === previousLength) {
+      return false;
+    }
+
+    this.snapshot();
+    this.emit('state:settled');
+    this.emit('render');
+    return true;
+  }
+
+  /**
+   * Inserts multiple clips on chosen tracks and groups them in one history entry.
+   *
+   * @param options - Placements and optional group metadata.
+   * @returns The created group, or null when validation fails.
+   */
+  insertClipGroup(options: TimelineInsertClipGroupOptions): TimelineClipGroup | null {
+    if (options.placements.length < 2) {
+      return null;
+    }
+    if (options.groupId !== undefined && this.getClipGroup(options.groupId) !== undefined) {
+      return null;
+    }
+    const insertedClipIds = new Set<string>();
+    for (const placement of options.placements) {
+      if (insertedClipIds.has(placement.clip.id) || this.getClip(placement.clip.id)) {
+        return null;
+      }
+      const targetTrack = this.state.tracks.find((track) => track.id === placement.targetTrackId);
+      if (targetTrack === undefined || targetTrack.locked) {
+        return null;
+      }
+      insertedClipIds.add(placement.clip.id);
+    }
+
+    const group = createLeanClipGroups([
+      {
+        id: options.groupId ?? crypto.randomUUID(),
+        clipIds: [...insertedClipIds],
+        ...(options.label !== undefined ? { label: options.label } : {}),
+      },
+    ])[0];
+    const tracks = createLeanTracks(this.state.tracks);
+    const createdClips: Clip[] = [];
+    try {
+      for (const placement of options.placements) {
+        const targetTrack = tracks.find((track) => track.id === placement.targetTrackId);
+        if (targetTrack === undefined) {
+          return null;
+        }
+        const duration = subRational(placement.clip.timelineEnd, placement.clip.timelineStart);
+        const clip = createLeanClip(placement.clip, {
+          timelineStart: placement.startTime,
+          timelineEnd: addRational(placement.startTime, duration),
+        });
+        shiftClipKeyframes(clip, subRational(clip.timelineStart, placement.clip.timelineStart));
+        targetTrack.clips.push(clip);
+        this.sortTrackClips(targetTrack);
+        createdClips.push(createLeanClip(clip));
+      }
+    } catch {
+      return null;
+    }
+
+    this.state.tracks = tracks;
+    this.state.clipGroups.push(group);
+    this.selectClips(group.clipIds);
+    this.invalidateContent();
+    for (const clip of createdClips) {
+      this.emit('clip:created', { clip, reason: 'insert' } satisfies ClipCreatedEvent);
+    }
+    this.snapshot();
+    this.emit('state:settled');
+    this.emit('render');
+    return group;
   }
 
   private createPlacedClip(command: TimelinePlaceClipCommand): Clip {
@@ -4345,6 +4905,16 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     if (targetTrack.kind !== found.track.kind && options.allowCrossKindTrackMove !== true) {
       return false;
     }
+    const linkedClipIds = this.getLinkedClipIds(options.clipId);
+    if (linkedClipIds.length > 1 && targetTrack.id !== found.track.id) {
+      return false;
+    }
+    for (const linkedClipId of linkedClipIds) {
+      const linked = this.getClip(linkedClipId);
+      if (!linked || linked.clip.movable === false || linked.track.locked) {
+        return false;
+      }
+    }
 
     const previousStartTime = cloneRationalTime(found.clip.timelineStart);
     const previousEndTime = cloneRationalTime(found.clip.timelineEnd);
@@ -4387,23 +4957,46 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       actualStart = subRational(actualEnd, duration);
     }
 
-    const movingClip = targetTrack.id === found.track.id ? found.clip : createLeanClip(found.clip);
-    movingClip.timelineStart = actualStart;
-    movingClip.timelineEnd = actualEnd;
-    shiftClipKeyframes(movingClip, subRational(actualStart, previousStartTime));
+    const deltaTime = subRational(actualStart, previousStartTime);
+    const changedClips: Clip[] = [];
+    for (const linkedClipId of linkedClipIds) {
+      const linked = this.getClip(linkedClipId);
+      if (!linked) {
+        return false;
+      }
+      const nextStart = addRational(linked.clip.timelineStart, deltaTime);
+      const nextEnd = addRational(linked.clip.timelineEnd, deltaTime);
+      if (
+        (linked.clip.minStart !== undefined &&
+          compareRational(nextStart, linked.clip.minStart) < 0) ||
+        (linked.clip.maxEnd !== undefined && compareRational(nextEnd, linked.clip.maxEnd) > 0)
+      ) {
+        return false;
+      }
 
-    if (targetTrack.id !== found.track.id) {
-      found.track.clips.splice(found.clipIndex, 1);
-      targetTrack.clips.push(movingClip);
+      const movingClip =
+        linkedClipId === options.clipId && targetTrack.id !== linked.track.id
+          ? createLeanClip(linked.clip)
+          : linked.clip;
+      movingClip.timelineStart = nextStart;
+      movingClip.timelineEnd = nextEnd;
+      shiftClipKeyframes(movingClip, deltaTime);
+
+      if (linkedClipId === options.clipId && targetTrack.id !== linked.track.id) {
+        linked.track.clips.splice(linked.clipIndex, 1);
+        targetTrack.clips.push(movingClip);
+      }
+      changedClips.push(createLeanClip(movingClip));
     }
 
-    this.sortTrackClips(found.track);
-    if (targetTrack.id !== found.track.id) {
-      this.sortTrackClips(targetTrack);
+    for (const track of this.state.tracks) {
+      this.sortTrackClips(track);
     }
 
     if (this.dragSnapshot) {
-      this.applyOverwrites(options.clipId);
+      for (const linkedClipId of linkedClipIds) {
+        this.applyOverwrites(linkedClipId);
+      }
     }
 
     const moved = this.getClip(options.clipId);
@@ -4424,6 +5017,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       previousEndTime,
       startTime: cloneRationalTime(moved.clip.timelineStart),
       endTime: cloneRationalTime(moved.clip.timelineEnd),
+      changedClips,
     };
     const phase = this.dragSnapshot ? 'preview' : 'commit';
     this.emit('clip:move', { ...moveResult, phase });
@@ -4689,6 +5283,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       track.clips = newClips;
       this.sortTrackClips(track);
       if (!isPreview) {
+        this.normalizeClipGroups();
         this.invalidateContent();
         for (const clip of removedClips) {
           this.emit('clip:removed', {
@@ -4776,17 +5371,60 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    * @param clipId - Clip id to select, or `null` to clear clip selection.
    */
   selectClip(clipId: string | null) {
-    let selectedClip: Clip | null = null;
+    const selectedClipIds = clipId === null ? [] : this.getLinkedClipIds(clipId);
+    this.selectClips(selectedClipIds);
+  }
+
+  /**
+   * Selects a set of clips and clears selection from all others.
+   *
+   * @param clipIds - Clip ids to select.
+   */
+  selectClips(clipIds: readonly string[]) {
+    const selectedClipIds = new Set(clipIds);
+    const selectedClips: Clip[] = [];
+    let primaryClip: Clip | null = null;
     for (const track of this.state.tracks) {
       for (const clip of track.clips) {
-        clip.selected = clip.id === clipId;
+        clip.selected = selectedClipIds.has(clip.id);
         if (clip.selected) {
-          selectedClip = clip;
+          selectedClips.push(clip);
+          primaryClip ??= clip;
         }
       }
     }
-    this.emit('clip:select', { clipId, clip: selectedClip });
+    this.emit('clip:select', {
+      clipId: primaryClip?.id ?? null,
+      clip: primaryClip,
+      clipIds: selectedClips.map((clip) => clip.id),
+      clips: selectedClips,
+    });
     this.emit('render');
+  }
+
+  /**
+   * Toggles one clip in the current multi-selection.
+   *
+   * @param clipId - Clip id to toggle.
+   * @param selected - Optional explicit selected state.
+   */
+  toggleClipSelection(clipId: string, selected?: boolean) {
+    if (this.getClip(clipId) === undefined) {
+      return false;
+    }
+    const currentSelection = new Set(this.getSelectedClipIds());
+    const nextSelected = selected ?? !currentSelection.has(clipId);
+    if (nextSelected) {
+      for (const linkedClipId of this.getLinkedClipIds(clipId)) {
+        currentSelection.add(linkedClipId);
+      }
+    } else {
+      for (const linkedClipId of this.getLinkedClipIds(clipId)) {
+        currentSelection.delete(linkedClipId);
+      }
+    }
+    this.selectClips([...currentSelection]);
+    return true;
   }
 
   /**
@@ -4798,36 +5436,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    */
   splitClip(clipId: string, splitTime: RationalTime) {
     assertValidRationalTime(splitTime, 'splitTime');
-    const found = this.getClip(clipId);
-    if (found) {
-      const { track, clip, clipIndex: idx } = found;
-      if (
-        compareRational(splitTime, clip.timelineStart) > 0 &&
-        compareRational(splitTime, clip.timelineEnd) < 0
-      ) {
-        const clip1 = createLeanClip(clip, { timelineEnd: splitTime });
-        const clip2 = createLeanClip(clip, {
-          id: crypto.randomUUID(),
-          timelineStart: splitTime,
-          sourceStart: addRational(clip.sourceStart, subRational(splitTime, clip.timelineStart)),
-          selected: false,
-        });
-        filterClipKeyframesToClipRange(clip1);
-        filterClipKeyframesToClipRange(clip2);
-        track.clips.splice(idx, 1, clip1, clip2);
-        this.emit('clip:split', {
-          originalId: clipId,
-          left: clip1,
-          right: clip2,
-        } satisfies ClipSplitEvent);
-        this.snapshot();
-        this.invalidateContent();
-        this.emit('state:settled');
-        this.emit('render');
-        return true;
-      }
-    }
-    return false;
+    return this.commitEdit({ type: 'split', time: splitTime, clipIds: [clipId] }).committed;
   }
 
   /**
@@ -4861,14 +5470,26 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
   deleteClip(clipId: string) {
     const found = this.getClip(clipId);
     if (found) {
-      const removedClip = createLeanClip(found.clip);
-      found.track.clips.splice(found.clipIndex, 1);
+      const clipIdsToRemove = new Set(this.getLinkedClipIds(clipId));
+      const removedClips: Clip[] = [];
+      for (const track of this.state.tracks) {
+        track.clips = track.clips.filter((clip) => {
+          if (clipIdsToRemove.has(clip.id)) {
+            removedClips.push(createLeanClip(clip));
+            return false;
+          }
+          return true;
+        });
+      }
+      this.normalizeClipGroups();
       this.snapshot();
       this.invalidateContent();
-      this.emit('clip:removed', {
-        clip: removedClip,
-        reason: 'delete',
-      } satisfies ClipRemovedEvent);
+      for (const clip of removedClips) {
+        this.emit('clip:removed', {
+          clip,
+          reason: 'delete',
+        } satisfies ClipRemovedEvent);
+      }
       this.emit('state:settled');
       this.emit('render');
       return true;
@@ -4984,6 +5605,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     if (idx !== -1) {
       const removed = this.state.tracks.splice(idx, 1)[0];
       const scrollChanged = this.clampScrollTop();
+      this.normalizeClipGroups();
       this.snapshot();
       this.emit('track:remove', { track: removed });
       this.invalidateContent();

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -16,6 +16,7 @@ import type {
 /** Reason a committed engine command created a new clip. */
 export type ClipCreatedReason =
   | 'paste'
+  | 'split'
   | 'insert'
   | 'overwrite'
   | 'overwrite-split'
@@ -80,6 +81,8 @@ export interface ClipSlipEvent {
 export interface ClipSelectEvent {
   clipId: string | null;
   clip: Clip | null;
+  clipIds: string[];
+  clips: Clip[];
 }
 
 /** Keyframe add/update event payload. */

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,5 +1,6 @@
 import {
   type TimelineEngine,
+  createLeanClipGroups,
   createLeanMarkers,
   createLeanTracks,
   stringifyLeanTracks,
@@ -7,7 +8,7 @@ import {
 
 export class HistoryManager {
   private engine: TimelineEngine;
-  private history: { tracks: string; markers: string }[] = [];
+  private history: { tracks: string; markers: string; clipGroups: string }[] = [];
   private historyIndex: number = -1;
 
   constructor(engine: TimelineEngine) {
@@ -18,9 +19,15 @@ export class HistoryManager {
     const state = this.engine.getState();
     const tracksStr = stringifyLeanTracks(state.tracks);
     const markersStr = JSON.stringify(state.markers ?? []);
+    const clipGroupsStr = JSON.stringify(createLeanClipGroups(state.clipGroups));
 
     const last = this.history[this.historyIndex];
-    if (last !== undefined && last.tracks === tracksStr && last.markers === markersStr) {
+    if (
+      last !== undefined &&
+      last.tracks === tracksStr &&
+      last.markers === markersStr &&
+      last.clipGroups === clipGroupsStr
+    ) {
       return;
     }
 
@@ -33,6 +40,7 @@ export class HistoryManager {
     this.history.push({
       tracks: tracksStr,
       markers: markersStr,
+      clipGroups: clipGroupsStr,
     });
 
     this.historyIndex = this.history.length - 1;
@@ -63,10 +71,11 @@ export class HistoryManager {
     return this.historyIndex < this.history.length - 1;
   }
 
-  private restoreSnapshot(snapshot: { tracks: string; markers: string }) {
+  private restoreSnapshot(snapshot: { tracks: string; markers: string; clipGroups: string }) {
     const state = this.engine.getState();
     state.tracks = createLeanTracks(JSON.parse(snapshot.tracks));
     state.markers = createLeanMarkers(JSON.parse(snapshot.markers));
+    state.clipGroups = createLeanClipGroups(JSON.parse(snapshot.clipGroups));
     this.engine.invalidateContent();
     this.engine.emit('state:settled');
     this.engine.emit('render');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -694,6 +694,7 @@ export type TimelineEditOperation =
   | 'roll-trim'
   | 'slip'
   | 'slide'
+  | 'split'
   | 'insert'
   | 'overwrite'
   | 'delete-range'
@@ -795,6 +796,46 @@ export interface TimelinePlaceClipCommand {
   snap?: boolean;
 }
 
+/** One deterministic clip placement used when inserting an already-associated clip group. */
+export interface TimelineClipGroupPlacement {
+  /** Clip to place on the timeline. Its timeline range is recalculated from startTime. */
+  clip: Clip;
+  /** Destination track id. */
+  targetTrackId: string;
+  /** Timeline start for the placed clip. */
+  startTime: RationalTime;
+}
+
+/** Serializable group of timeline clips edited as a linked unit. */
+export interface TimelineClipGroup {
+  /** Stable group identifier. */
+  id: string;
+  /** Ordered clip ids that belong to this group. */
+  clipIds: string[];
+  /** Optional visible group label for app chrome. */
+  label?: string;
+}
+
+/** Options for creating a clip group from existing clips. */
+export interface TimelineCreateClipGroupOptions {
+  /** Optional stable group id. A random id is generated when omitted. */
+  id?: string;
+  /** Existing clip ids to group. */
+  clipIds: readonly string[];
+  /** Optional visible group label for app chrome. */
+  label?: string;
+}
+
+/** Options for inserting multiple clips and grouping them in one history entry. */
+export interface TimelineInsertClipGroupOptions {
+  /** Optional stable group id. A random id is generated when omitted. */
+  groupId?: string;
+  /** Optional visible group label for app chrome. */
+  label?: string;
+  /** Clip placements to insert atomically. */
+  placements: readonly TimelineClipGroupPlacement[];
+}
+
 /** Command that moves an existing clip. */
 export interface TimelineMoveEditCommand extends TimelineClipMoveOptions {
   type: 'move';
@@ -838,6 +879,13 @@ export interface TimelineSlideEditCommand {
   snap?: boolean;
 }
 
+/** Command that splits selected clips at one timeline time. */
+export interface TimelineSplitEditCommand {
+  type: 'split';
+  time: RationalTime;
+  clipIds: readonly string[];
+}
+
 /** Command that inserts a new clip and pushes later clips forward. */
 export interface TimelineInsertEditCommand extends TimelinePlaceClipCommand {
   type: 'insert';
@@ -873,6 +921,7 @@ export type TimelineEditCommand =
   | TimelineRollTrimEditCommand
   | TimelineSlipEditCommand
   | TimelineSlideEditCommand
+  | TimelineSplitEditCommand
   | TimelineInsertEditCommand
   | TimelineOverwriteEditCommand
   | TimelineDeleteRangeEditCommand
@@ -1090,6 +1139,8 @@ export interface TimelineClipMoveResult {
   startTime: RationalTime;
   /** Clip end after the move. */
   endTime: RationalTime;
+  /** All clips changed by the move, including linked group members. */
+  changedClips: Clip[];
 }
 
 /**
@@ -1213,6 +1264,8 @@ export interface SourceFrameResolver {
 export interface TimelineState {
   /** Active set of tracks. */
   tracks: Track[];
+  /** Clip groups edited as linked units. */
+  clipGroups: TimelineClipGroup[];
   /** Monotonic counter incremented when track or clip edits can change active layer lookup at a fixed playhead. */
   contentRevision: number;
   /** The current playhead position. */

--- a/packages/react/src/Provider.tsx
+++ b/packages/react/src/Provider.tsx
@@ -16,6 +16,7 @@ function createProviderState(engine: TimelineEngine): TimelineState {
   const engineState = engine.getState();
   return {
     tracks: [...engine.tracks],
+    clipGroups: [...engine.clipGroups],
     contentRevision: engine.contentRevision,
     playheadTime: engine.playheadTime,
     zoomScale: engine.zoomScale,

--- a/packages/react/src/components/interactions/ClipInteractionLayer.test.tsx
+++ b/packages/react/src/components/interactions/ClipInteractionLayer.test.tsx
@@ -243,6 +243,157 @@ describe('ClipInteractionLayer', () => {
     expect(moveClip).toHaveBeenCalledTimes(1);
   });
 
+  it('selects all group members when clicking one grouped clip', () => {
+    const engine = createEngine([
+      createTrack('video', [createClip('video-clip', 1, 5)]),
+      createTrack('audio', [createClip('audio-clip', 1, 5)], { kind: 'audio' }),
+    ]);
+    engine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <ClipInteractionLayer />
+      </TimelineProvider>
+    );
+
+    const layer = container.querySelector('.timeline-clip-interaction-layer') as Element;
+    fireEvent.pointerDown(layer, {
+      clientX: 130,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+    });
+
+    expect(engine.getClip('video-clip')?.clip.selected).toBe(true);
+    expect(engine.getClip('audio-clip')?.clip.selected).toBe(true);
+  });
+
+  it('toggles ungrouped clips into multi-selection with shift-click', () => {
+    const engine = createEngine([
+      createTrack('track-1', [
+        createClip('clip-a', 1, 3, { selected: true }),
+        createClip('clip-b', 4, 6),
+      ]),
+    ]);
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <ClipInteractionLayer />
+      </TimelineProvider>
+    );
+
+    const layer = container.querySelector('.timeline-clip-interaction-layer') as Element;
+    fireEvent.pointerDown(layer, {
+      clientX: 430,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      shiftKey: true,
+    });
+
+    expect(engine.getClip('clip-a')?.clip.selected).toBe(true);
+    expect(engine.getClip('clip-b')?.clip.selected).toBe(true);
+
+    fireEvent.pointerDown(layer, {
+      clientX: 430,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 2,
+      shiftKey: true,
+    });
+
+    expect(engine.getClip('clip-a')?.clip.selected).toBe(true);
+    expect(engine.getClip('clip-b')?.clip.selected).toBe(false);
+  });
+
+  it('toggles grouped clips into multi-selection with shift-click', () => {
+    const engine = createEngine([
+      createTrack('video', [createClip('video-clip', 1, 5)]),
+      createTrack('audio', [createClip('audio-clip', 1, 5)], { kind: 'audio' }),
+    ]);
+    engine.createClipGroup({ id: 'linked-av', clipIds: ['video-clip', 'audio-clip'] });
+    engine.selectClip(null);
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <ClipInteractionLayer />
+      </TimelineProvider>
+    );
+
+    const layer = container.querySelector('.timeline-clip-interaction-layer') as Element;
+    fireEvent.pointerDown(layer, {
+      clientX: 130,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      shiftKey: true,
+    });
+
+    expect(engine.getClip('video-clip')?.clip.selected).toBe(true);
+    expect(engine.getClip('audio-clip')?.clip.selected).toBe(true);
+
+    fireEvent.pointerDown(layer, {
+      clientX: 130,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 2,
+      shiftKey: true,
+    });
+
+    expect(engine.getClip('video-clip')?.clip.selected).toBe(false);
+    expect(engine.getClip('audio-clip')?.clip.selected).toBe(false);
+  });
+
+  it('starts body drags after shift-click selection', () => {
+    const engine = createEngine([
+      createTrack('track-1', [
+        createClip('clip-a', 1, 3, { selected: true }),
+        createClip('clip-b', 4, 6),
+      ]),
+    ]);
+    const moveClip = vi.spyOn(engine, 'moveClip');
+
+    const { container } = render(
+      <TimelineProvider engine={engine}>
+        <ClipInteractionLayer />
+      </TimelineProvider>
+    );
+
+    const layer = container.querySelector('.timeline-clip-interaction-layer') as Element;
+    fireEvent.pointerDown(layer, {
+      clientX: 430,
+      clientY: 40,
+      pointerType: 'mouse',
+      button: 0,
+      pointerId: 1,
+      shiftKey: true,
+    });
+    fireEvent.pointerMove(layer, {
+      clientX: 450,
+      clientY: 40,
+      pointerType: 'mouse',
+      pointerId: 1,
+    });
+    fireEvent.pointerUp(layer, {
+      clientX: 450,
+      clientY: 40,
+      pointerType: 'mouse',
+      pointerId: 1,
+    });
+
+    expect(moveClip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clipId: 'clip-b',
+        targetTrackId: 'track-1',
+      })
+    );
+  });
+
   it('reports clip double-click hits without starting a drag', () => {
     const engine = createEngine([createTrack('track-1', [createClip('clip-1', 1, 5)])]);
     const moveClip = vi.spyOn(engine, 'moveClip');

--- a/packages/react/src/components/interactions/ClipInteractionLayer.tsx
+++ b/packages/react/src/components/interactions/ClipInteractionLayer.tsx
@@ -416,7 +416,11 @@ export const ClipInteractionLayer = React.forwardRef<HTMLDivElement, ClipInterac
       event.preventDefault();
       event.stopPropagation();
 
-      engine.selectClip(hit.clip.id);
+      if (event.shiftKey) {
+        engine.toggleClipSelection(hit.clip.id);
+      } else {
+        engine.selectClip(hit.clip.id);
+      }
       clipNavigation.setActiveClip(hit.clip.id);
       setHoveredClipId(hit.clip.id);
       setHoveredRegion(hit.region);

--- a/packages/react/src/hooks.test.ts
+++ b/packages/react/src/hooks.test.ts
@@ -24,6 +24,7 @@ import {
   useTimelineClips,
   useTimelineClipDrag,
   useTimelineClipDropFeedback,
+  useTimelineClipGroups,
   useTimelineClipRects,
   useTimelineClipboard,
   useTimelineEvent,
@@ -1397,6 +1398,81 @@ test('useTimelineSelection derives and clears clip and track selection', () => {
 
   expect(result.current.selectedClipId).toBeNull();
   expect(result.current.selectedTrackId).toBeNull();
+});
+
+test('useTimelineClipGroups exposes grouping commands and selected group state', () => {
+  const engine = new TimelineEngine({
+    tracks: [
+      createTrack('video', [createClip('video-clip', 0, 8)]),
+      createTrack('audio', [createClip('audio-clip', 0, 8)], { kind: 'audio' }),
+    ],
+  });
+
+  const groupsHook = renderHook(() => useTimelineClipGroups(), {
+    wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+  });
+  const selectionHook = renderHook(() => useTimelineSelection(), {
+    wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+  });
+  const editHook = renderHook(() => useTimelineEditCommands(), {
+    wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+  });
+
+  act(() => {
+    expect(groupsHook.result.current.groupClips(['video-clip', 'audio-clip']).ok).toBe(true);
+  });
+
+  expect(groupsHook.result.current.groups).toHaveLength(1);
+
+  act(() => {
+    selectionHook.result.current.selectClip('video-clip');
+  });
+
+  expect(selectionHook.result.current.selectedClipIds).toEqual(['video-clip', 'audio-clip']);
+  expect(selectionHook.result.current.selectedGroupId).toBe(groupsHook.result.current.groups[0].id);
+
+  act(() => {
+    expect(editHook.result.current.splitSelectedClipsAtTime(fromSeconds(4)).ok).toBe(true);
+  });
+
+  expect(engine.clipGroups).toHaveLength(2);
+
+  act(() => {
+    expect(groupsHook.result.current.ungroupSelectedClips().ok).toBe(true);
+  });
+
+  expect(engine.clipGroups.length).toBeLessThan(2);
+});
+
+test('useTimelineClipGroups ungroups every selected clip group', () => {
+  const engine = new TimelineEngine({
+    tracks: [
+      createTrack('video', [
+        createClip('video-a', 0, 2),
+        createClip('video-b', 3, 5),
+        createClip('video-c', 6, 8),
+        createClip('video-d', 9, 11),
+      ]),
+    ],
+  });
+  engine.createClipGroup({ id: 'group-a', clipIds: ['video-a', 'video-b'] });
+  engine.createClipGroup({ id: 'group-b', clipIds: ['video-c', 'video-d'] });
+
+  const groupsHook = renderHook(() => useTimelineClipGroups(), {
+    wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+  });
+  const selectionHook = renderHook(() => useTimelineSelection(), {
+    wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+  });
+
+  act(() => {
+    selectionHook.result.current.selectClips(['video-a', 'video-c']);
+  });
+  act(() => {
+    expect(groupsHook.result.current.ungroupSelectedClips().ok).toBe(true);
+  });
+
+  expect(engine.clipGroups).toEqual([]);
 });
 
 test('useTimelineViewport derives visible range and controls viewport state', () => {

--- a/packages/react/src/hooks/clips/index.ts
+++ b/packages/react/src/hooks/clips/index.ts
@@ -3,6 +3,7 @@ export * from './useActiveClips';
 export * from './useActiveLayers';
 export * from './useTimelineClipDrag';
 export * from './useTimelineClipDropFeedback';
+export * from './useTimelineClipGroups';
 export * from './useTimelineClipNavigation';
 export * from './useTimelineClipRects';
 export * from './useTimelineClips';

--- a/packages/react/src/hooks/clips/timelineClipModel.ts
+++ b/packages/react/src/hooks/clips/timelineClipModel.ts
@@ -1,4 +1,9 @@
-import type { Clip, TimelineClipEntry, Track } from '@techsquidtv/canvas-timeline-core';
+import type {
+  Clip,
+  TimelineClipEntry,
+  TimelineClipGroup,
+  Track,
+} from '@techsquidtv/canvas-timeline-core';
 
 export type { TimelineClipEntry } from '@techsquidtv/canvas-timeline-core';
 
@@ -14,6 +19,16 @@ export interface TimelineSelectionState<TrackKind = string> {
   selectedClipId: string | null;
   /** ID of the track containing the selected clip, or null when no clip is selected. */
   selectedClipTrackId: string | null;
+  /** All selected clips in track order. */
+  selectedClips: Clip[];
+  /** IDs of all selected clips in track order. */
+  selectedClipIds: string[];
+  /** Selected group when the primary selected clip belongs to one. */
+  selectedGroup: TimelineClipGroup | null;
+  /** Selected group id when the primary selected clip belongs to one. */
+  selectedGroupId: string | null;
+  /** Whether any clip or track is selected. */
+  hasSelection: boolean;
   /** Currently selected track, or null when no track row is selected. */
   selectedTrack: Track<TrackKind> | null;
   /** ID of the currently selected track, or null when no track row is selected. */
@@ -46,31 +61,48 @@ export function flattenTimelineClips<TrackKind>(
  * @returns Current selection metadata.
  */
 export function deriveTimelineSelection<TrackKind>(
-  tracks: Track<TrackKind>[]
+  tracks: Track<TrackKind>[],
+  clipGroups: TimelineClipGroup[] = []
 ): TimelineSelectionState<TrackKind> {
   let selectedClip: Clip | null = null;
   let selectedClipTrackId: string | null = null;
   let selectedTrack: Track<TrackKind> | null = null;
+  const selectedClips: Clip[] = [];
+  const clipGroupByClipId = new Map<string, TimelineClipGroup>();
+  for (const group of clipGroups) {
+    for (const clipId of group.clipIds) {
+      clipGroupByClipId.set(clipId, group);
+    }
+  }
 
   for (const track of tracks) {
     if (track.selected) {
       selectedTrack = track;
     }
 
-    if (!selectedClip) {
-      const clip = track.clips.find((candidate) => candidate.selected);
-      if (clip) {
+    for (const clip of track.clips) {
+      if (clip.selected) {
+        selectedClips.push(clip);
+      }
+      if (!selectedClip && clip.selected) {
         selectedClip = clip;
         selectedClipTrackId = track.id;
       }
     }
   }
+  const selectedGroup =
+    selectedClip === null ? null : (clipGroupByClipId.get(selectedClip.id) ?? null);
 
   return {
     selectedClip,
     selectedClipId: selectedClip?.id ?? null,
     selectedClipTrackId,
+    selectedClips,
+    selectedClipIds: selectedClips.map((clip) => clip.id),
+    selectedGroup,
+    selectedGroupId: selectedGroup?.id ?? null,
     selectedTrack,
     selectedTrackId: selectedTrack?.id ?? null,
+    hasSelection: selectedClips.length > 0 || selectedTrack !== null,
   };
 }

--- a/packages/react/src/hooks/clips/useTimelineClipDrag.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDrag.ts
@@ -304,6 +304,10 @@ export function useTimelineClipDrag<TrackKind = string>(
         previousEndTime: activeDrag.previousEndTime,
         startTime: { ...found.clip.timelineStart },
         endTime: { ...found.clip.timelineEnd },
+        changedClips: engine.getClipGroupForClip(activeDrag.clipId)?.clipIds.flatMap((clipId) => {
+          const grouped = engine.getClip(clipId);
+          return grouped === undefined ? [] : [grouped.clip];
+        }) ?? [found.clip],
       });
     },
     [

--- a/packages/react/src/hooks/clips/useTimelineClipGroups.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipGroups.ts
@@ -1,0 +1,89 @@
+import { useCallback, useMemo } from 'react';
+import type { TimelineClipEntry, TimelineClipGroup } from '@techsquidtv/canvas-timeline-core';
+import { useTimeline } from '../core/useTimeline';
+import { useTimelineSelection } from '../selection/useTimelineSelection';
+import {
+  timelineCommandFail,
+  timelineCommandOk,
+  type TimelineCommandResult,
+} from '../core/timelineCommandResult';
+
+/** Result returned by `useTimelineClipGroups`. */
+export interface UseTimelineClipGroupsResult {
+  /** Current clip groups. */
+  groups: TimelineClipGroup[];
+  /** Selected clip group, or null when the primary selected clip is ungrouped. */
+  selectedGroup: TimelineClipGroup | null;
+  /** Selected clip group id, or null when the primary selected clip is ungrouped. */
+  selectedGroupId: string | null;
+  /** Returns one clip group by id. */
+  getClipGroup: (groupId: string) => TimelineClipGroup | undefined;
+  /** Returns the clip group containing a clip. */
+  getClipGroupForClip: (clipId: string) => TimelineClipGroup | undefined;
+  /** Returns clips contained by a group in group order. */
+  getClipGroupClips: (groupId: string) => TimelineClipEntry[];
+  /** Groups existing clips. */
+  groupClips: (
+    clipIds: readonly string[],
+    label?: string
+  ) => TimelineCommandResult<TimelineClipGroup>;
+  /** Removes one clip group. */
+  ungroupClipGroup: (groupId: string) => TimelineCommandResult;
+  /** Removes the current selected group, or groups containing selected clips. */
+  ungroupSelectedClips: () => TimelineCommandResult;
+}
+
+/**
+ * Exposes clip group state and commands for editor chrome.
+ *
+ * @returns Clip group collection, selected group metadata, lookups, and commands.
+ */
+export function useTimelineClipGroups(): UseTimelineClipGroupsResult {
+  const { engine, state } = useTimeline();
+  const { selectedClipIds, selectedGroup, selectedGroupId } = useTimelineSelection();
+  const groups = useMemo(() => state.clipGroups, [state.clipGroups]);
+
+  const getClipGroup = useCallback((groupId: string) => engine.getClipGroup(groupId), [engine]);
+  const getClipGroupForClip = useCallback(
+    (clipId: string) => engine.getClipGroupForClip(clipId),
+    [engine]
+  );
+  const getClipGroupClips = useCallback(
+    (groupId: string) => engine.getClipGroupClips(groupId),
+    [engine]
+  );
+
+  const groupClips = useCallback(
+    (clipIds: readonly string[], label?: string) => {
+      const group = engine.createClipGroup({ clipIds, ...(label !== undefined ? { label } : {}) });
+      return group === null
+        ? timelineCommandFail<TimelineClipGroup>('invalid-range')
+        : timelineCommandOk(group);
+    },
+    [engine]
+  );
+
+  const ungroupClipGroup = useCallback(
+    (groupId: string) =>
+      engine.ungroupClipGroup(groupId) ? timelineCommandOk() : timelineCommandFail('not-found'),
+    [engine]
+  );
+
+  const ungroupSelectedClips = useCallback(() => {
+    return engine.ungroupClips(selectedClipIds)
+      ? timelineCommandOk()
+      : timelineCommandFail('not-found');
+  }, [engine, selectedClipIds]);
+
+  return {
+    groups,
+    selectedGroup,
+    selectedGroupId,
+    getClipGroup,
+    getClipGroupForClip,
+    getClipGroupClips,
+    groupClips,
+    ungroupClipGroup,
+    ungroupSelectedClips,
+  };
+}

--- a/packages/react/src/hooks/clips/useTimelineClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineClips.ts
@@ -5,6 +5,7 @@ import type {
   TimelineEngine,
   TimelineClipMoveOptions,
   TimelineClipMoveResult,
+  TimelineClipGroup,
   TimelineEditValidationResult,
   TimelineInteractionGeometry,
   Track,
@@ -41,6 +42,14 @@ export interface UseTimelineClipsResult<TrackKind = string> {
   selectedClipId: string | null;
   /** ID of the track containing the selected clip, or null when no clip is selected. */
   selectedClipTrackId: string | null;
+  /** All selected clips in track order. */
+  selectedClips: Clip[];
+  /** IDs of all selected clips in track order. */
+  selectedClipIds: string[];
+  /** Selected group when the primary selected clip belongs to one. */
+  selectedGroup: TimelineClipGroup | null;
+  /** Selected group id when the primary selected clip belongs to one. */
+  selectedGroupId: string | null;
   /** Returns a clip lookup from the engine, including containing track and indexes. */
   getClip: TimelineEngine['getClip'];
   /** Returns the current viewport rectangle for a clip. */
@@ -88,8 +97,16 @@ export interface UseTimelineClipsResult<TrackKind = string> {
  */
 export function useTimelineClips<TrackKind = string>(): UseTimelineClipsResult<TrackKind> {
   const { engine, state } = useTimeline();
-  const { selectedClip, selectedClipId, selectedClipTrackId, selectClip } =
-    useTimelineSelection<TrackKind>();
+  const {
+    selectedClip,
+    selectedClipId,
+    selectedClipTrackId,
+    selectedClips,
+    selectedClipIds,
+    selectedGroup,
+    selectedGroupId,
+    selectClip,
+  } = useTimelineSelection<TrackKind>();
 
   const clips = useMemo(
     () => flattenTimelineClips(state.tracks as Track<TrackKind>[]),
@@ -221,6 +238,7 @@ export function useTimelineClips<TrackKind = string>(): UseTimelineClipsResult<T
         previousEndTime,
         startTime: { ...moved.clip.timelineStart },
         endTime: { ...moved.clip.timelineEnd },
+        changedClips: commit.preview.changedClips,
       });
     },
     [engine, state.tracks]
@@ -319,6 +337,10 @@ export function useTimelineClips<TrackKind = string>(): UseTimelineClipsResult<T
     selectedClip,
     selectedClipId,
     selectedClipTrackId,
+    selectedClips,
+    selectedClipIds,
+    selectedGroup,
+    selectedGroupId,
     getClip,
     getClipRect,
     getClipAtPoint,

--- a/packages/react/src/hooks/docs/docsMetadata.ts
+++ b/packages/react/src/hooks/docs/docsMetadata.ts
@@ -157,6 +157,13 @@ export const timelineHookMetadata = [
     description: 'Reads timeline clips and exposes canonical clip editing commands.',
   },
   {
+    name: 'useTimelineClipGroups',
+    group: 'editing-hooks',
+    category: 'clip-editing',
+    reactivity: 'snapshot',
+    description: 'Reads clip groups and exposes group management commands.',
+  },
+  {
     name: 'useTimelineEditMode',
     group: 'editing-hooks',
     category: 'clip-editing',

--- a/packages/react/src/hooks/editing/useTimelineEditCommands.ts
+++ b/packages/react/src/hooks/editing/useTimelineEditCommands.ts
@@ -12,10 +12,12 @@ import type {
   TimelineRippleTrimEditCommand,
   TimelineRollTrimEditCommand,
   TimelineSlideEditCommand,
+  TimelineSplitEditCommand,
   TimelineTrimEditCommand,
 } from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useTimeline } from '../core/useTimeline';
+import { useTimelineSelection } from '../selection/useTimelineSelection';
 import {
   timelineCommandFail,
   timelineCommandOk,
@@ -58,6 +60,17 @@ export interface UseTimelineEditCommandsResult {
   slideClip: (
     command: Omit<TimelineSlideEditCommand, 'type'>
   ) => TimelineCommandResult<TimelineEditCommitResult>;
+  /** Commits a split command for one clip. */
+  splitClip: (
+    clipId: string,
+    time: RationalTime
+  ) => TimelineCommandResult<TimelineEditCommitResult>;
+  /** Commits a split command for multiple clips. */
+  splitClips: (
+    command: Omit<TimelineSplitEditCommand, 'type'>
+  ) => TimelineCommandResult<TimelineEditCommitResult>;
+  /** Splits the current selected clips at a timeline time. */
+  splitSelectedClipsAtTime: (time: RationalTime) => TimelineCommandResult<TimelineEditCommitResult>;
   /** Commits an insert command. */
   insertClip: (
     command: Omit<TimelineInsertEditCommand, 'type'>
@@ -94,6 +107,7 @@ function toTimelineCommandFailureReason(
  */
 export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
   const { engine } = useTimeline();
+  const { selectedClipIds } = useTimelineSelection();
 
   const validateEdit = useCallback(
     (command: TimelineEditCommand) => engine.validateEdit(command),
@@ -135,6 +149,11 @@ export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
       slipClip: (clipId: string, deltaTime: RationalTime) =>
         commitEdit({ type: 'slip', clipId, deltaTime }),
       slideClip: (command) => commitEdit({ type: 'slide', ...command }),
+      splitClip: (clipId: string, time: RationalTime) =>
+        commitEdit({ type: 'split', clipIds: [clipId], time }),
+      splitClips: (command) => commitEdit({ type: 'split', ...command }),
+      splitSelectedClipsAtTime: (time: RationalTime) =>
+        commitEdit({ type: 'split', clipIds: selectedClipIds, time }),
       insertClip: (command: {
         clip: Clip;
         targetTrackId: string;
@@ -150,6 +169,6 @@ export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
       deleteRange: (command) => commitEdit({ type: 'delete-range', ...command }),
       liftRange: (command) => commitEdit({ type: 'lift-range', ...command }),
     }),
-    [cancelEdit, commitEdit, previewEdit, validateEdit]
+    [cancelEdit, commitEdit, previewEdit, selectedClipIds, validateEdit]
   );
 }

--- a/packages/react/src/hooks/selection/useTimelineSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineSelection.ts
@@ -11,6 +11,10 @@ export interface UseTimelineSelectionResult<
 > extends TimelineSelectionState<TrackKind> {
   /** Selects a clip by id, or clears clip selection when passed null. */
   selectClip: (clipId: string | null) => void;
+  /** Selects multiple clips by id, clearing clips not included. */
+  selectClips: (clipIds: readonly string[]) => void;
+  /** Toggles one clip in the current multi-selection. */
+  toggleClipSelection: (clipId: string, selected?: boolean) => boolean;
   /** Selects a track by id, or clears track selection when passed null. */
   selectTrack: (trackId: string | null) => void;
   /** Clears both clip and track selection. */
@@ -25,8 +29,8 @@ export interface UseTimelineSelectionResult<
 export function useTimelineSelection<TrackKind = string>(): UseTimelineSelectionResult<TrackKind> {
   const { engine, state } = useTimeline();
   const selection = useMemo(
-    () => deriveTimelineSelection(state.tracks as Track<TrackKind>[]),
-    [state.tracks]
+    () => deriveTimelineSelection(state.tracks as Track<TrackKind>[], state.clipGroups),
+    [state.clipGroups, state.tracks]
   );
 
   const selectClip = useCallback(
@@ -43,6 +47,18 @@ export function useTimelineSelection<TrackKind = string>(): UseTimelineSelection
     [engine]
   );
 
+  const selectClips = useCallback(
+    (clipIds: readonly string[]) => {
+      engine.selectClips(clipIds);
+    },
+    [engine]
+  );
+
+  const toggleClipSelection = useCallback(
+    (clipId: string, selected?: boolean) => engine.toggleClipSelection(clipId, selected),
+    [engine]
+  );
+
   const clearSelection = useCallback(() => {
     engine.selectClip(null);
     engine.selectTrack(null);
@@ -51,6 +67,8 @@ export function useTimelineSelection<TrackKind = string>(): UseTimelineSelection
   return {
     ...selection,
     selectClip,
+    selectClips,
+    toggleClipSelection,
     selectTrack,
     clearSelection,
   };

--- a/packages/utils/src/time.test.ts
+++ b/packages/utils/src/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { addRational, assertValidRationalTime, fromSeconds, toSeconds } from './time';
+import { addRational, assertValidRationalTime, fromSeconds, subRational, toSeconds } from './time';
 
 describe('rational time utilities', () => {
   it('rejects invalid rational times with field-specific messages', () => {
@@ -25,5 +25,17 @@ describe('rational time utilities', () => {
     expect(() => addRational(fromSeconds(1), { v: 1, r: Number.NaN })).toThrow(
       'b.r must be a positive finite tick rate.'
     );
+  });
+
+  it('uses the least common tick rate for mixed-rate arithmetic', () => {
+    const timelineTime = fromSeconds(6.5);
+    const dragTime = fromSeconds(6.25, 24000);
+
+    const delta = subRational(dragTime, timelineTime);
+    const moved = addRational(timelineTime, delta);
+
+    expect(delta.r).toBe(120000);
+    expect(moved.r).toBe(120000);
+    expect(toSeconds(moved)).toBeCloseTo(6.25);
   });
 });

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -56,6 +56,27 @@ export function fromSeconds(sec: number, rate: number = 60000): RationalTime {
   return { v: Math.round(sec * rate), r: rate };
 }
 
+function greatestCommonDivisor(a: number, b: number): number {
+  let left = Math.abs(a);
+  let right = Math.abs(b);
+  while (right !== 0) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left;
+}
+
+function getCommonIntegerRate(a: RationalTime, b: RationalTime): number | null {
+  if (!Number.isInteger(a.r) || !Number.isInteger(b.r)) {
+    return null;
+  }
+
+  const divisor = greatestCommonDivisor(a.r, b.r);
+  const commonRate = a.r * (b.r / divisor);
+  return Number.isFinite(commonRate) && Number.isInteger(commonRate) ? commonRate : null;
+}
+
 /**
  * Adds two rational timeline times.
  *
@@ -69,9 +90,11 @@ export function addRational(a: RationalTime, b: RationalTime): RationalTime {
   if (a.r === b.r) {
     return { v: a.v + b.v, r: a.r };
   }
-  const r = a.r * b.r;
-  const v = a.v * b.r + b.v * a.r;
-  return { v, r };
+  const r = getCommonIntegerRate(a, b);
+  if (r !== null) {
+    return { v: a.v * (r / a.r) + b.v * (r / b.r), r };
+  }
+  return fromSeconds(toSeconds(a) + toSeconds(b), Math.max(a.r, b.r));
 }
 
 /**
@@ -87,9 +110,11 @@ export function subRational(a: RationalTime, b: RationalTime): RationalTime {
   if (a.r === b.r) {
     return { v: a.v - b.v, r: a.r };
   }
-  const r = a.r * b.r;
-  const v = a.v * b.r - b.v * a.r;
-  return { v, r };
+  const r = getCommonIntegerRate(a, b);
+  if (r !== null) {
+    return { v: a.v * (r / a.r) - b.v * (r / b.r), r };
+  }
+  return fromSeconds(toSeconds(a) - toSeconds(b), Math.max(a.r, b.r));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds core clip group state, validation, group commands, grouped selection, grouped move/delete/copy/paste behavior, and split command repartitioning.
- Exposes React grouping and multi-selection hooks, Shift-click multi-select in the clip interaction layer, and split-selected edit commands.
- Adds a source-backed Clip Grouping demo plus docs coverage and regression tests for grouping, split, drag, history, clipboard, and rational-time mixed-rate edits.

## Release Impact

- Packages/API: Major changeset for the aggregate, core, and React packages; patch changeset for utils rational-time arithmetic.
- Docs/demos: Adds the Clip Grouping demo and updates tracks/clips, hooks, and architecture docs.
- Breaking changes: TimelineState now includes clipGroups, selection is primary-plus-many, move results include changedClips, and split edits are command-layer operations.
- Checklist areas reviewed: 1, 2, 3, 4, 5, 8, 10, and 11.

## Validation

- `vp test packages/core/src/engine.test.ts packages/react/src/hooks.test.ts packages/react/src/components/interactions/ClipInteractionLayer.test.tsx`
- `vp check`
- `vp run --filter @techsquidtv/canvas-timeline-www docs:demos`
- `printf '%s\n' 'feat(timeline)!: add clip grouping API' | vp exec commitlint --verbose`
- `vp run build:packages`