### PR TITLE
docs: improve React API TSDoc enforcement

### DIFF
--- a/.changeset/react-api-tsdoc-docs.md
+++ b/.changeset/react-api-tsdoc-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Improve React API TSDoc, generated API link rendering, and documentation quality enforcement without changing package runtime behavior.

--- a/apps/www/scripts/generate-api-reference.mjs
+++ b/apps/www/scripts/generate-api-reference.mjs
@@ -12,6 +12,21 @@ const generatedDir = resolve(appDir, '.generated');
 const outputPath = resolve(generatedDir, 'api-reference.json');
 const warningsPath = resolve(generatedDir, 'api-reference-warnings.txt');
 const typedocBin = resolve(appDir, 'node_modules/.bin/typedoc');
+const externalSymbolLinkMappings = {
+  '@techsquidtv/canvas-timeline-core': {
+    ActiveLayerOptions: '/packages/core/api/active-layer-options',
+    ActiveLayerResult: '/packages/core/api/active-layer-result',
+    ActiveLayerSelector: '/packages/core/api/active-layer-selector',
+    TimelineEngine: '/packages/core/api/timeline-engine',
+    TimelineState: '/packages/core/api/timeline-state',
+  },
+  '@techsquidtv/canvas-timeline-react': {
+    useTimelineMediaSync: '/packages/react/api/use-timeline-media-sync',
+  },
+  '@techsquidtv/canvas-timeline-utils': {
+    RationalTime: '/packages/utils/api/rational-time',
+  },
+};
 
 const packageEntries = [
   {
@@ -69,8 +84,84 @@ const kindNames = new Map([
   [4194304, 'Reference'],
 ]);
 
-function textFromCommentParts(parts = [], { collapseWhitespace = true } = {}) {
-  const text = parts.map((part) => part.text ?? part.name ?? '').join('');
+const linkTags = new Set(['@link', '@linkcode', '@linkplain']);
+
+function commentPartText(part) {
+  if (typeof part.text === 'string') {
+    return part.text;
+  }
+
+  if (typeof part.name === 'string') {
+    return part.name;
+  }
+
+  return '';
+}
+
+function commentPartTarget(part) {
+  const target = part.target;
+
+  if (typeof target === 'string') {
+    return target;
+  }
+
+  if (typeof target?.name === 'string') {
+    return target.name;
+  }
+
+  if (typeof target?.qualifiedName === 'string') {
+    return target.qualifiedName;
+  }
+
+  return undefined;
+}
+
+function trimTSDocLinkText(value) {
+  return value
+    .replace(/^\{@link(?:code|plain)?\s+/, '')
+    .replace(/\}$/, '')
+    .trim();
+}
+
+function docPartsFromCommentParts(parts = []) {
+  const docParts = [];
+
+  for (const part of parts) {
+    const kind = part.kind ?? 'text';
+    const text = commentPartText(part);
+
+    if (kind === 'inline-tag' && linkTags.has(part.tag)) {
+      const rawTarget = commentPartTarget(part);
+      const cleanedText = trimTSDocLinkText(text);
+      const [targetText, labelText] = cleanedText.split('|').map((segment) => segment.trim());
+      const target = rawTarget ?? targetText;
+      const label = labelText || targetText || rawTarget;
+
+      if (target) {
+        docParts.push({
+          kind: 'link',
+          text: label || target,
+          target,
+        });
+      }
+      continue;
+    }
+
+    if (!text) {
+      continue;
+    }
+
+    docParts.push({
+      kind: kind === 'code' ? 'code' : 'text',
+      text,
+    });
+  }
+
+  return docParts;
+}
+
+function textFromDocParts(parts, { collapseWhitespace = true } = {}) {
+  const text = parts.map((part) => part.text).join('');
 
   if (!collapseWhitespace) {
     return text.trim();
@@ -79,8 +170,16 @@ function textFromCommentParts(parts = [], { collapseWhitespace = true } = {}) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+function textFromCommentParts(parts = [], options = {}) {
+  return textFromDocParts(docPartsFromCommentParts(parts), options);
+}
+
 function commentSummary(comment) {
   return textFromCommentParts(comment?.summary);
+}
+
+function commentSummaryParts(comment) {
+  return docPartsFromCommentParts(comment?.summary);
 }
 
 function commentExamples(comment) {
@@ -94,6 +193,19 @@ function commentBlockTag(comment, tagName) {
   const tag = comment?.blockTags?.find((blockTag) => blockTag.tag === tagName);
 
   return textFromCommentParts(tag?.content);
+}
+
+function commentBlockTagParts(comment, tagName) {
+  const tag = comment?.blockTags?.find((blockTag) => blockTag.tag === tagName);
+
+  return docPartsFromCommentParts(tag?.content);
+}
+
+function commentBlockTagsParts(comment, tagName) {
+  return (comment?.blockTags ?? [])
+    .filter((tag) => tag.tag === tagName)
+    .map((tag) => docPartsFromCommentParts(tag.content))
+    .filter((parts) => parts.length > 0);
 }
 
 function parametersText(parameters = []) {
@@ -198,6 +310,7 @@ function paramsFor(reflection) {
     optional: Boolean(parameter.flags?.isOptional),
     defaultValue: parameter.defaultValue,
     summary: commentSummary(parameter.comment),
+    summaryParts: commentSummaryParts(parameter.comment),
   }));
 }
 
@@ -265,6 +378,16 @@ function normalizeMember(member) {
     member.setSignature ??
     member.type?.declaration?.signatures?.[0];
 
+  const summaryParts =
+    commentSummaryParts(member.comment).length > 0
+      ? commentSummaryParts(member.comment)
+      : commentSummaryParts(member.getSignature?.comment).length > 0
+        ? commentSummaryParts(member.getSignature?.comment)
+        : commentSummaryParts(member.setSignature?.comment).length > 0
+          ? commentSummaryParts(member.setSignature?.comment)
+          : commentSummaryParts(signature?.comment);
+  const summary = textFromDocParts(summaryParts);
+
   return {
     name: member.name,
     kind: kindNames.get(member.kind) ?? `Kind ${member.kind}`,
@@ -277,11 +400,8 @@ function normalizeMember(member) {
     optional: Boolean(member.flags?.isOptional),
     params: paramsFor(signature ? { signatures: [signature] } : member),
     returns: memberReturn(member),
-    summary:
-      commentSummary(member.comment) ||
-      commentSummary(member.getSignature?.comment) ||
-      commentSummary(member.setSignature?.comment) ||
-      commentSummary(signature?.comment),
+    summary,
+    summaryParts,
   };
 }
 
@@ -309,13 +429,54 @@ function constructorsFor(reflection) {
 function typeParametersFor(reflection) {
   const signature = reflection.signatures?.[0];
   const typeParameters = reflection.typeParameters ?? signature?.typeParameters ?? [];
+  const comments = [reflection.comment, signature?.comment].filter(Boolean);
 
-  return typeParameters.map((typeParameter) => ({
-    name: typeParameter.name,
-    default: typeParameter.default ? typeName(typeParameter.default) : undefined,
-    constraint: typeParameter.type ? typeName(typeParameter.type) : undefined,
-    summary: commentSummary(typeParameter.comment),
-  }));
+  return typeParameters.map((typeParameter) => {
+    const summaryParts = typeParameterSummaryParts(typeParameter, comments);
+
+    return {
+      name: typeParameter.name,
+      default: typeParameter.default ? typeName(typeParameter.default) : undefined,
+      constraint: typeParameter.type ? typeName(typeParameter.type) : undefined,
+      summary: textFromDocParts(summaryParts),
+      summaryParts,
+    };
+  });
+}
+
+function typeParameterSummaryParts(typeParameter, comments) {
+  const directParts = commentSummaryParts(typeParameter.comment);
+
+  if (directParts.length > 0) {
+    return directParts;
+  }
+
+  for (const comment of comments) {
+    for (const blockTag of comment?.blockTags ?? []) {
+      if (blockTag.tag !== '@template' && blockTag.tag !== '@typeParam') {
+        continue;
+      }
+
+      const tagName = blockTag.name;
+      const parts = docPartsFromCommentParts(blockTag.content);
+
+      if (tagName === typeParameter.name) {
+        return parts;
+      }
+
+      const text = textFromDocParts(parts);
+      if (text.startsWith(`${typeParameter.name} - `)) {
+        return docPartsFromCommentParts([
+          {
+            kind: 'text',
+            text: text.slice(typeParameter.name.length + 3),
+          },
+        ]);
+      }
+    }
+  }
+
+  return [];
 }
 
 function returnMembersFor(reflection) {
@@ -521,7 +682,19 @@ function aliasOfFor(reflection) {
 
 function normalizeSymbol(reflection, packageEntry, warnings) {
   const signature = reflection.signatures?.[0];
-  let summary = commentSummary(reflection.comment) || commentSummary(signature?.comment);
+  let summaryParts =
+    commentSummaryParts(reflection.comment).length > 0
+      ? commentSummaryParts(reflection.comment)
+      : commentSummaryParts(signature?.comment);
+  let summary = textFromDocParts(summaryParts);
+  const remarksParts =
+    commentBlockTagParts(reflection.comment, '@remarks').length > 0
+      ? commentBlockTagParts(reflection.comment, '@remarks')
+      : commentBlockTagParts(signature?.comment, '@remarks');
+  const see = [
+    ...commentBlockTagsParts(reflection.comment, '@see'),
+    ...commentBlockTagsParts(signature?.comment, '@see'),
+  ];
   const examples = [...commentExamples(reflection.comment), ...commentExamples(signature?.comment)];
   const source = reflection.sources?.[0] ?? signature?.sources?.[0];
   const symbolSlug = slugifySymbolName(reflection.name);
@@ -534,8 +707,10 @@ function normalizeSymbol(reflection, packageEntry, warnings) {
 
   if (summary === reflection.name) {
     summary = '';
+    summaryParts = [];
   } else if (summary.startsWith(`${reflection.name} `)) {
     summary = summary.slice(reflection.name.length).trim();
+    summaryParts = docPartsFromCommentParts([{ kind: 'text', text: summary }]);
   }
 
   if (!summary) {
@@ -549,6 +724,9 @@ function normalizeSymbol(reflection, packageEntry, warnings) {
     name: reflection.name,
     kind: kindNames.get(reflection.kind) ?? `Kind ${reflection.kind}`,
     summary,
+    summaryParts,
+    remarks: textFromDocParts(remarksParts),
+    remarksParts,
     signature: signatureFor(reflection),
     params,
     typeParameters,
@@ -562,7 +740,12 @@ function normalizeSymbol(reflection, packageEntry, warnings) {
     returnsSummary:
       commentBlockTag(reflection.comment, '@returns') ||
       commentBlockTag(signature?.comment, '@returns'),
+    returnsSummaryParts:
+      commentBlockTagParts(reflection.comment, '@returns').length > 0
+        ? commentBlockTagParts(reflection.comment, '@returns')
+        : commentBlockTagParts(signature?.comment, '@returns'),
     examples,
+    see,
     sourcePackage: packageEntry.slug,
     source: source
       ? {
@@ -586,26 +769,24 @@ function topLevelApiReflections(rawProject) {
 
 async function runTypedoc(packageEntry) {
   const rawPath = resolve(generatedDir, `typedoc-${packageEntry.slug}.json`);
+  const optionsPath = resolve(generatedDir, `typedoc-${packageEntry.slug}.jsonc`);
   const entryPoints = packageEntry.entryPoints ?? [packageEntry.entryPoint];
-  const args = [
-    '--json',
-    rawPath,
-    '--tsconfig',
-    'tsconfig.base.json',
-    '--entryPoints',
-    ...entryPoints,
-    '--entryPointStrategy',
-    'resolve',
-    '--excludePrivate',
-    '--excludeInternal',
-    '--readme',
-    'none',
-    '--name',
-    packageEntry.name,
-    '--logLevel',
-    'Warn',
-    '--skipErrorChecking',
-  ];
+  const options = {
+    json: rawPath,
+    tsconfig: resolve(rootDir, 'tsconfig.base.json'),
+    entryPoints: entryPoints.map((entryPoint) => resolve(rootDir, entryPoint)),
+    entryPointStrategy: 'resolve',
+    excludePrivate: true,
+    excludeInternal: true,
+    readme: 'none',
+    name: packageEntry.name,
+    logLevel: 'Warn',
+    skipErrorChecking: true,
+    externalSymbolLinkMappings,
+  };
+  const args = ['--options', optionsPath];
+
+  await writeFile(optionsPath, `${JSON.stringify(options, null, 2)}\n`);
   const result = spawnSync(typedocBin, args, {
     cwd: rootDir,
     encoding: 'utf8',
@@ -678,6 +859,8 @@ if (missingRequiredSymbols.length > 0) {
   );
 }
 
+validateCuratedReactDocs(packages);
+
 const reference = {
   generatedAt: new Date().toISOString(),
   packages,
@@ -696,3 +879,91 @@ globalThis.console.info(
   `Wrote ${outputPath} with ${packages.length} packages and ${symbols.length} symbols.`
 );
 globalThis.console.info(`Wrote ${warningsPath} with ${warnings.length} warnings.`);
+
+function validateCuratedReactDocs(packages) {
+  const reactPackage = packages.find((packageDoc) => packageDoc.slug === 'react');
+
+  if (!reactPackage) {
+    throw new Error('Generated API reference is missing the React package.');
+  }
+
+  const curatedNames = new Set([
+    'TimelineProvider',
+    'TimelineProviderProps',
+    'TimelineMediaSyncAdapter',
+    'UseTimelineMediaSyncOptions',
+    'UseTimelineMediaSyncResult',
+    'useTimelineMediaSync',
+    'useTimelineState',
+  ]);
+  const exampleRequiredNames = new Set([
+    'TimelineProvider',
+    'useTimelineMediaSync',
+    'useTimelineState',
+  ]);
+  const remarksLinkRequiredNames = new Set([
+    'TimelineProvider',
+    'TimelineProviderProps',
+    'TimelineMediaSyncAdapter',
+    'UseTimelineMediaSyncOptions',
+    'useTimelineMediaSync',
+    'useTimelineState',
+  ]);
+  const failures = [];
+
+  for (const name of curatedNames) {
+    const symbol = reactPackage.symbols.find((candidate) => candidate.name === name);
+
+    if (!symbol) {
+      failures.push(`Missing curated React API symbol ${name}.`);
+      continue;
+    }
+
+    requireDocParts(symbol.summaryParts, `${name} summary`, failures);
+    requireDocParts(symbol.remarksParts, `${name} @remarks`, failures);
+
+    if (remarksLinkRequiredNames.has(name) && !hasDocLink(symbol.remarksParts)) {
+      failures.push(`${name} @remarks must include at least one {@link ...} reference.`);
+    }
+
+    if (exampleRequiredNames.has(name) && symbol.examples.length === 0) {
+      failures.push(`${name} must include at least one @example block.`);
+    }
+
+    for (const param of symbol.params) {
+      requireDocParts(param.summaryParts, `${name}.${param.name} @param`, failures);
+    }
+
+    for (const typeParameter of symbol.typeParameters) {
+      requireDocParts(
+        typeParameter.summaryParts,
+        `${name}.${typeParameter.name} @template`,
+        failures
+      );
+    }
+
+    if (symbol.kind === 'Interface') {
+      for (const property of symbol.properties) {
+        requireDocParts(property.summaryParts, `${name}.${property.name} property`, failures);
+      }
+    }
+
+    if (symbol.name.startsWith('use')) {
+      requireDocParts(symbol.returnsSummaryParts, `${name} @returns`, failures);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Curated React API documentation is incomplete.\n${failures.join('\n')}`);
+  }
+}
+
+function requireDocParts(parts, label, failures) {
+  if (textFromDocParts(parts).length === 0) {
+    failures.push(`${label} is missing.`);
+  }
+}
+
+function hasDocLink(parts) {
+  return parts.some((part) => part.kind === 'link');
+}

--- a/apps/www/src/lib/api-markdown.test.ts
+++ b/apps/www/src/lib/api-markdown.test.ts
@@ -41,6 +41,62 @@ describe('API Markdown builder', () => {
     expect(markdown).not.toContain('class=');
   });
 
+  test('renders structured TSDoc links in copied API Markdown', () => {
+    const packageDoc = requiredPackage('react');
+    const markdown = buildApiSymbolMarkdown(packageDoc, {
+      slug: 'linked-example',
+      name: 'linkedExample',
+      kind: 'Function',
+      summary: 'Reads linked docs.',
+      summaryParts: [{ kind: 'text', text: 'Reads linked docs.' }],
+      remarks: 'Use the state model.',
+      remarksParts: [
+        { kind: 'text', text: 'Use the ' },
+        { kind: 'link', text: 'state model', target: 'TimelineState' },
+        { kind: 'text', text: ' before rendering.' },
+      ],
+      signature: 'linkedExample(): TimelineState',
+      params: [],
+      typeParameters: [
+        {
+          name: 'LayerName',
+          constraint: 'string',
+          default: 'string',
+          summary: 'Layer key.',
+          summaryParts: [
+            { kind: 'text', text: 'Layer key for ' },
+            { kind: 'link', text: 'active layers', target: 'ActiveLayerResult' },
+            { kind: 'text', text: '.' },
+          ],
+        },
+      ],
+      properties: [],
+      methods: [],
+      constructors: [],
+      returnMembers: [],
+      returns: 'TimelineState',
+      returnsSummary: 'Current state.',
+      returnsSummaryParts: [{ kind: 'text', text: 'Current state.' }],
+      examples: [],
+      see: [
+        [
+          {
+            kind: 'link',
+            text: 'React editor hooks',
+            target: 'https://canvastimeline.com/docs/react-hooks',
+          },
+        ],
+      ],
+      sourcePackage: 'react',
+    });
+
+    expect(markdown).toContain('## Usage notes');
+    expect(markdown).toContain('[state model](/packages/core/api/timeline-state)');
+    expect(markdown).toContain('[active layers](/packages/core/api/active-layer-result)');
+    expect(markdown).toContain('[React editor hooks](https://canvastimeline.com/docs/react-hooks)');
+    expect(markdown).not.toContain('{@link');
+  });
+
   test('escapes Markdown table cells and inline code delimiters', () => {
     expect(markdownTable(['Name|Type', 'Path\\Segment'], [['line\nbreak', 'a|b\\c']])).toBe(
       '| Name\\|Type | Path\\\\Segment |\n| :--- | :--- |\n| line<br>break | a\\|b\\\\c |'

--- a/apps/www/src/lib/api-markdown.ts
+++ b/apps/www/src/lib/api-markdown.ts
@@ -1,11 +1,13 @@
 import { groupApiSymbols } from './api-symbol-groups';
 import {
   apiReference,
+  apiDocPartHref,
   apiSymbolHref,
   getApiSymbol,
   type ApiMember,
   type ApiPackage,
   type ApiParameter,
+  type ApiDocTextPart,
   type ApiSymbol,
   type ApiTypeParameter,
 } from './api-reference';
@@ -83,6 +85,8 @@ export function buildApiSymbolMarkdown(
     `Kind: \`${resolvedSymbol.kind}\``,
     `Entry point: \`${packageDoc.entryPoint}\``,
     '',
+    ...remarksSection(resolvedSymbol),
+    ...timelineStateBreakdownSection(resolvedSymbol),
     '## Signature',
     '',
     codeBlock(resolvedSymbol.signature, 'ts'),
@@ -96,15 +100,16 @@ export function buildApiSymbolMarkdown(
           ...(aliasedSymbol ? [codeBlock(aliasedSymbol.signature, 'ts'), ''] : []),
         ]
       : []),
-    ...typeParameterSection(typeParameters),
-    ...parameterSection(resolvedSymbol.params),
-    ...memberSection('Properties', properties),
-    ...memberSection('Constructors', constructors),
+    ...typeParameterSection(packageDoc, resolvedSymbol, typeParameters),
+    ...parameterSection(packageDoc, resolvedSymbol, resolvedSymbol.params),
+    ...memberSection(packageDoc, resolvedSymbol, 'Properties', properties),
+    ...memberSection(packageDoc, resolvedSymbol, 'Constructors', constructors),
     ...literalValueSection(resolvedSymbol),
-    ...memberSection('Methods', methods),
-    ...returnsSection(resolvedSymbol),
-    ...memberSection('Return members', returnMembers),
+    ...memberSection(packageDoc, resolvedSymbol, 'Methods', methods),
+    ...returnsSection(packageDoc, resolvedSymbol),
+    ...memberSection(packageDoc, resolvedSymbol, 'Return members', returnMembers),
     ...exampleSection(examples),
+    ...seeSection(packageDoc, resolvedSymbol),
     ...sourceSection(packageDoc, resolvedSymbol),
   ].join('\n');
 
@@ -124,7 +129,67 @@ export function getApiPackage(packageSlug: string) {
   return apiReference.packages.find((packageDoc) => packageDoc.slug === packageSlug);
 }
 
-function typeParameterSection(typeParameters: ApiTypeParameter[]) {
+function remarksSection(symbol: ApiSymbol) {
+  if (symbol.remarksParts.length === 0) {
+    return [];
+  }
+
+  return [
+    '## Usage notes',
+    '',
+    formatDocParts(symbol.remarksParts, symbol.sourcePackage, symbol.sourcePackage),
+    '',
+  ];
+}
+
+function timelineStateBreakdownSection(symbol: ApiSymbol) {
+  if (symbol.name !== 'useTimelineState') {
+    return [];
+  }
+
+  return [
+    '## State available',
+    '',
+    markdownTable(
+      ['Area', 'Fields', 'Use for'],
+      [
+        [
+          'Content',
+          '`tracks`, `clipGroups`, `contentRevision`',
+          'Track lists, clip counts, inspectors, and content-change badges.',
+        ],
+        [
+          'Playback and time',
+          '`playheadTime`, `playing`, `playbackRate`, `duration`',
+          'Toolbar state and coarse playback status. Use `useTimelinePlayheadTime()` for live readouts.',
+        ],
+        [
+          'Viewport',
+          '`zoomScale`, `scrollLeft`, `scrollTop`, `viewportWidth`, `viewportHeight`',
+          'Viewport-aware chrome. Use viewport hooks for focused scroll and zoom controls.',
+        ],
+        [
+          'Selection and ranges',
+          '`inPoint`, `outPoint`',
+          'Range labels, loop region state, and edit selection chrome.',
+        ],
+        ['Markers', '`markers`', 'Marker lists and annotation panels.'],
+        [
+          'Interaction feedback',
+          '`snapEnabled`, `snapThresholdPixels`, `snapFeedback`, `clipDropFeedback`',
+          'Snapping toggles, drag/drop hints, and lightweight editor status.',
+        ],
+      ]
+    ),
+    '',
+  ];
+}
+
+function typeParameterSection(
+  packageDoc: ApiPackage,
+  symbol: ApiSymbol,
+  typeParameters: ApiTypeParameter[]
+) {
   if (typeParameters.length === 0) {
     return [];
   }
@@ -138,14 +203,20 @@ function typeParameterSection(typeParameters: ApiTypeParameter[]) {
         code(typeParameter.name),
         code(typeParameter.constraint ?? 'None'),
         code(typeParameter.default ?? 'None'),
-        typeParameter.summary || 'No type parameter summary yet.',
+        formatDescription(
+          typeParameter.summaryParts,
+          typeParameter.summary,
+          'No type parameter summary yet.',
+          packageDoc.slug,
+          symbol.sourcePackage
+        ),
       ])
     ),
     '',
   ];
 }
 
-function parameterSection(params: ApiParameter[]) {
+function parameterSection(packageDoc: ApiPackage, symbol: ApiSymbol, params: ApiParameter[]) {
   if (params.length === 0) {
     return [];
   }
@@ -158,15 +229,25 @@ function parameterSection(params: ApiParameter[]) {
       params.map((param) => [
         code(`${param.name}${param.optional ? '?' : ''}`),
         code(param.type),
-        param.summary ||
-          (param.defaultValue ? `Default: ${param.defaultValue}` : 'No parameter summary yet.'),
+        formatDescription(
+          param.summaryParts,
+          param.summary,
+          param.defaultValue ? `Default: ${param.defaultValue}` : 'No parameter summary yet.',
+          packageDoc.slug,
+          symbol.sourcePackage
+        ),
       ])
     ),
     '',
   ];
 }
 
-function memberSection(title: string, members: ApiMember[]) {
+function memberSection(
+  packageDoc: ApiPackage,
+  symbol: ApiSymbol,
+  title: string,
+  members: ApiMember[]
+) {
   if (members.length === 0) {
     return [];
   }
@@ -179,7 +260,13 @@ function memberSection(title: string, members: ApiMember[]) {
       members.map((member) => [
         code(`${member.name}${member.optional ? '?' : ''}`),
         code(member.signature),
-        member.summary || `No ${member.kind.toLowerCase()} summary yet.`,
+        formatDescription(
+          member.summaryParts,
+          member.summary,
+          `No ${member.kind.toLowerCase()} summary yet.`,
+          packageDoc.slug,
+          symbol.sourcePackage
+        ),
       ])
     ),
     '',
@@ -204,7 +291,7 @@ function literalValueSection(symbol: ApiSymbol) {
   ];
 }
 
-function returnsSection(symbol: ApiSymbol) {
+function returnsSection(packageDoc: ApiPackage, symbol: ApiSymbol) {
   if (!symbol.returns) {
     return [];
   }
@@ -214,7 +301,33 @@ function returnsSection(symbol: ApiSymbol) {
     '',
     code(symbol.returns),
     '',
-    ...(symbol.returnsSummary ? [symbol.returnsSummary, ''] : []),
+    ...(symbol.returnsSummaryParts.length > 0 || symbol.returnsSummary
+      ? [
+          formatDescription(
+            symbol.returnsSummaryParts,
+            symbol.returnsSummary,
+            '',
+            packageDoc.slug,
+            symbol.sourcePackage
+          ),
+          '',
+        ]
+      : []),
+  ];
+}
+
+function seeSection(packageDoc: ApiPackage, symbol: ApiSymbol) {
+  if (symbol.see.length === 0) {
+    return [];
+  }
+
+  return [
+    '## Related links',
+    '',
+    ...symbol.see.map(
+      (parts) => `- ${formatDocParts(parts, packageDoc.slug, symbol.sourcePackage)}`
+    ),
+    '',
   ];
 }
 
@@ -263,6 +376,41 @@ function formatExample(example: string) {
   const trimmedExample = example.trim();
 
   return trimmedExample.startsWith('```') ? trimmedExample : codeBlock(trimmedExample, 'ts');
+}
+
+function formatDescription(
+  parts: ApiDocTextPart[],
+  text: string | undefined,
+  fallback: string,
+  packageSlug: string,
+  sourcePackage: string
+) {
+  if (parts.length > 0) {
+    return formatDocParts(parts, packageSlug, sourcePackage);
+  }
+
+  return text || fallback;
+}
+
+function formatDocParts(parts: ApiDocTextPart[], packageSlug: string, sourcePackage: string) {
+  return parts
+    .map((part) => {
+      if (part.kind === 'code') {
+        return code(part.text);
+      }
+
+      if (part.kind !== 'link') {
+        return part.text;
+      }
+
+      const href = apiDocPartHref(part, packageSlug, sourcePackage);
+      const label = part.text || part.target || 'link';
+
+      return href ? `[${label}](${href})` : label;
+    })
+    .join('')
+    .replace(/[ \t]+\n/g, '\n')
+    .trim();
 }
 
 function titleCase(value: string) {

--- a/apps/www/src/lib/api-reference.ts
+++ b/apps/www/src/lib/api-reference.ts
@@ -414,11 +414,3 @@ export function apiDocPartHref(
 
   return linkedSymbol ? apiSymbolHref(linkedSymbol.sourcePackage, linkedSymbol.slug) : undefined;
 }
-
-export function apiDocPlainText(parts: ApiDocTextPart[]) {
-  return parts
-    .map((part) => part.text)
-    .join('')
-    .replace(/\s+/g, ' ')
-    .trim();
-}

--- a/apps/www/src/lib/api-reference.ts
+++ b/apps/www/src/lib/api-reference.ts
@@ -6,6 +6,7 @@ export interface ApiParameter {
   optional: boolean;
   defaultValue?: string;
   summary?: string;
+  summaryParts: ApiDocTextPart[];
 }
 
 export interface ApiTypeParameter {
@@ -13,6 +14,7 @@ export interface ApiTypeParameter {
   default?: string;
   constraint?: string;
   summary?: string;
+  summaryParts: ApiDocTextPart[];
 }
 
 export interface ApiMember {
@@ -24,6 +26,13 @@ export interface ApiMember {
   params: ApiParameter[];
   returns?: string;
   summary?: string;
+  summaryParts: ApiDocTextPart[];
+}
+
+export interface ApiDocTextPart {
+  kind: 'text' | 'code' | 'link';
+  text: string;
+  target?: string;
 }
 
 interface ApiLiteralTable {
@@ -43,6 +52,9 @@ export interface ApiSymbol {
   name: string;
   kind: string;
   summary: string;
+  summaryParts: ApiDocTextPart[];
+  remarks: string;
+  remarksParts: ApiDocTextPart[];
   signature: string;
   params: ApiParameter[];
   typeParameters: ApiTypeParameter[];
@@ -54,7 +66,9 @@ export interface ApiSymbol {
   aliasOf?: ApiAlias;
   returns?: string;
   returnsSummary?: string;
+  returnsSummaryParts: ApiDocTextPart[];
   examples: string[];
+  see: ApiDocTextPart[][];
   sourcePackage: string;
   packageName?: string;
   source?: {
@@ -139,6 +153,14 @@ function readStringArray(value: JsonValue | undefined, fieldName: string): strin
   );
 }
 
+function readOptionalArray(value: JsonValue | undefined, _fieldName: string): readonly JsonValue[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  return readArray(value, _fieldName);
+}
+
 function readRecordArray(
   value: JsonValue | undefined,
   fieldName: string
@@ -160,6 +182,7 @@ function parseApiParameter(value: JsonValue, fieldName: string): ApiParameter {
     optional: readBoolean(object.optional, `${fieldName}.optional`),
     defaultValue: readOptionalString(object.defaultValue, `${fieldName}.defaultValue`),
     summary: readOptionalString(object.summary, `${fieldName}.summary`),
+    summaryParts: parseApiDocTextParts(object.summaryParts, `${fieldName}.summaryParts`),
   };
 }
 
@@ -171,6 +194,7 @@ function parseApiTypeParameter(value: JsonValue, fieldName: string): ApiTypePara
     default: readOptionalString(object.default, `${fieldName}.default`),
     constraint: readOptionalString(object.constraint, `${fieldName}.constraint`),
     summary: readOptionalString(object.summary, `${fieldName}.summary`),
+    summaryParts: parseApiDocTextParts(object.summaryParts, `${fieldName}.summaryParts`),
   };
 }
 
@@ -188,7 +212,38 @@ function parseApiMember(value: JsonValue, fieldName: string): ApiMember {
     ),
     returns: readOptionalString(object.returns, `${fieldName}.returns`),
     summary: readOptionalString(object.summary, `${fieldName}.summary`),
+    summaryParts: parseApiDocTextParts(object.summaryParts, `${fieldName}.summaryParts`),
   };
+}
+
+function parseApiDocTextPart(value: JsonValue, fieldName: string): ApiDocTextPart {
+  const object = readObject(value, fieldName);
+  const kind = readString(object.kind, `${fieldName}.kind`);
+
+  if (kind !== 'text' && kind !== 'code' && kind !== 'link') {
+    throw new TypeError(`API reference field "${fieldName}.kind" must be text, code, or link.`);
+  }
+
+  return {
+    kind,
+    text: readString(object.text, `${fieldName}.text`),
+    target: readOptionalString(object.target, `${fieldName}.target`),
+  };
+}
+
+function parseApiDocTextParts(value: JsonValue | undefined, fieldName: string): ApiDocTextPart[] {
+  return readOptionalArray(value, fieldName).map((item, index) =>
+    parseApiDocTextPart(item, `${fieldName}[${index}]`)
+  );
+}
+
+function parseApiDocTextPartBlocks(
+  value: JsonValue | undefined,
+  fieldName: string
+): ApiDocTextPart[][] {
+  return readOptionalArray(value, fieldName).map((item, index) =>
+    parseApiDocTextParts(item, `${fieldName}[${index}]`)
+  );
 }
 
 function parseLiteralTable(value: JsonValue | undefined, fieldName: string) {
@@ -241,6 +296,9 @@ function parseApiSymbol(value: JsonValue, fieldName: string): ApiSymbol {
     name: readString(object.name, `${fieldName}.name`),
     kind: readString(object.kind, `${fieldName}.kind`),
     summary: readString(object.summary, `${fieldName}.summary`),
+    summaryParts: parseApiDocTextParts(object.summaryParts, `${fieldName}.summaryParts`),
+    remarks: readOptionalString(object.remarks, `${fieldName}.remarks`) ?? '',
+    remarksParts: parseApiDocTextParts(object.remarksParts, `${fieldName}.remarksParts`),
     signature: readString(object.signature, `${fieldName}.signature`),
     params: readArray(object.params, `${fieldName}.params`).map((item, index) =>
       parseApiParameter(item, `${fieldName}.params[${index}]`)
@@ -264,7 +322,12 @@ function parseApiSymbol(value: JsonValue, fieldName: string): ApiSymbol {
     aliasOf: parseApiAlias(object.aliasOf, `${fieldName}.aliasOf`),
     returns: readOptionalString(object.returns, `${fieldName}.returns`),
     returnsSummary: readOptionalString(object.returnsSummary, `${fieldName}.returnsSummary`),
+    returnsSummaryParts: parseApiDocTextParts(
+      object.returnsSummaryParts,
+      `${fieldName}.returnsSummaryParts`
+    ),
     examples: readStringArray(object.examples, `${fieldName}.examples`),
+    see: parseApiDocTextPartBlocks(object.see, `${fieldName}.see`),
     sourcePackage: readString(object.sourcePackage, `${fieldName}.sourcePackage`),
     packageName: readOptionalString(object.packageName, `${fieldName}.packageName`),
     source: parseApiSource(object.source, `${fieldName}.source`),
@@ -318,4 +381,44 @@ export function apiPackageHref(packageSlug: string) {
 
 export function apiSymbolHref(packageSlug: string, symbolSlug: string) {
   return `${apiPackageHref(packageSlug)}/${symbolSlug}`;
+}
+
+export function apiDocPartHref(
+  part: ApiDocTextPart,
+  packageSlug: string,
+  sourcePackage = packageSlug
+) {
+  if (part.kind !== 'link' || !part.target) {
+    return undefined;
+  }
+
+  if (/^https?:\/\//.test(part.target)) {
+    return part.target;
+  }
+
+  const normalizedTarget = part.target
+    .replace(/^@[^#]+#/, '')
+    .replace(/^\w+#/, '')
+    .split(/[.(]/)[0];
+  const linkedSymbol =
+    apiReference.symbols.find(
+      (symbol) => symbol.name === normalizedTarget && symbol.sourcePackage === sourcePackage
+    ) ??
+    apiReference.symbols.find(
+      (symbol) => symbol.name === normalizedTarget && symbol.sourcePackage === packageSlug
+    ) ??
+    apiReference.symbols.find(
+      (symbol) => symbol.name === normalizedTarget && symbol.sourcePackage !== 'timeline'
+    ) ??
+    apiReference.symbols.find((symbol) => symbol.name === normalizedTarget);
+
+  return linkedSymbol ? apiSymbolHref(linkedSymbol.sourcePackage, linkedSymbol.slug) : undefined;
+}
+
+export function apiDocPlainText(parts: ApiDocTextPart[]) {
+  return parts
+    .map((part) => part.text)
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/apps/www/src/pages/packages/[slug]/api/[symbol].astro
+++ b/apps/www/src/pages/packages/[slug]/api/[symbol].astro
@@ -5,9 +5,11 @@ import ApiTypeText from '@/components/ApiTypeText.astro';
 import MarkdownCopyButton from '@/components/MarkdownCopyButton.astro';
 import {
   apiPackageHref,
+  apiDocPartHref,
   apiReference,
   apiSymbolHref,
   getApiSymbol,
+  type ApiDocTextPart,
   type ApiPackage,
   type ApiSymbol,
 } from '@/lib/api-reference';
@@ -70,6 +72,42 @@ const returnMembersHeading =
 const examplesHeading = resolvedSymbol.examples.length > 0 ? 'Examples' : 'Aliased examples';
 const hexColorPattern = /^#[0-9a-f]{3,8}$/i;
 const structuredData = createApiSymbolArticleStructuredData(packageDoc, resolvedSymbol);
+const timelineStateBreakdown =
+  resolvedSymbol.name === 'useTimelineState'
+    ? [
+        {
+          area: 'Content',
+          fields: 'tracks, clipGroups, contentRevision',
+          useFor: 'Track lists, clip counts, inspectors, and content-change badges.',
+        },
+        {
+          area: 'Playback and time',
+          fields: 'playheadTime, playing, playbackRate, duration',
+          useFor:
+            'Toolbar state and coarse playback status. Use useTimelinePlayheadTime() for live readouts.',
+        },
+        {
+          area: 'Viewport',
+          fields: 'zoomScale, scrollLeft, scrollTop, viewportWidth, viewportHeight',
+          useFor: 'Viewport-aware chrome. Use viewport hooks for focused scroll and zoom controls.',
+        },
+        {
+          area: 'Selection and ranges',
+          fields: 'inPoint, outPoint',
+          useFor: 'Range labels, loop region state, and edit selection chrome.',
+        },
+        {
+          area: 'Markers',
+          fields: 'markers',
+          useFor: 'Marker lists and annotation panels.',
+        },
+        {
+          area: 'Interaction feedback',
+          fields: 'snapEnabled, snapThresholdPixels, snapFeedback, clipDropFeedback',
+          useFor: 'Snapping toggles, drag/drop hints, and lightweight editor status.',
+        },
+      ]
+    : [];
 
 function parseExample(example: string) {
   const trimmedExample = example.trim();
@@ -83,6 +121,46 @@ function parseExample(example: string) {
     lang: match[1] || 'ts',
     code: match[2].trim(),
   };
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function docPartsHtml(parts: ApiDocTextPart[], packageSlug: string, sourcePackage: string) {
+  return parts
+    .map((part) => {
+      if (part.kind === 'code') {
+        return `<code>${escapeHtml(part.text)}</code>`;
+      }
+
+      if (part.kind !== 'link') {
+        return escapeHtml(part.text);
+      }
+
+      const href = apiDocPartHref(part, packageSlug, sourcePackage);
+      const label = escapeHtml(part.text || part.target || 'link');
+
+      return href
+        ? `<a href="${escapeHtml(href)}" class="text-primary font-semibold hover:underline">${label}</a>`
+        : label;
+    })
+    .join('');
+}
+
+function descriptionHtml(
+  parts: ApiDocTextPart[],
+  text: string | undefined,
+  fallback: string,
+  packageSlug: string,
+  sourcePackage: string
+) {
+  return parts.length > 0 ? docPartsHtml(parts, packageSlug, sourcePackage) : escapeHtml(text ?? fallback);
 }
 ---
 
@@ -128,6 +206,50 @@ function parseExample(example: string) {
       
       <!-- Main Content Column -->
       <article class="lg:col-span-8 space-y-12">
+
+        {
+          resolvedSymbol.remarksParts.length > 0 ? (
+            <section aria-labelledby="remarks-heading" class="space-y-4">
+              <h2 id="remarks-heading" class="text-xl md:text-2xl font-bold text-foreground">Usage notes</h2>
+              <p
+                class="text-sm text-muted-foreground leading-relaxed"
+                set:html={docPartsHtml(
+                  resolvedSymbol.remarksParts,
+                  packageDoc.slug,
+                  resolvedSymbol.sourcePackage
+                )}
+              />
+            </section>
+          ) : null
+        }
+
+        {
+          timelineStateBreakdown.length > 0 ? (
+            <section class="space-y-4" aria-labelledby="state-breakdown-heading">
+              <h2 id="state-breakdown-heading" class="text-xl md:text-2xl font-bold text-foreground">State available</h2>
+              <div class="overflow-x-auto rounded-xl border border-border bg-card">
+                <table class="w-full text-left border-collapse text-sm">
+                  <thead>
+                    <tr class="border-b border-border bg-muted/30">
+                      <th class="p-4 font-semibold text-foreground">Area</th>
+                      <th class="p-4 font-semibold text-foreground">Fields</th>
+                      <th class="p-4 font-semibold text-foreground">Use for</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-border/60">
+                    {timelineStateBreakdown.map((row) => (
+                      <tr class="hover:bg-muted/10 transition-colors">
+                        <td class="p-4 text-foreground font-semibold">{row.area}</td>
+                        <td class="p-4 font-mono text-xs text-muted-foreground">{row.fields}</td>
+                        <td class="p-4 text-muted-foreground leading-relaxed">{row.useFor}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ) : null
+        }
         
         <!-- Signature Section -->
         <section aria-labelledby="sig-heading" class="space-y-4">
@@ -178,7 +300,15 @@ function parseExample(example: string) {
                           ) : 'None'}
                         </td>
                         <td class="p-4 text-muted-foreground leading-relaxed">
-                          {typeParameter.summary || 'No type parameter summary yet.'}
+                          <span
+                            set:html={descriptionHtml(
+                              typeParameter.summaryParts,
+                              typeParameter.summary,
+                              'No type parameter summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
                         </td>
                       </tr>
                     ))}
@@ -239,7 +369,15 @@ function parseExample(example: string) {
                           />
                         </td>
                         <td class="p-4 text-muted-foreground leading-relaxed">
-                          {param.summary || (param.defaultValue ? `Default: ${param.defaultValue}` : 'No parameter summary yet.')}
+                          <span
+                            set:html={descriptionHtml(
+                              param.summaryParts,
+                              param.summary,
+                              param.defaultValue ? `Default: ${param.defaultValue}` : 'No parameter summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
                         </td>
                       </tr>
                     ))}
@@ -278,7 +416,17 @@ function parseExample(example: string) {
                             />
                           </code>
                         </td>
-                        <td class="p-4 text-muted-foreground leading-relaxed">{property.summary || 'No property summary yet.'}</td>
+                        <td class="p-4 text-muted-foreground leading-relaxed">
+                          <span
+                            set:html={descriptionHtml(
+                              property.summaryParts,
+                              property.summary,
+                              'No property summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -314,7 +462,17 @@ function parseExample(example: string) {
                             />
                           </code>
                         </td>
-                        <td class="p-4 text-muted-foreground leading-relaxed">{constructor.summary || 'No constructor summary yet.'}</td>
+                        <td class="p-4 text-muted-foreground leading-relaxed">
+                          <span
+                            set:html={descriptionHtml(
+                              constructor.summaryParts,
+                              constructor.summary,
+                              'No constructor summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -395,7 +553,17 @@ function parseExample(example: string) {
                             />
                           </code>
                         </td>
-                        <td class="p-4 text-muted-foreground leading-relaxed">{method.summary || 'No method summary yet.'}</td>
+                        <td class="p-4 text-muted-foreground leading-relaxed">
+                          <span
+                            set:html={descriptionHtml(
+                              method.summaryParts,
+                              method.summary,
+                              'No method summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -416,7 +584,18 @@ function parseExample(example: string) {
                   sourcePackage={resolvedSymbol.sourcePackage}
                 />
               </div>
-              {resolvedSymbol.returnsSummary ? <p class="text-sm text-muted-foreground leading-relaxed pl-1">{resolvedSymbol.returnsSummary}</p> : null}
+              {resolvedSymbol.returnsSummaryParts.length > 0 || resolvedSymbol.returnsSummary ? (
+                <p
+                  class="text-sm text-muted-foreground leading-relaxed pl-1"
+                  set:html={descriptionHtml(
+                    resolvedSymbol.returnsSummaryParts,
+                    resolvedSymbol.returnsSummary,
+                    '',
+                    packageDoc.slug,
+                    resolvedSymbol.sourcePackage
+                  )}
+                />
+              ) : null}
             </section>
           ) : null
         }
@@ -449,7 +628,17 @@ function parseExample(example: string) {
                             />
                           </code>
                         </td>
-                        <td class="p-4 text-muted-foreground leading-relaxed">{member.summary || 'No return member summary yet.'}</td>
+                        <td class="p-4 text-muted-foreground leading-relaxed">
+                          <span
+                            set:html={descriptionHtml(
+                              member.summaryParts,
+                              member.summary,
+                              'No return member summary yet.',
+                              packageDoc.slug,
+                              resolvedSymbol.sourcePackage
+                            )}
+                          />
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -479,12 +668,32 @@ function parseExample(example: string) {
             </section>
           ) : null
         }
+
+        {
+          resolvedSymbol.see.length > 0 ? (
+            <section class="space-y-4" aria-labelledby="related-heading">
+              <h2 id="related-heading" class="text-xl md:text-2xl font-bold text-foreground">Related links</h2>
+              <ul class="list-disc pl-5 space-y-2 text-sm text-muted-foreground">
+                {resolvedSymbol.see.map((parts) => (
+                  <li
+                    set:html={docPartsHtml(
+                      parts,
+                      packageDoc.slug,
+                      resolvedSymbol.sourcePackage
+                    )}
+                  />
+                ))}
+              </ul>
+            </section>
+          ) : null
+        }
       </article>
 
       <!-- Sidebar Column -->
       <aside class="lg:col-span-4 space-y-6 lg:sticky lg:top-24">
         <MarkdownCopyButton
           href={`/packages/${packageDoc.slug}/api/${symbol.slug}.md`}
+          tooltip="Copies this API page as Markdown with examples, related links, and declaration details for LLM-assisted lookup."
           class="api-symbol-markdown-copy"
         />
         

--- a/packages/core/src/emitter.ts
+++ b/packages/core/src/emitter.ts
@@ -1,6 +1,9 @@
 /**
  * A general, generic type-safe event emitter class.
  * Extended by components needing typed event publishing and subscription contracts.
+ *
+ * @template M - Event map whose keys are event names and values are payload
+ * types.
  */
 export class TypedEventEmitter<M extends object> {
   private listeners: Partial<{ [K in keyof M]: Set<(payload: M[K]) => void> }> =

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -233,10 +233,15 @@ export interface TimelineZoomConstraints {
 
 /** Geometry defaults shared by canvas-aligned interaction layers. */
 export const defaultTimelineInteractionGeometry = {
+  /** Height of the ruler/header band above track rows in CSS pixels. */
   rulerHeight: 32,
+  /** Default expanded track row height in CSS pixels. */
   trackHeight: 48,
+  /** Default collapsed track row height in CSS pixels. */
   collapsedTrackHeight: 24,
+  /** Mouse and pen edge hit-test threshold in CSS pixels. */
   edgeThreshold: 10,
+  /** Wider touch edge hit-test threshold in CSS pixels. */
   touchEdgeThreshold: 24,
 } as const;
 
@@ -2895,6 +2900,13 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     this.emit('state:settled');
   }
 
+  /**
+   * Marks timeline content as changed and notifies subscribers.
+   *
+   * Use this after external metadata that affects rendering changes without a
+   * structural timeline edit, such as waveform availability, thumbnails, or
+   * cached analysis keyed by clip id.
+   */
   invalidateContent() {
     this.state.contentRevision = this.contentRevision + 1;
     this.emit('content:change', this.state.contentRevision);

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -65,6 +65,7 @@ export interface ClipMoveEvent extends TimelineClipMoveResult {
  * Live clip resizing event payload.
  */
 export interface ClipResizeEvent {
+  /** Clip after the resize preview or commit updated one boundary. */
   clip: Clip;
 }
 
@@ -72,6 +73,7 @@ export interface ClipResizeEvent {
  * Live clip slip event payload.
  */
 export interface ClipSlipEvent {
+  /** Clip after its source start moved while timeline bounds stayed fixed. */
   clip: Clip;
 }
 
@@ -79,28 +81,39 @@ export interface ClipSlipEvent {
  * Clip selection change event payload.
  */
 export interface ClipSelectEvent {
+  /** Primary selected clip id, or null after clearing selection. */
   clipId: string | null;
+  /** Primary selected clip, or null after clearing selection. */
   clip: Clip | null;
+  /** All selected clip ids in state order. */
   clipIds: string[];
+  /** All selected clips in state order for inspector and action toolbar UI. */
   clips: Clip[];
 }
 
 /** Keyframe add/update event payload. */
 export interface ClipKeyframeChangeEvent {
+  /** Clip that owns the changed keyframe. */
   clipId: string;
+  /** Added or updated keyframe snapshot. */
   keyframe: TimelineKeyframe;
 }
 
 /** Keyframe removal event payload. */
 export interface ClipKeyframeRemoveEvent {
+  /** Clip that owned the removed keyframe. */
   clipId: string;
+  /** Removed keyframe snapshot before it left the clip. */
   keyframe: TimelineKeyframe;
 }
 
 /** Keyframe selection change event payload. */
 export interface ClipKeyframeSelectEvent {
+  /** Clip containing the selected keyframe, or null after clearing selection. */
   clipId: string | null;
+  /** Selected keyframe id, or null after clearing selection. */
   keyframeId: string | null;
+  /** Selected keyframe snapshot, or null after clearing selection. */
   keyframe: TimelineKeyframe | null;
 }
 
@@ -108,7 +121,9 @@ export interface ClipKeyframeSelectEvent {
  * Event payload emitted when the playhead enters, updates within, or leaves a clip.
  */
 export interface ClipPlayheadEvent {
+  /** Clip crossed by the current playhead event. */
   clipId: string;
+  /** Timeline time at which the crossing or in-clip update was evaluated. */
   time: RationalTime;
 }
 
@@ -116,7 +131,9 @@ export interface ClipPlayheadEvent {
  * Undo/redo history state change event payload.
  */
 export interface HistoryChangeEvent {
+  /** Current history cursor index after undo, redo, or snapshot creation. */
   index: number;
+  /** Number of undoable history entries available in the stack. */
   length: number;
 }
 
@@ -124,6 +141,7 @@ export interface HistoryChangeEvent {
  * Selection in/out point boundary change event payload.
  */
 export interface InOutChangeEvent {
+  /** Timeline state snapshot containing the new in/out point values. */
   state: TimelineState;
 }
 
@@ -131,6 +149,7 @@ export interface InOutChangeEvent {
  * Marker change event payload (add, remove, update).
  */
 export interface MarkerChangeEvent {
+  /** Marker snapshot added, removed, or updated by the command. */
   marker: Marker;
 }
 
@@ -138,6 +157,7 @@ export interface MarkerChangeEvent {
  * Track change event payload (add, remove).
  */
 export interface TrackChangeEvent {
+  /** Track snapshot added to or removed from the timeline. */
   track: Track;
 }
 
@@ -145,7 +165,9 @@ export interface TrackChangeEvent {
  * Track mute change event payload.
  */
 export interface TrackMuteEvent {
+  /** Track whose mute state changed. */
   trackId: string;
+  /** New mute state. */
   muted: boolean;
 }
 
@@ -153,7 +175,9 @@ export interface TrackMuteEvent {
  * Track visibility change event payload.
  */
 export interface TrackVisibilityEvent {
+  /** Track whose visibility state changed. */
   trackId: string;
+  /** New visibility state. */
   visible: boolean;
 }
 
@@ -161,7 +185,9 @@ export interface TrackVisibilityEvent {
  * Track lock change event payload.
  */
 export interface TrackLockEvent {
+  /** Track whose lock state changed. */
   trackId: string;
+  /** New lock state. */
   locked: boolean;
 }
 
@@ -169,6 +195,7 @@ export interface TrackLockEvent {
  * Track selection change event payload.
  */
 export interface TrackSelectEvent {
+  /** Selected track id, or null after clearing track selection. */
   trackId: string | null;
 }
 
@@ -176,7 +203,9 @@ export interface TrackSelectEvent {
  * Track resize event payload.
  */
 export interface TrackResizeEvent {
+  /** Track whose row height changed. */
   trackId: string;
+  /** New row height in CSS pixels. */
   height: number;
 }
 
@@ -184,9 +213,11 @@ export interface TrackResizeEvent {
  * Central event mapping definition for all engine events.
  */
 export interface EngineEventMap {
-  // Structural lifecycle
+  /** Emits after committed state is stable and undo/redo history may have advanced. */
   'state:settled': void;
+  /** Emits while transient preview state is available but not committed. */
   'state:preview': void;
+  /** Requests visual renderers to redraw timeline content. */
   render: void;
 
   /** Emits active live edit impacts during interactions, or null when impacts clear. */
@@ -198,54 +229,81 @@ export interface EngineEventMap {
   /** Emits transient cross-track drop feedback during body drag interactions. */
   'clip:drop-feedback': TimelineClipDropFeedback;
 
-  // Clip lifecycle (committed)
+  /** Emits after a committed command creates a clip. */
   'clip:created': ClipCreatedEvent;
+  /** Emits after a committed command removes a clip. */
   'clip:removed': ClipRemovedEvent;
+  /** Emits after a committed split replaces one clip with left and right clips. */
   'clip:split': ClipSplitEvent;
 
-  // Clip interaction (live, per frame)
+  /** Emits during and after clip body movement. */
   'clip:move': ClipMoveEvent;
+  /** Emits during and after clip trim resize changes. */
   'clip:resize': ClipResizeEvent;
+  /** Emits during and after source slip changes. */
   'clip:slip': ClipSlipEvent;
+  /** Emits when the selected clip set changes. */
   'clip:select': ClipSelectEvent;
+  /** Emits when a clip keyframe is created. */
   'keyframe:add': ClipKeyframeChangeEvent;
+  /** Emits when a clip keyframe changes time, value, interpolation, or easing. */
   'keyframe:update': ClipKeyframeChangeEvent;
+  /** Emits when a clip keyframe is removed. */
   'keyframe:remove': ClipKeyframeRemoveEvent;
+  /** Emits when keyframe selection changes. */
   'keyframe:select': ClipKeyframeSelectEvent;
 
-  // Clip playhead crossings
+  /** Emits when the playhead first enters an enabled clip interval. */
   'clip:enter': ClipPlayheadEvent;
+  /** Emits while the playhead remains inside an enabled clip interval. */
   'clip:update': ClipPlayheadEvent;
+  /** Emits when the playhead leaves an enabled clip interval. */
   'clip:leave': ClipPlayheadEvent;
 
-  // Playback
+  /** Emits when playback starts or stops. */
   'playback:state': boolean;
+  /** Emits when playback rate changes. */
   'playback:rate': number;
+  /** Emits when scrubbing or playback moves the playhead. */
   'playhead:scrub': RationalTime;
 
-  // State
+  /** Emits when in/out points change. */
   'state:inOut': InOutChangeEvent;
+  /** Emits after content edits increment the render/content revision number. */
   'content:change': number;
+  /** Emits after undo, redo, or snapshot creation changes history position. */
   'history:change': HistoryChangeEvent;
+  /** Emits when clipboard contents change after copy, cut, paste, or clear. */
   'clipboard:change': void;
+  /** Emits when the measured viewport size changes. */
   'viewport:resize': { viewportWidth: number | undefined; viewportHeight: number | undefined };
+  /** Emits when snapping feedback changes during pointer interactions. */
   'snap:change': TimelineSnapFeedback;
 
-  // Markers
+  /** Emits when a marker is added. */
   'marker:add': MarkerChangeEvent;
+  /** Emits when a marker is removed. */
   'marker:remove': MarkerChangeEvent;
+  /** Emits when marker time, label, or metadata changes. */
   'marker:update': MarkerChangeEvent;
 
-  // Tracks
+  /** Emits when a track is added. */
   'track:add': TrackChangeEvent;
+  /** Emits when a track is removed. */
   'track:remove': TrackChangeEvent;
+  /** Emits when a track mute flag changes. */
   'track:mute': TrackMuteEvent;
+  /** Emits when a track visibility flag changes. */
   'track:visibility': TrackVisibilityEvent;
+  /** Emits when a track lock flag changes. */
   'track:lock': TrackLockEvent;
+  /** Emits when selected track id changes. */
   'track:select': TrackSelectEvent;
+  /** Emits when an explicit track row height changes. */
   'track:resize': TrackResizeEvent;
 
-  // Navigation
+  /** Emits when horizontal zoom scale changes. */
   'zoom:change': number;
+  /** Emits when scroll offsets change. */
   'scroll:change': { scrollLeft: number; scrollTop: number };
 }

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,9 @@ import type {
 
 /**
  * A value that may be available immediately or after asynchronous media lookup.
+ *
+ * @template T - Resolved value type returned either directly or through a
+ * promise.
  */
 export type MaybePromise<T> = T | Promise<T>;
 
@@ -49,6 +52,18 @@ export interface ClipSourceRange {
 
 /**
  * Filters for selecting active clips at a timeline time.
+ *
+ * @remarks
+ *
+ * Use `ActiveClipQuery` when an integration needs one matching clip, such as a
+ * focused preview thumbnail, inspector, subtitle renderer, or source-specific
+ * media control. For named multi-layer playback surfaces, prefer
+ * {@link ActiveLayerOptions} and {@link TimelineEngine.getActiveLayers}.
+ *
+ * @template TrackKind - App-defined track kind values used by your timeline,
+ * such as `"visual"`, `"audio"`, or `"subtitle"`.
+ *
+ * @see {@link https://canvastimeline.com/docs/events-and-lifecycle | Events and lifecycle}
  */
 export interface ActiveClipQuery<TrackKind = string> {
   /** Timeline time to inspect. Defaults to the current playhead. */
@@ -68,6 +83,22 @@ export interface ActiveClipQuery<TrackKind = string> {
  * such as visual previews, audio playback, subtitles, effects, or a particular source
  * asset. Selectors are matched against the active clips returned for a single
  * timeline time.
+ *
+ * @template TrackKind - App-defined track kind values accepted by this layer,
+ * such as `"visual"`, `"audio"`, or `"subtitle"`.
+ *
+ * @example
+ * ```ts
+ * import type { ActiveLayerSelector } from '@techsquidtv/canvas-timeline-core';
+ *
+ * const visuals: ActiveLayerSelector<'visual' | 'audio'> = {
+ *   trackKind: 'visual',
+ *   sourceId: 'camera-a',
+ * };
+ * ```
+ *
+ * @see {@link ActiveClipQuery}
+ * @see {@link https://canvastimeline.com/demos/html-media-sync | HTML media sync demo}
  */
 export type ActiveLayerSelector<TrackKind = string> = Omit<ActiveClipQuery<TrackKind>, 'time'>;
 
@@ -77,6 +108,29 @@ export type ActiveLayerSelector<TrackKind = string> = Omit<ActiveClipQuery<Track
  * Use this when integrations need named layers such as `visuals`, `audio`,
  * `subtitles`, or `effects` instead of one flat active-clip list. The same
  * active clip can match more than one layer.
+ *
+ * @template LayerName - String literal names for the layers your integration
+ * exposes, for example `"visuals" | "audio"`.
+ * @template TrackKind - App-defined track kind values matched by each layer
+ * selector.
+ *
+ * @example
+ * ```ts
+ * import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+ * import type { ActiveLayerOptions } from '@techsquidtv/canvas-timeline-core';
+ *
+ * const options = {
+ *   time: fromSeconds(4),
+ *   layers: {
+ *     visuals: { trackKind: 'visual', sourceId: 'source-1' },
+ *     audio: { trackKind: 'audio', sourceId: 'source-1' },
+ *   },
+ * } satisfies ActiveLayerOptions<'visuals' | 'audio', 'visual' | 'audio'>;
+ * ```
+ *
+ * @see {@link ActiveLayerSelector}
+ * @see {@link ActiveLayerResult}
+ * @see {@link TimelineEngine.getActiveLayers}
  */
 export interface ActiveLayerOptions<LayerName extends string = string, TrackKind = string> {
   /** Timeline time to inspect. Defaults to the current playhead. */
@@ -92,6 +146,27 @@ export interface ActiveLayerOptions<LayerName extends string = string, TrackKind
  * convenience `primary` entries for apps that only need the first match in each
  * layer. Each `ActiveClip` includes mapped source time and source range data for
  * preview and playback synchronization.
+ *
+ * @template LayerName - String literal names from the `layers` option, such as
+ * `"visuals" | "audio"`.
+ * @template TrackKind - App-defined track kind values carried by returned
+ * tracks.
+ *
+ * @example
+ * ```ts
+ * const activeLayers = engine.getActiveLayers({
+ *   layers: {
+ *     visuals: { trackKind: 'visual' },
+ *     audio: { trackKind: 'audio' },
+ *   },
+ * });
+ *
+ * const visualClip = activeLayers.primary.visuals?.clip;
+ * const audioClips = activeLayers.layers.audio;
+ * ```
+ *
+ * @see {@link ActiveClip}
+ * @see {@link https://canvastimeline.com/packages/react/api/use-active-layers | useActiveLayers}
  */
 export interface ActiveLayerResult<LayerName extends string = string, TrackKind = string> {
   /** Timeline time used for the lookup. */
@@ -152,13 +227,21 @@ export interface ClipHitTestInput extends TimelineInteractionGeometry {
 
 /** Viewport-space rectangle for a clip and its containing track. */
 export interface ClipViewportRect {
+  /** Clip represented by the rectangle. */
   clipId: string;
+  /** Track containing the clip. */
   trackId: string;
+  /** Zero-based track index in timeline order. */
   trackIndex: number;
+  /** Zero-based clip index inside the containing track. */
   clipIndex: number;
+  /** Left edge in viewport CSS pixels after horizontal scroll is applied. */
   x: number;
+  /** Top edge in viewport CSS pixels, including the ruler offset. */
   y: number;
+  /** Clip width in viewport CSS pixels. */
   width: number;
+  /** Clip height in viewport CSS pixels. */
   height: number;
 }
 
@@ -192,7 +275,11 @@ export interface TrackHitTestInput extends TimelineTrackGeometryOptions {
   y: number;
 }
 
-/** Hit-test result for a timeline track row. */
+/**
+ * Hit-test result for a timeline track row.
+ *
+ * @template TrackKind - App-defined track kind carried by the matched track.
+ */
 export interface TimelineTrackHitTestResult<TrackKind = string> {
   /** Track under the queried point. */
   track: Track<TrackKind>;
@@ -204,13 +291,21 @@ export interface TimelineTrackHitTestResult<TrackKind = string> {
 
 /** Hit-test result for a clip pointer target. */
 export interface ClipHitTestResult {
+  /** Track containing the matched clip. */
   track: Track;
+  /** Clip matched by the pointer query. */
   clip: Clip;
+  /** Zero-based track index in timeline order. */
   trackIndex: number;
+  /** Zero-based clip index inside the containing track. */
   clipIndex: number;
+  /** Clip body or edge region matched by the pointer query. */
   region: ClipHitRegion;
+  /** Viewport-space bounds used for the match. */
   rect: ClipViewportRect;
+  /** Whether current policy and lock state allow moving the clip body. */
   canMove: boolean;
+  /** Whether current policy and lock state allow trimming the clip edges. */
   canTrim: boolean;
 }
 
@@ -299,12 +394,19 @@ export interface TimelineKeyframe {
 
 /** Viewport-space rectangle for one keyframe affordance. */
 export interface TimelineKeyframeViewportRect {
+  /** Clip that owns the keyframe. */
   clipId: string;
+  /** Track containing the owning clip. */
   trackId: string;
+  /** Keyframe represented by this rectangle. */
   keyframeId: string;
+  /** Left edge in viewport CSS pixels after horizontal scroll is applied. */
   x: number;
+  /** Top edge in viewport CSS pixels within the clip row. */
   y: number;
+  /** Keyframe affordance width in viewport CSS pixels. */
   width: number;
+  /** Keyframe affordance height in viewport CSS pixels. */
   height: number;
 }
 
@@ -318,15 +420,25 @@ export interface TimelineKeyframePoint {
 
 /** Viewport-space rectangle for one keyframe tangent affordance. */
 export interface TimelineKeyframeTangentHandleViewportRect {
+  /** Clip that owns the edited curve segment. */
   clipId: string;
+  /** Track containing the owning clip. */
   trackId: string;
+  /** Stable segment id for the adjacent keyframe pair. */
   segmentId: string;
+  /** Keyframe whose Bezier easing is edited by this handle. */
   keyframeId: string;
+  /** Endpoint keyframe where the handle line is anchored. */
   anchorKeyframeId: string;
+  /** Keyframe side edited by this tangent handle. */
   side: TimelineKeyframeSide;
+  /** Left edge in viewport CSS pixels after horizontal scroll is applied. */
   x: number;
+  /** Top edge in viewport CSS pixels within the clip row. */
   y: number;
+  /** Handle affordance width in viewport CSS pixels. */
   width: number;
+  /** Handle affordance height in viewport CSS pixels. */
   height: number;
 }
 
@@ -372,7 +484,11 @@ export interface TimelineKeyframeHitTestInput extends TimelineKeyframeGeometryOp
   pointerType?: string;
 }
 
-/** Keyframe entry with viewport geometry and edit/display state. */
+/**
+ * Keyframe entry with viewport geometry and edit/display state.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export interface TimelineKeyframeRect<TrackKind = string> extends TimelineClipEntry<TrackKind> {
   /** Raw keyframe represented by this entry. */
   keyframe: TimelineKeyframe;
@@ -384,7 +500,11 @@ export interface TimelineKeyframeRect<TrackKind = string> extends TimelineClipEn
   canEdit: boolean;
 }
 
-/** Bezier tangent handle entry with viewport geometry and edit state. */
+/**
+ * Bezier tangent handle entry with viewport geometry and edit state.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export interface TimelineKeyframeTangentHandle<
   TrackKind = string,
 > extends TimelineClipEntry<TrackKind> {
@@ -414,7 +534,11 @@ export interface TimelineKeyframeTangentHandle<
   canEdit: boolean;
 }
 
-/** Keyframe segment entry with viewport geometry and optional Bezier tangents. */
+/**
+ * Keyframe segment entry with viewport geometry and optional Bezier tangents.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export interface TimelineKeyframeSegment<TrackKind = string> extends TimelineClipEntry<TrackKind> {
   /** Stable segment id for the adjacent keyframe pair. */
   segmentId: string;
@@ -506,13 +630,25 @@ export interface TimelineKeyframeRenderGeometry {
   clips: TimelineKeyframeRenderClip[];
 }
 
-/** Viewport-intersecting keyframe entry. */
+/**
+ * Viewport-intersecting keyframe entry.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export type VisibleTimelineKeyframe<TrackKind = string> = TimelineKeyframeRect<TrackKind>;
 
-/** Hit-test result for a timeline keyframe pointer target. */
+/**
+ * Hit-test result for a timeline keyframe pointer target.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export type TimelineKeyframeHitTestResult<TrackKind = string> = TimelineKeyframeRect<TrackKind>;
 
-/** Viewport-intersecting keyframe segment. */
+/**
+ * Viewport-intersecting keyframe segment.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export type VisibleTimelineKeyframeSegment<TrackKind = string> = TimelineKeyframeSegment<TrackKind>;
 
 /** Viewport-space pointer query for keyframe tangent handle hit testing. */
@@ -525,7 +661,11 @@ export interface TimelineKeyframeTangentHitTestInput extends TimelineKeyframeSeg
   pointerType?: string;
 }
 
-/** Hit-test result for a keyframe tangent handle pointer target. */
+/**
+ * Hit-test result for a keyframe tangent handle pointer target.
+ *
+ * @template TrackKind - App-defined track kind carried by the containing track.
+ */
 export type TimelineKeyframeTangentHandleHitTestResult<TrackKind = string> =
   TimelineKeyframeTangentHandle<TrackKind>;
 
@@ -970,51 +1110,73 @@ export interface TimelineInsertClipGroupOptions {
 
 /** Command that moves an existing clip. */
 export interface TimelineMoveEditCommand extends TimelineClipMoveOptions {
+  /** Command discriminator for clip body movement. */
   type: 'move';
 }
 
 /** Command that trims one existing clip boundary. */
 export interface TimelineTrimEditCommand {
+  /** Command discriminator for single-edge trimming. */
   type: 'trim';
+  /** Clip whose boundary should move. */
   clipId: string;
+  /** Boundary to trim. */
   edge: 'start' | 'end';
+  /** Desired new timeline time for the selected boundary. */
   newTime: RationalTime;
+  /** Whether to resolve magnetic snapping while trimming. Defaults to true. */
   snap?: boolean;
 }
 
 /** Command that trims one boundary and ripples later clips on the same track. */
 export interface TimelineRippleTrimEditCommand extends Omit<TimelineTrimEditCommand, 'type'> {
+  /** Command discriminator for ripple trimming. */
   type: 'ripple-trim';
 }
 
 /** Command that rolls the shared boundary between two adjacent clips. */
 export interface TimelineRollTrimEditCommand {
+  /** Command discriminator for rolling an adjacent edit point. */
   type: 'roll-trim';
+  /** Clip ending at the shared boundary. */
   leftClipId: string;
+  /** Clip starting at the shared boundary. */
   rightClipId: string;
+  /** Desired shared boundary time after the roll. */
   boundaryTime: RationalTime;
+  /** Whether to resolve magnetic snapping while rolling. Defaults to true. */
   snap?: boolean;
 }
 
 /** Command that shifts an existing clip's source start without moving timeline bounds. */
 export interface TimelineSlipEditCommand {
+  /** Command discriminator for source slipping. */
   type: 'slip';
+  /** Clip whose source start should shift. */
   clipId: string;
+  /** Relative source-time delta applied while timeline bounds stay fixed. */
   deltaTime: RationalTime;
 }
 
 /** Command that moves an existing clip by a relative timeline offset. */
 export interface TimelineSlideEditCommand {
+  /** Command discriminator for timeline sliding. */
   type: 'slide';
+  /** Clip whose timeline position should shift. */
   clipId: string;
+  /** Relative timeline delta applied to the clip position. */
   deltaTime: RationalTime;
+  /** Whether to resolve magnetic snapping while sliding. Defaults to true. */
   snap?: boolean;
 }
 
 /** Command that splits selected clips at one timeline time. */
 export interface TimelineSplitEditCommand {
+  /** Command discriminator for splitting clips. */
   type: 'split';
+  /** Timeline time at which each selected clip should split. */
   time: RationalTime;
+  /** Clips to split when they contain `time`. */
   clipIds: readonly string[];
 }
 
@@ -1026,11 +1188,13 @@ export interface TimelineDeleteClipsEditCommand {
 
 /** Command that inserts a new clip and pushes later clips forward. */
 export interface TimelineInsertEditCommand extends TimelinePlaceClipCommand {
+  /** Command discriminator for ripple insert placement. */
   type: 'insert';
 }
 
 /** Command that inserts grouped clips and pushes later clips forward per target track. */
 export interface TimelineInsertClipGroupEditCommand extends TimelineInsertClipGroupOptions {
+  /** Command discriminator for grouped ripple insert placement. */
   type: 'insert-clip-group';
   /** Whether to snap the first placement and apply that shared delta to the group. Defaults to true. */
   snap?: boolean;
@@ -1038,11 +1202,13 @@ export interface TimelineInsertClipGroupEditCommand extends TimelineInsertClipGr
 
 /** Command that places a new clip and removes or trims overlaps on the target track. */
 export interface TimelineOverwriteEditCommand extends TimelinePlaceClipCommand {
+  /** Command discriminator for overwrite placement. */
   type: 'overwrite';
 }
 
 /** Command that places grouped clips and overwrites overlaps per target track. */
 export interface TimelineOverwriteClipGroupEditCommand extends TimelineInsertClipGroupOptions {
+  /** Command discriminator for grouped overwrite placement. */
   type: 'overwrite-clip-group';
   /** Whether to snap the first placement and apply that shared delta to the group. Defaults to true. */
   snap?: boolean;
@@ -1050,18 +1216,27 @@ export interface TimelineOverwriteClipGroupEditCommand extends TimelineInsertCli
 
 /** Command that removes a timeline range and ripples later clips closed by default. */
 export interface TimelineDeleteRangeEditCommand {
+  /** Command discriminator for range deletion. */
   type: 'delete-range';
+  /** Inclusive start of the timeline range to remove. */
   startTime: RationalTime;
+  /** Exclusive end of the timeline range to remove. */
   endTime: RationalTime;
+  /** Optional track ids to affect. Omit to affect every editable track. */
   trackIds?: readonly string[];
+  /** Whether later clips close the removed gap. Defaults to true. */
   ripple?: boolean;
 }
 
 /** Command that removes a timeline range while leaving the gap in place. */
 export interface TimelineLiftRangeEditCommand {
+  /** Command discriminator for range lifting. */
   type: 'lift-range';
+  /** Inclusive start of the timeline range to lift. */
   startTime: RationalTime;
+  /** Exclusive end of the timeline range to lift. */
   endTime: RationalTime;
+  /** Optional track ids to affect. Omit to affect every editable track. */
   trackIds?: readonly string[];
 }
 
@@ -1082,7 +1257,11 @@ export type TimelineEditCommand =
   | TimelineDeleteRangeEditCommand
   | TimelineLiftRangeEditCommand;
 
-/** Context passed to product-defined edit policy callbacks. */
+/**
+ * Context passed to product-defined edit policy callbacks.
+ *
+ * @template Command - Specific edit command being validated by a policy hook.
+ */
 export interface TimelineEditPolicyContext<
   Command extends TimelineEditCommand = TimelineEditCommand,
 > {
@@ -1366,6 +1545,20 @@ export interface TimelineRulerTickOptions {
 
 /**
  * Clip that is active at a timeline time, including its mapped source time.
+ *
+ * @remarks
+ *
+ * `ActiveClip` is the bridge between timeline structure and source media. It
+ * keeps the original {@link Clip}, containing {@link Track}, inspected timeline
+ * time, source-media timestamp, source interval, and a `syncKey` that changes
+ * when timing-affecting clip data changes. Media adapters use this shape to
+ * seek a source file without duplicating timeline math.
+ *
+ * @template TrackKind - App-defined track kind value carried by the containing
+ * track.
+ *
+ * @see {@link ActiveLayerResult}
+ * @see {@link ClipSourceRange}
  */
 export interface ActiveClip<TrackKind = string> {
   /** Track containing the active clip. */

--- a/packages/html-media-adapter/src/index.ts
+++ b/packages/html-media-adapter/src/index.ts
@@ -15,6 +15,17 @@ export type HTMLMediaAdapterSource = string | Blob | File;
 
 /**
  * Timeline media sync adapter backed by one HTMLMediaElement.
+ *
+ * @remarks
+ *
+ * This adapter is intentionally small: it maps the first active clip from the
+ * configured layers to a native `<video>` or `<audio>` element, seeks the
+ * element to the clip's source time, and lets the element clock drive timeline
+ * playback. Use it for simple browser-native previews before reaching for a
+ * frame-accurate decoded adapter.
+ *
+ * @see {@link createHTMLMediaAdapter}
+ * @see {@link useHTMLTimelineMedia}
  */
 export interface HTMLMediaAdapter extends TimelineMediaSyncAdapter {
   /** Release object URLs and pause the media element. */
@@ -23,6 +34,12 @@ export interface HTMLMediaAdapter extends TimelineMediaSyncAdapter {
 
 /**
  * Options for creating an imperative HTML media element adapter.
+ *
+ * @remarks
+ *
+ * Sources are keyed by timeline clip `sourceId`. Values can be URLs, `Blob`s,
+ * or `File`s, which makes this useful for both persisted project media and
+ * user-selected local files.
  */
 export interface CreateHTMLMediaAdapterOptions {
   /** Native video or audio element to synchronize with the timeline. */
@@ -33,6 +50,9 @@ export interface CreateHTMLMediaAdapterOptions {
 
 /**
  * Options for creating an HTML media adapter from a React ref.
+ *
+ * @template TMediaElement - Native element type held by the ref, such as
+ * `HTMLVideoElement` or `HTMLAudioElement`.
  */
 export interface UseHTMLMediaAdapterOptions<
   TMediaElement extends HTMLMediaElement = HTMLMediaElement,
@@ -55,6 +75,19 @@ export interface UseHTMLMediaAdapterResult {
 
 /**
  * Options for wiring one native media element directly to timeline playback.
+ *
+ * @remarks
+ *
+ * This is the high-level React shape used by the HTML media sync demo. Provide
+ * a media element ref, source map, and named layers. The hook creates an
+ * {@link HTMLMediaAdapter}, passes it to {@link useTimelineMediaSync}, and
+ * exposes transport commands suitable for toolbar buttons.
+ *
+ * @template LayerName - Named media layer keys inferred from `layers`, such as
+ * `"visuals"` for a video-only preview.
+ * @template TMediaElement - Native element type held by `ref`.
+ *
+ * @see {@link https://canvastimeline.com/demos/html-media-sync | HTML media sync demo}
  */
 export interface UseHTMLTimelineMediaOptions<
   LayerName extends string = string,
@@ -66,6 +99,9 @@ export interface UseHTMLTimelineMediaOptions<
 
 /**
  * Timeline transport state plus the underlying native media adapter.
+ *
+ * @template LayerName - Named media layer keys from
+ * {@link UseHTMLTimelineMediaOptions.layers}.
  */
 export interface UseHTMLTimelineMediaResult<
   LayerName extends string = string,
@@ -85,7 +121,40 @@ const noopAdapter: HTMLMediaAdapter = {
 /**
  * Create an adapter that maps active timeline clips to one HTMLMediaElement.
  *
+ * @remarks
+ *
+ * Use the imperative adapter when your app owns the media element lifecycle but
+ * wants Canvas Timeline to do clip-to-source time mapping. React apps normally
+ * use {@link useHTMLMediaAdapter} or {@link useHTMLTimelineMedia} instead so
+ * disposal follows component lifetime.
+ *
  * @param options - Media element and source map used for timeline synchronization.
+ * @returns Adapter callbacks compatible with {@link useTimelineMediaSync}.
+ *
+ * @example
+ * ```ts
+ * import { createHTMLMediaAdapter } from '@techsquidtv/canvas-timeline-html-media-adapter';
+ *
+ * const video = document.querySelector('video');
+ *
+ * if (video) {
+ *   const adapter = createHTMLMediaAdapter({
+ *     element: video,
+ *     sources: {
+ *       'source-1': '/media/interview.mp4',
+ *     },
+ *   });
+ *
+ *   await adapter.seek?.(engine.getTime(), engine.getActiveLayers({
+ *     layers: {
+ *       visuals: { trackKind: 'visual', sourceId: 'source-1' },
+ *     },
+ *   }));
+ * }
+ * ```
+ *
+ * @see {@link HTMLMediaAdapter}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): HTMLMediaAdapter {
   const { element, sources } = options;
@@ -242,7 +311,16 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
 /**
  * Create and dispose an HTML media element timeline adapter from a React ref.
  *
+ * @remarks
+ *
+ * Use this lower-level hook when you want direct access to the
+ * {@link HTMLMediaAdapter} but will wire playback through
+ * {@link useTimelineMediaSync} yourself. For the common case where a single
+ * element should drive timeline playback, use {@link useHTMLTimelineMedia}.
+ *
  * @param options - React media element ref and source map for the adapter.
+ * @template TMediaElement - Native element type held by `options.ref`.
+ * @returns Adapter readiness and callbacks for the mounted media element.
  */
 export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTMLMediaElement>(
   options: UseHTMLMediaAdapterOptions<TMediaElement>
@@ -276,7 +354,51 @@ export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTM
 /**
  * Create a native media adapter and bind it to timeline-synchronized playback.
  *
+ * @remarks
+ *
+ * This hook is the simplest route for browser-native video or audio previews:
+ * create a stable `sources` map, name the active layers you want to sync, and
+ * render standard transport buttons from the returned commands. It is best for
+ * straightforward media previews; use the Mediabunny adapter when you need
+ * decoded canvas frames, audio scheduling, or richer source inspection.
+ *
  * @param options - Media element ref, source map, active layers, and optional error callback.
+ * @template LayerName - Named media layer keys inferred from `options.layers`.
+ * @template TMediaElement - Native element type held by `options.ref`.
+ * @returns Timeline transport state, readiness, active layers, and the underlying adapter.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo, useRef } from 'react';
+ * import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-adapter';
+ *
+ * const previewLayers = {
+ *   visuals: { trackKind: 'visual', sourceId: 'sample-video' },
+ * } as const;
+ *
+ * export function NativeVideoPreview() {
+ *   const ref = useRef<HTMLVideoElement>(null);
+ *   const sources = useMemo(() => ({ 'sample-video': '/media/sample.mp4' }), []);
+ *   const media = useHTMLTimelineMedia({
+ *     ref,
+ *     sources,
+ *     layers: previewLayers,
+ *     onError: console.error,
+ *   });
+ *
+ *   return (
+ *     <>
+ *       <video ref={ref} muted playsInline />
+ *       <button type="button" disabled={!media.ready} onClick={() => void media.play()}>
+ *         {media.playing ? 'Playing' : 'Play'}
+ *       </button>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineMediaSync}
+ * @see {@link https://canvastimeline.com/demos/html-media-sync | HTML media sync demo}
  */
 export function useHTMLTimelineMedia<
   LayerName extends string = string,

--- a/packages/html-media-adapter/src/tsconfig.json
+++ b/packages/html-media-adapter/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/mediabunny-adapter/src/react.ts
+++ b/packages/mediabunny-adapter/src/react.ts
@@ -13,6 +13,13 @@ import {
 
 /**
  * Options for creating a Mediabunny adapter from React.
+ *
+ * @remarks
+ *
+ * This lower-level options shape is useful when an app wants the underlying
+ * {@link MediabunnyAdapter} for custom preview controls. The higher-level
+ * {@link useMediabunnyTimelineMedia} hook adds timeline transport commands on
+ * top of this adapter.
  */
 export interface UseMediabunnyAdapterOptions extends Omit<
   CreateMediabunnyAdapterOptions,
@@ -24,6 +31,18 @@ export interface UseMediabunnyAdapterOptions extends Omit<
 
 /**
  * Options for wiring Mediabunny decoded preview directly to timeline playback.
+ *
+ * @remarks
+ *
+ * Provide timeline sources, a canvas ref for visual frames, and named active
+ * layer selectors. The hook creates a {@link MediabunnyAdapter}, uses
+ * {@link useTimelineMediaSync} for external-clock playback, and keeps decoded
+ * frames and audio scheduling aligned with the timeline playhead.
+ *
+ * @template LayerName - Named media layer keys inferred from `layers`, such as
+ * `"visuals" | "audio"`.
+ *
+ * @see {@link https://canvastimeline.com/demos/media-preview-sync | Mediabunny media sync demo}
  */
 export interface UseMediabunnyTimelineMediaOptions<LayerName extends string = string>
   extends
@@ -35,6 +54,9 @@ export interface UseMediabunnyTimelineMediaOptions<LayerName extends string = st
 
 /**
  * Timeline transport state plus Mediabunny preview status and adapter details.
+ *
+ * @template LayerName - Named media layer keys from
+ * {@link UseMediabunnyTimelineMediaOptions.layers}.
  */
 export interface UseMediabunnyTimelineMediaResult<
   LayerName extends string = string,
@@ -83,7 +105,37 @@ const loadMediabunny = () => import('mediabunny') as Promise<MediabunnyModule>;
 /**
  * Create and dispose a Mediabunny timeline adapter from React state.
  *
+ * @remarks
+ *
+ * Use this hook when your app wants to manage transport with
+ * {@link useTimelineMediaSync} manually, inspect decoded frame state, or share
+ * one adapter across custom preview controls. For a ready-made transport hook,
+ * use {@link useMediabunnyTimelineMedia}.
+ *
  * @param options - Mediabunny sources, optional canvas ref, audio options, and module loader.
+ * @returns The current Mediabunny adapter, including readiness, status, decoded frame state, and sync callbacks.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo, useRef } from 'react';
+ * import { useMediabunnyAdapter } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
+ *
+ * export function DecoderStatus() {
+ *   const canvasRef = useRef<HTMLCanvasElement>(null);
+ *   const sources = useMemo(() => [{ id: 'source-1', url: '/media/sample.mp4' }], []);
+ *   const adapter = useMediabunnyAdapter({ canvasRef, sources });
+ *
+ *   return (
+ *     <>
+ *       <canvas ref={canvasRef} width={1280} height={720} />
+ *       <p>{adapter.status}</p>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link MediabunnyAdapter}
+ * @see {@link useMediabunnyTimelineMedia}
  */
 export function useMediabunnyAdapter(options: UseMediabunnyAdapterOptions): MediabunnyAdapter {
   const { audio, audioTrackKinds, canvasRef, mediabunny, sources, visualTrackKinds } = options;
@@ -120,7 +172,56 @@ export function useMediabunnyAdapter(options: UseMediabunnyAdapterOptions): Medi
 /**
  * Create a Mediabunny adapter and bind it to timeline-synchronized playback.
  *
+ * @remarks
+ *
+ * This is the high-level React hook for decoded media previews. It is the same
+ * shape used by the media sync demo and the full editor demo: define stable
+ * `visuals` and `audio` layers, pass sources keyed by timeline clip `sourceId`,
+ * and drive toolbar buttons from the returned `play`, `pause`, and
+ * `setPlaybackRate` commands.
+ *
  * @param options - Mediabunny sources, active layers, optional canvas ref, and sync options.
+ * @template LayerName - Named media layer keys inferred from `options.layers`,
+ * such as `"visuals" | "audio"`.
+ * @returns Timeline transport state, active layer data, decoded frame status, source durations, and the low-level adapter.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo, useRef } from 'react';
+ * import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
+ *
+ * type PreviewLayerName = 'visuals' | 'audio';
+ *
+ * const previewLayers = {
+ *   visuals: { trackKind: 'visual' },
+ *   audio: { trackKind: 'audio' },
+ * } as const;
+ *
+ * export function DecodedPreview() {
+ *   const canvasRef = useRef<HTMLCanvasElement>(null);
+ *   const sources = useMemo(() => [{ id: 'source-1', url: '/media/interview.mp4' }], []);
+ *   const media = useMediabunnyTimelineMedia<PreviewLayerName>({
+ *     canvasRef,
+ *     sources,
+ *     layers: previewLayers,
+ *     onError: console.error,
+ *   });
+ *
+ *   return (
+ *     <>
+ *       <canvas ref={canvasRef} width={1280} height={720} />
+ *       <button type="button" disabled={!media.ready} onClick={() => void media.play()}>
+ *         {media.playing ? 'Playing' : 'Play'}
+ *       </button>
+ *       <span>{media.status}</span>
+ *     </>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineMediaSync}
+ * @see {@link https://canvastimeline.com/demos/media-preview-sync | Mediabunny media sync demo}
+ * @see {@link https://canvastimeline.com/demos/full-editor-demo | Full editor demo}
  */
 export function useMediabunnyTimelineMedia<LayerName extends string = string>(
   options: UseMediabunnyTimelineMediaOptions<LayerName>

--- a/packages/mediabunny-adapter/src/tsconfig.json
+++ b/packages/mediabunny-adapter/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/react/src/Provider.tsx
+++ b/packages/react/src/Provider.tsx
@@ -3,7 +3,16 @@ import type { TimelineEngine, TimelineState } from '@techsquidtv/canvas-timeline
 import { TimelineContext } from './context';
 
 /**
- * Props for wiring a TimelineEngine into React context.
+ * Props for wiring a {@link TimelineEngine} into React context.
+ *
+ * @remarks
+ *
+ * Pass one stable engine instance to {@link TimelineProvider}. Descendant hooks
+ * such as {@link useTimeline} and {@link useTimelineState} read from this
+ * context and receive synchronized {@link TimelineState} snapshots.
+ *
+ * @see {@link https://canvastimeline.com/docs/getting-started | Getting Started}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export interface TimelineProviderProps {
   /** React subtree that should read from the provided engine. */
@@ -43,14 +52,55 @@ function createProviderState(engine: TimelineEngine): TimelineState {
 }
 
 /**
- * TimelineProvider
+ * Provides a {@link TimelineEngine} to React timeline hooks and components.
  *
- * Sets up a bridge between the central event-driven `TimelineEngine` model
- * and standard React functional layouts. Subscribes to settled state,
- * selection, playback, content, and clipboard changes, pushing lightweight state
- * updates downwards into hooks.
+ * @remarks
+ *
+ * `TimelineProvider` is the bridge between the event-driven engine model and
+ * React layouts. It subscribes to settled state, selection, playback, content,
+ * and clipboard changes, then publishes lightweight {@link TimelineState}
+ * snapshots to descendants. Hooks such as {@link useTimeline} and
+ * {@link useTimelineState} must run inside this provider.
  *
  * @param props - Provider configuration and child tree.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo } from 'react';
+ * import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+ * import {
+ *   TimelineProvider,
+ *   useTimelineState,
+ * } from '@techsquidtv/canvas-timeline-react';
+ * import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+ *
+ * function TrackCount() {
+ *   const state = useTimelineState();
+ *
+ *   return <span>{state.tracks.length} tracks</span>;
+ * }
+ *
+ * export function EditorShell() {
+ *   const engine = useMemo(
+ *     () =>
+ *       new TimelineEngine({
+ *         duration: fromSeconds(30),
+ *         tracks: [],
+ *       }),
+ *     []
+ *   );
+ *
+ *   return (
+ *     <TimelineProvider engine={engine}>
+ *       <TrackCount />
+ *     </TimelineProvider>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link TimelineEngine}
+ * @see {@link TimelineState}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function TimelineProvider(props: TimelineProviderProps) {
   const { children, engine } = props;

--- a/packages/react/src/accessibility.ts
+++ b/packages/react/src/accessibility.ts
@@ -115,6 +115,10 @@ function getTrackLabel<TrackKind = string>(track?: Track<TrackKind>) {
  *
  * @param clip - Timeline clip to describe.
  * @param track - Optional track containing the clip.
+ * @template TrackKind - App-defined track kind values carried by the containing
+ * track.
+ * @returns Short label suitable for `aria-label`, active-descendant text, or
+ * inspector headings.
  */
 export function getClipAccessibleName<TrackKind = string>(clip: Clip, track?: Track<TrackKind>) {
   const clipLabel = clip.label?.trim() || clip.id;
@@ -127,6 +131,10 @@ export function getClipAccessibleName<TrackKind = string>(clip: Clip, track?: Tr
  *
  * @param clip - Timeline clip whose timing and edit state should be described.
  * @param track - Optional track containing the clip.
+ * @template TrackKind - App-defined track kind values carried by the containing
+ * track.
+ * @returns Spoken description with timing, duration, and relevant edit-state
+ * flags.
  */
 export function getClipAccessibleDescription<TrackKind = string>(
   clip: Clip,

--- a/packages/react/src/hooks/clips/timelineClipModel.ts
+++ b/packages/react/src/hooks/clips/timelineClipModel.ts
@@ -39,6 +39,8 @@ export interface TimelineSelectionState<TrackKind = string> {
  * Flattens timeline tracks into stable clip entries.
  *
  * @param tracks - Timeline tracks to flatten.
+ * @template TrackKind - App-defined track kind values carried by returned
+ * entries.
  * @returns Flattened clip entries in track order.
  */
 export function flattenTimelineClips<TrackKind>(
@@ -59,6 +61,8 @@ export function flattenTimelineClips<TrackKind>(
  *
  * @param tracks - Timeline tracks to inspect.
  * @param clipGroups - Clip group state used to derive selected group metadata.
+ * @template TrackKind - App-defined track kind values carried by selected track
+ * state.
  * @returns Current selection metadata.
  */
 export function deriveTimelineSelection<TrackKind>(

--- a/packages/react/src/hooks/clips/useActiveLayers.ts
+++ b/packages/react/src/hooks/clips/useActiveLayers.ts
@@ -6,10 +6,50 @@ import { useTimelinePlayheadTime } from '../playback/useTimelinePlayheadTime';
 /**
  * Returns active timeline layers at a timeline time.
  *
+ * @remarks
+ *
  * The hook is collection-first: each named layer returns every matching active
  * clip in stable track order. `primary` is only a convenience first match.
+ * Use it for preview panels, custom media status, subtitle overlays, and
+ * diagnostics that need to inspect which timeline clips are active without
+ * starting playback. For transport controls that drive an external media clock,
+ * compose {@link useTimelineMediaSync} or {@link useTimelineMediaPlayback}
+ * instead.
  *
  * @param options - Active layer selectors and optional lookup time.
+ * @template LayerName - Named layer keys inferred from `options.layers`, such
+ * as `"visuals" | "audio"`.
+ * @returns Active clips grouped by the configured layer selectors.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo } from 'react';
+ * import { useActiveLayers } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * const previewLayers = {
+ *   visuals: { trackKind: 'visual' },
+ *   audio: { trackKind: 'audio' },
+ * } as const;
+ *
+ * export function ActiveMediaReadout() {
+ *   const layers = useMemo(() => previewLayers, []);
+ *   const activeLayers = useActiveLayers({ layers });
+ *
+ *   return (
+ *     <dl>
+ *       <dt>Visual</dt>
+ *       <dd>{activeLayers.primary.visuals?.clip.name ?? 'No visual clip'}</dd>
+ *       <dt>Audio clips</dt>
+ *       <dd>{activeLayers.layers.audio.length}</dd>
+ *     </dl>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link ActiveLayerOptions}
+ * @see {@link ActiveLayerResult}
+ * @see {@link useTimelineMediaSync}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useActiveLayers<LayerName extends string = string>(
   options: ActiveLayerOptions<LayerName>

--- a/packages/react/src/hooks/clips/useTimelineClipDrag.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDrag.ts
@@ -38,7 +38,22 @@ export interface TimelineClipDragMoveInput {
   viewportY: number;
 }
 
-/** Options accepted by `useTimelineClipDrag`. */
+/**
+ * Options accepted by `useTimelineClipDrag`.
+ *
+ * @remarks
+ *
+ * Pass renderer-aligned geometry so pointer Y coordinates resolve to the same
+ * track rows users see on screen. `canDropClipOnTrack` lets applications enforce
+ * domain rules such as preventing audio clips from moving to visual tracks
+ * unless a modifier key or tool mode allows it.
+ *
+ * @template TrackKind - App-defined track kind values carried by target tracks,
+ * such as `"visual" | "audio"`.
+ *
+ * @see {@link useTimelineTrackDropTargets}
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
+ */
 export interface UseTimelineClipDragOptions<
   TrackKind = string,
 > extends TimelineInteractionGeometry {
@@ -122,7 +137,46 @@ function getTrackPenetration<TrackKind>(
 /**
  * Headless clip body drag behavior shared by canvas and custom timeline UIs.
  *
+ * @remarks
+ *
+ * Use this when building a custom interaction layer around canvas-painted clips.
+ * The hook handles drag lifecycle, snapping preparation, cross-track drop
+ * policy, transient drop feedback, and commit/settle behavior. Package
+ * consumers using the standard DOM chrome can render `Timeline.ClipInteractionLayer`
+ * instead.
+ *
  * @param options - Drag geometry, vertical snap sensitivity, and optional drop policy.
+ * @template TrackKind - App-defined track kind values carried by target tracks.
+ * @returns Clip drag state and commands for pointer-driven body moves.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineClipDrag } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function CustomClipDragHandle({ clipId }: { clipId: string }) {
+ *   const drag = useTimelineClipDrag();
+ *
+ *   return (
+ *     <button
+ *       type="button"
+ *       aria-pressed={drag.dragging}
+ *       onPointerDown={(event) => {
+ *         drag.startClipDrag({
+ *           clipId,
+ *           clientX: event.clientX,
+ *           viewportY: event.nativeEvent.offsetY,
+ *         });
+ *       }}
+ *     >
+ *       Move clip
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineClipDropFeedback}
+ * @see {@link useTimelineTrackDropTargets}
+ * @see {@link https://canvastimeline.com/demos/basic-editor-surface | Basic editor surface demo}
  */
 export function useTimelineClipDrag<TrackKind = string>(
   options: UseTimelineClipDragOptions<TrackKind> = {}

--- a/packages/react/src/hooks/clips/useTimelineClipDropFeedback.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDropFeedback.ts
@@ -5,7 +5,19 @@ import { useTimelineExternalStore } from '../core/useTimelineExternalStore';
 const clipDropFeedbackEvents = ['clip:drop-feedback'] as const;
 const getTimelineClipDropFeedback = (engine: TimelineEngine) => engine.getClipDropFeedback();
 
-/** Result returned by `useTimelineClipDropFeedback`. */
+/**
+ * Result returned by `useTimelineClipDropFeedback`.
+ *
+ * @remarks
+ *
+ * The fields are intentionally transient and mirror the current pointer drag
+ * state. Use them for status text, track row highlighting, or custom invalid
+ * target feedback while {@link useTimelineClipDrag} or `Timeline.ClipInteractionLayer`
+ * owns the actual drag operation.
+ *
+ * @see {@link useTimelineClipDrag}
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
+ */
 export interface UseTimelineClipDropFeedbackResult {
   /** Current transient clip drop feedback. */
   feedback: TimelineClipDropFeedback;
@@ -26,7 +38,36 @@ export interface UseTimelineClipDropFeedbackResult {
 /**
  * Subscribes to live cross-track clip drop feedback.
  *
+ * @remarks
+ *
  * This is a focused live interaction hook intended for custom drag affordances.
+ * It subscribes to `clip:drop-feedback` instead of the broad provider snapshot,
+ * so components can react while the pointer crosses tracks without turning the
+ * entire editor shell into drag-time React state.
+ *
+ * @returns Current clip drag feedback and convenience fields for custom UI.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineClipDropFeedback } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function DropStatus() {
+ *   const feedback = useTimelineClipDropFeedback();
+ *
+ *   if (!feedback.hasFeedback) {
+ *     return null;
+ *   }
+ *
+ *   return (
+ *     <p role="status">
+ *       {feedback.valid ? 'Drop to move clip' : `Cannot drop here: ${feedback.feedback.reason}`}
+ *     </p>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineClipDrag}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useTimelineClipDropFeedback(): UseTimelineClipDropFeedbackResult {
   const feedback = useTimelineExternalStore(clipDropFeedbackEvents, getTimelineClipDropFeedback);

--- a/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
@@ -12,6 +12,17 @@ import { timelineCommandFail } from '../core/timelineCommandResult';
 
 /**
  * Metadata for one canvas-rendered clip exposed through clip navigation.
+ *
+ * @remarks
+ *
+ * Canvas Timeline keeps clip visuals on canvas for performance. This model
+ * gives a single DOM focus target enough metadata to announce and manipulate
+ * whichever canvas clip is currently active.
+ *
+ * @template TrackKind - App-defined track kind values carried by the containing
+ * track.
+ *
+ * @see {@link useTimelineClipNavigation}
  */
 export interface TimelineNavigableClip<TrackKind = string> {
   /** Raw timeline clip represented by this navigation item. */
@@ -36,6 +47,16 @@ export interface TimelineNavigableClip<TrackKind = string> {
 
 /**
  * Options for constant-DOM canvas clip navigation.
+ *
+ * @remarks
+ *
+ * Use these options when a canvas timeline needs keyboard navigation without
+ * rendering one DOM button per clip. `selectOnNavigate` is useful for inspector
+ * workflows; leave it disabled when navigation should move a virtual cursor
+ * without mutating timeline selection.
+ *
+ * @template TrackKind - App-defined track kind values passed to custom label
+ * and description formatters.
  */
 export interface TimelineClipNavigationOptions<TrackKind = string> {
   /** Initial active clip id. Defaults to selected clip, then the first clip. */
@@ -91,17 +112,32 @@ function getActiveClipStatus<TrackKind>(
  *
  * @param options - Initial active clip and navigation behavior options.
  * @returns Active clip metadata, flattened clip list, navigation commands, edit commands, and optional focus-target props.
+ * @template TrackKind - App-defined track kind values carried by navigable
+ * clips.
  *
  * @example
  * ```tsx
- * const clipNavigation = useTimelineClipNavigation();
+ * import { useTimelineClipNavigation } from '@techsquidtv/canvas-timeline-react/hooks';
  *
- * return (
- *   <div {...clipNavigation.focusTargetProps}>
- *     {clipNavigation.activeClip?.name}
- *   </div>
- * );
+ * export function CanvasClipNavigator() {
+ *   const clipNavigation = useTimelineClipNavigation({ selectOnNavigate: true });
+ *
+ *   return (
+ *     <div {...clipNavigation.focusTargetProps}>
+ *       <p>{clipNavigation.activeClipStatus}</p>
+ *       <button type="button" onClick={() => clipNavigation.navigatePrevious()}>
+ *         Previous clip
+ *       </button>
+ *       <button type="button" onClick={() => clipNavigation.navigateNext()}>
+ *         Next clip
+ *       </button>
+ *     </div>
+ *   );
+ * }
  * ```
+ *
+ * @see {@link TimelineNavigableClip}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useTimelineClipNavigation<TrackKind = string>(
   options: TimelineClipNavigationOptions<TrackKind> = {}

--- a/packages/react/src/hooks/clips/useTimelineClipRects.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipRects.ts
@@ -6,17 +6,57 @@ import type {
 import { useTimeline } from '../core/useTimeline';
 import { useTimelineGeometryRevision } from '../core/useTimelineGeometryRevision';
 
-/** Options accepted by `useTimelineClipRects`. */
+/**
+ * Options accepted by `useTimelineClipRects`.
+ *
+ * @remarks
+ *
+ * Pass the same ruler, track-height, and edge-threshold values used by your
+ * renderer or interaction layer so DOM overlays line up with canvas-painted
+ * clips. Leave options empty when using the default package geometry.
+ *
+ * @see {@link https://canvastimeline.com/docs/renderer-customization | Canvas renderer customization}
+ */
 export type UseTimelineClipRectsOptions = TimelineClipGeometryOptions;
 
 /**
  * Returns viewport-space geometry for every timeline clip.
  *
+ * @remarks
+ *
  * The hook subscribes to geometry-affecting timeline events and intentionally
- * does not subscribe to playhead-only updates.
+ * does not subscribe to playhead-only updates. Use it for low-count DOM
+ * overlays such as selected clip outlines, inline labels, or inspector hit
+ * targets. For large custom renderers, prefer {@link useTimelineVisibleClips}
+ * so offscreen clips are clipped or skipped.
  *
  * @param options - Optional ruler and track metrics aligned with the renderer.
  * @returns Clip entries with viewport rectangles and edit/display state.
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineClipRects } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function SelectedClipBadges() {
+ *   const rects = useTimelineClipRects();
+ *
+ *   return rects
+ *     .filter((entry) => entry.selected)
+ *     .map((entry) => (
+ *       <span
+ *         key={entry.clipId}
+ *         style={{ left: entry.x, top: entry.y, width: entry.width, height: entry.height }}
+ *       >
+ *         {entry.clip.label ?? entry.clip.id}
+ *       </span>
+ *     ));
+ * }
+ * ```
+ *
+ * @see {@link useTimelineVisibleClips}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useTimelineClipRects<TrackKind = string>(
   options: UseTimelineClipRectsOptions = {}

--- a/packages/react/src/hooks/clips/useTimelineClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineClips.ts
@@ -19,10 +19,36 @@ import {
 
 export type { TimelineClipEntry } from './timelineClipModel';
 
-/** Editable presentation fields accepted by `useTimelineClips().updateClip`. */
+/**
+ * Editable presentation fields accepted by `useTimelineClips().updateClip`.
+ *
+ * @remarks
+ *
+ * These fields are intentionally presentation-only. Timeline structure, timing,
+ * track placement, and source offsets should go through the command-layer hook
+ * so the engine can validate edits and preserve history.
+ *
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
+ */
 export type TimelineClipUpdate = Partial<Pick<Clip, 'label' | 'opacity' | 'color'>>;
 
-/** Result returned by `useTimelineClips`. */
+/**
+ * Result returned by `useTimelineClips`.
+ *
+ * @remarks
+ *
+ * The result combines a flattened clip list, selected-clip metadata, geometry
+ * helpers, source-time mapping helpers, and safe edit commands. Use it for
+ * command bars, inspectors, context menus, and custom clip panels. For live
+ * drag affordances, combine it with {@link useTimelineClipDrag} and
+ * {@link useTimelineClipDropFeedback}.
+ *
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries, such as `"visual" | "audio"`.
+ *
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
+ */
 export interface UseTimelineClipsResult<TrackKind = string> {
   /** Flattened timeline clips in track order. */
   clips: TimelineClipEntry<TrackKind>[];
@@ -71,7 +97,71 @@ export interface UseTimelineClipsResult<TrackKind = string> {
 /**
  * Provides the canonical clip collection and clip metadata for React editor UI.
  *
+ * @remarks
+ *
+ * `useTimelineClips` is the broad clip-domain hook. It is appropriate for
+ * product chrome that needs clip read state, selection metadata, geometry
+ * helpers, and presentation updates, such as a clip inspector, project panel,
+ * or timeline command palette. It does not subscribe to per-frame playback
+ * ticks; geometry helpers read from the engine when a command or render path
+ * asks for them.
+ *
+ * Use {@link useTimelineEditCommands} for structural timeline edits such as
+ * move, trim, split, insert, overwrite, and delete.
+ *
  * @returns Flattened clips, selected clip metadata, clip lookups, and presentation commands.
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries, such as `"visual" | "audio"`.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineClips } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function ClipLabelEditor() {
+ *   const { selectedClip, updateClip } = useTimelineClips();
+ *
+ *   if (!selectedClip) {
+ *     return null;
+ *   }
+ *
+ *   return (
+ *     <input
+ *       value={selectedClip.label ?? ''}
+ *       onChange={(event) => updateClip(selectedClip.id, { label: event.target.value })}
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
+ * import { useTimelineClips } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function ClipInspector() {
+ *   const { selectedClip, selectedClipTrackId, timelineTimeToSourceTime } = useTimelineClips();
+ *
+ *   if (!selectedClip) {
+ *     return <p>No clip selected</p>;
+ *   }
+ *
+ *   const sourceTime = timelineTimeToSourceTime(selectedClip, selectedClip.timelineStart);
+ *
+ *   return (
+ *     <dl>
+ *       <dt>Track</dt>
+ *       <dd>{selectedClipTrackId}</dd>
+ *       <dt>Source start</dt>
+ *       <dd>{toSeconds(sourceTime).toFixed(2)}s</dd>
+ *     </dl>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineSelection}
+ * @see {@link useTimelineClipDrag}
+ * @see {@link useTimelineEditCommands}
+ * @see {@link https://canvastimeline.com/demos/timeline-editor-controls | Timeline editor controls demo}
  */
 export function useTimelineClips<TrackKind = string>(): UseTimelineClipsResult<TrackKind> {
   const { engine, state } = useTimeline();

--- a/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
+++ b/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
@@ -34,7 +34,21 @@ export interface TimelineExternalClipDropGroupOptions {
   label?: string;
 }
 
-/** Context passed to external clip drop callbacks. */
+/**
+ * Context passed to external clip drop callbacks.
+ *
+ * @remarks
+ *
+ * The context combines app-owned drag data with the resolved timeline target.
+ * Use it to build clip placements from a media bin, asset browser, file picker,
+ * or generated content panel. Times are already converted from pointer position
+ * into {@link RationalTime} so placement factories do not need to duplicate
+ * timeline geometry math.
+ *
+ * @template DragData - App-owned payload resolved from the native drag event.
+ * @template TrackKind - App-defined track kind values accepted by the drop
+ * surface.
+ */
 export interface TimelineExternalClipDropContext<DragData, TrackKind = string> {
   /** App-owned drag payload resolved from the native drag event. */
   data: DragData;
@@ -68,20 +82,52 @@ export interface TimelineExternalClipDropGuardResult {
   message?: string;
 }
 
-/** Custom policy for accepting or rejecting an external drop target. */
+/**
+ * Custom policy for accepting or rejecting an external drop target.
+ *
+ * @template DragData - App-owned payload resolved from the native drag event.
+ * @template TrackKind - App-defined track kind values used by candidate tracks.
+ */
 export type TimelineExternalClipDropGuard<DragData, TrackKind = string> = (
   context: TimelineExternalClipDropContext<DragData, TrackKind>
 ) => boolean | TimelineExternalClipDropGuardResult;
 
-/** Props spread onto the timeline element that receives native external drops. */
+/**
+ * Props spread onto the timeline element that receives native external drops.
+ *
+ * @remarks
+ *
+ * Spread these onto the same viewport element whose bounds should define
+ * pointer-to-time and pointer-to-track hit testing. The hook handles native drag
+ * events; applications provide payload parsing and placement creation.
+ */
 export interface TimelineExternalClipDropRootProps {
+  /** Registers a native drag entering the timeline drop surface. */
   onDragEnter: DragEventHandler<HTMLElement>;
+  /** Updates target track, drop time, validity, and browser drop feedback. */
   onDragOver: DragEventHandler<HTMLElement>;
+  /** Clears transient hover feedback when the drag leaves the drop surface. */
   onDragLeave: DragEventHandler<HTMLElement>;
+  /** Commits the resolved insert or overwrite edit for the app-owned payload. */
   onDrop: DragEventHandler<HTMLElement>;
 }
 
-/** Options accepted by `useTimelineExternalClipDrop`. */
+/**
+ * Options accepted by `useTimelineExternalClipDrop`.
+ *
+ * @remarks
+ *
+ * `resolveDragData` converts a browser drag event into app data. `createPlacements`
+ * turns that data into one or more timeline clip placements. The hook resolves
+ * target track, drop time, snapping, edit mode, grouped drops, and command
+ * results around those app callbacks.
+ *
+ * @template DragData - App-owned payload resolved from the native drag event.
+ * @template TrackKind - App-defined track kind values used by target tracks.
+ *
+ * @see {@link TimelineExternalClipDropContext}
+ * @see {@link https://canvastimeline.com/demos/external-clip-drop | External clip drop demo}
+ */
 export interface UseTimelineExternalClipDropOptions<
   DragData,
   TrackKind = string,
@@ -112,7 +158,19 @@ export interface UseTimelineExternalClipDropOptions<
   snap?: boolean;
 }
 
-/** Result returned by `useTimelineExternalClipDrop`. */
+/**
+ * Result returned by `useTimelineExternalClipDrop`.
+ *
+ * @remarks
+ *
+ * Use `rootProps` on the drop surface, then render the feedback fields in
+ * timeline chrome such as target-row highlighting, invalid-drop messages, or a
+ * preview badge. `lastResult` keeps the last command outcome available after
+ * hover feedback clears.
+ *
+ * @template TrackKind - App-defined track kind values carried by the current
+ * target track.
+ */
 export interface UseTimelineExternalClipDropResult<TrackKind = string> {
   /** Props for the element that should accept native external drops. */
   rootProps: TimelineExternalClipDropRootProps;
@@ -195,12 +253,59 @@ function isLeavingCurrentTarget(event: DragEvent<HTMLElement>) {
 /**
  * Adds native browser drag-and-drop support for app-owned clip data.
  *
+ * @remarks
+ *
  * The hook owns browser event handling, track/time resolution, and local
  * feedback state. Apps own payload parsing and clip placement factories; the
  * engine owns validation, policy, history, grouped edits, and undo/redo.
  *
  * @param options - Drop geometry, app payload callbacks, edit mode, and optional policy.
  * @returns Root props, feedback state, and the last drop command result.
+ * @template DragData - App-owned payload resolved from the native drag event.
+ * @template TrackKind - App-defined track kind values used by target tracks.
+ *
+ * @example
+ * ```tsx
+ * import { addRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+ * import { useTimelineExternalClipDrop } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * interface MediaAsset {
+ *   id: string;
+ *   durationSeconds: number;
+ * }
+ *
+ * export function AssetDropSurface() {
+ *   const drop = useTimelineExternalClipDrop<MediaAsset>({
+ *     resolveDragData: (event) => {
+ *       const id = event.dataTransfer.getData('text/plain');
+ *       return id ? { id, durationSeconds: 5 } : null;
+ *     },
+ *     createPlacements: ({ data, dropTime, targetTrack }) => {
+ *       const duration = fromSeconds(data.durationSeconds, dropTime.r);
+ *
+ *       return [
+ *         {
+ *           trackId: targetTrack.id,
+ *           clip: {
+ *             id: `clip-${data.id}`,
+ *             sourceId: data.id,
+ *             timelineStart: dropTime,
+ *             timelineEnd: addRational(dropTime, duration),
+ *             sourceStart: fromSeconds(0, dropTime.r),
+ *             sourceEnd: duration,
+ *           },
+ *         },
+ *       ];
+ *     },
+ *   });
+ *
+ *   return <div {...drop.rootProps}>{drop.valid ? 'Drop media' : 'Drag media here'}</div>;
+ * }
+ * ```
+ *
+ * @see {@link TimelineExternalClipDropContext}
+ * @see {@link useTimelineClipDropFeedback}
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
  */
 export function useTimelineExternalClipDrop<DragData, TrackKind = string>(
   options: UseTimelineExternalClipDropOptions<DragData, TrackKind>

--- a/packages/react/src/hooks/clips/useTimelineVisibleClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineVisibleClips.ts
@@ -6,17 +6,54 @@ import type {
 import { useTimeline } from '../core/useTimeline';
 import { useTimelineGeometryRevision } from '../core/useTimelineGeometryRevision';
 
-/** Options accepted by `useTimelineVisibleClips`. */
+/**
+ * Options accepted by `useTimelineVisibleClips`.
+ *
+ * @remarks
+ *
+ * Use viewport dimensions and `overscanPixels` to trade precision for render
+ * stability while scrolling. Pass renderer-aligned geometry when custom DOM or
+ * canvas layers must line up with `CanvasRenderer`.
+ *
+ * @see {@link https://canvastimeline.com/demos/react-dom-timeline | React DOM timeline demo}
+ */
 export type UseTimelineVisibleClipsOptions = VisibleTimelineClipOptions;
 
 /**
  * Returns viewport-intersecting timeline clips with clipped time/source ranges.
  *
+ * @remarks
+ *
  * This is the preferred hook for custom DOM clip renderers and custom canvas
- * layers that only need visible or near-visible clips.
+ * layers that only need visible or near-visible clips. Each returned entry
+ * includes the visible viewport rectangle plus clipped timeline/source ranges,
+ * so thumbnail, waveform, and annotation renderers can avoid work for hidden
+ * portions of long clips.
  *
  * @param options - Viewport, overscan, and optional renderer-aligned geometry settings.
  * @returns Visible clip entries in track order.
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineVisibleClips } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function VisibleClipList() {
+ *   const visibleClips = useTimelineVisibleClips({ overscanPixels: 160 });
+ *
+ *   return (
+ *     <ul>
+ *       {visibleClips.map((entry) => (
+ *         <li key={entry.clip.id}>{entry.clip.label ?? entry.clip.id}</li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineClipRects}
+ * @see {@link https://canvastimeline.com/docs/renderer-customization | Canvas renderer customization}
  */
 export function useTimelineVisibleClips<TrackKind = string>(
   options: UseTimelineVisibleClipsOptions = {}

--- a/packages/react/src/hooks/core/timelineCommandResult.ts
+++ b/packages/react/src/hooks/core/timelineCommandResult.ts
@@ -41,6 +41,7 @@ export interface TimelineCommandResult<Value = void> {
  * Creates a successful timeline command result.
  *
  * @param value - Optional command payload.
+ * @template Value - Successful command payload type.
  * @returns Successful command result.
  */
 export function timelineCommandOk<Value = void>(value?: Value): TimelineCommandResult<Value> {
@@ -53,6 +54,8 @@ export function timelineCommandOk<Value = void>(value?: Value): TimelineCommandR
  * @param reason - Machine-readable failure reason.
  * @param message - Optional human-readable failure detail.
  * @param cause - Optional original error that caused the failure.
+ * @template Value - Payload type expected by the matching successful command
+ * result.
  * @returns Failed command result.
  */
 export function timelineCommandFail<Value = void>(

--- a/packages/react/src/hooks/core/usePlaybackEffect.ts
+++ b/packages/react/src/hooks/core/usePlaybackEffect.ts
@@ -6,11 +6,40 @@ import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
  * Subscribes to real-time playback events (enter, update, leave) for a specific clip
  * as the global playhead crosses the clip's boundary timestamps.
  *
+ * @remarks
+ *
+ * Use this hook for clip-local effects such as highlighting subtitles, toggling
+ * preview overlays, triggering analytics, or coordinating lightweight external
+ * state when a known clip becomes active. `onUpdate` can fire every playback
+ * tick while the playhead is inside the clip, so keep that callback cheap and
+ * avoid broad React state updates for dense timelines.
+ *
  * @param clipId - The unique string ID of the target clip to track.
  * @param callbacks - Callback handlers triggered on transition crossings.
  * @param callbacks.onEnter - Called when the playhead enters the clip range.
  * @param callbacks.onUpdate - Called on every frame tick inside the clip range.
  * @param callbacks.onLeave - Called when the playhead moves outside of the clip range.
+ * @returns Nothing; the hook manages playback event subscriptions for the component lifetime.
+ *
+ * @example
+ * ```tsx
+ * import { useState } from 'react';
+ * import { usePlaybackEffect } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function ClipActiveBadge({ clipId }: { clipId: string }) {
+ *   const [active, setActive] = useState(false);
+ *
+ *   usePlaybackEffect(clipId, {
+ *     onEnter: () => setActive(true),
+ *     onLeave: () => setActive(false),
+ *   });
+ *
+ *   return active ? <span>Active now</span> : null;
+ * }
+ * ```
+ *
+ * @see {@link useTimelineEvent}
+ * @see {@link https://canvastimeline.com/docs/events-and-lifecycle | Events and lifecycle}
  */
 export function usePlaybackEffect(
   clipId: string,

--- a/packages/react/src/hooks/core/useTimelineEvent.ts
+++ b/packages/react/src/hooks/core/useTimelineEvent.ts
@@ -2,7 +2,14 @@ import { useEffect, useRef } from 'react';
 import type { EngineEventMap } from '@techsquidtv/canvas-timeline-core';
 import { useTimeline } from './useTimeline';
 
-/** Callback signature for a typed TimelineEngine event subscription. */
+/**
+ * Callback signature for a typed TimelineEngine event subscription.
+ *
+ * @template EventName - Timeline engine event name from `EngineEventMap`.
+ *
+ * @see {@link useTimelineEvent}
+ * @see {@link https://canvastimeline.com/docs/events-and-lifecycle | Events and lifecycle}
+ */
 export type TimelineEventHandler<EventName extends keyof EngineEventMap> =
   EngineEventMap[EventName] extends void
     ? () => void
@@ -17,13 +24,36 @@ export interface TimelineEventOptions {
 /**
  * Subscribes to a typed TimelineEngine event with a React-safe latest handler.
  *
+ * @remarks
+ *
  * The hook keeps the event subscription stable while updating the callback ref
  * every render, avoiding stale closures without resubscribing for handler-only
- * changes.
+ * changes. Use it for low-level integration work such as analytics, custom
+ * status panels, or imperative bridges. Prefer focused hooks such as
+ * {@link useTimelinePlayheadTime} or {@link useTimelineClipDropFeedback} when a
+ * public hook already exists for the state you need.
  *
  * @param eventName - TimelineEngine event name to subscribe to.
  * @param handler - Callback invoked with the typed event payload.
  * @param options - Optional subscription controls.
+ * @template EventName - Timeline engine event name from `EngineEventMap`.
+ * @returns Nothing; the subscription is managed for the component lifetime.
+ *
+ * @example
+ * ```tsx
+ * import { useState } from 'react';
+ * import { useTimelineEvent } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function PlaybackRateReadout() {
+ *   const [rate, setRate] = useState(1);
+ *
+ *   useTimelineEvent('playback:rate', setRate);
+ *
+ *   return <span>{rate}x</span>;
+ * }
+ * ```
+ *
+ * @see {@link https://canvastimeline.com/docs/events-and-lifecycle | Events and lifecycle}
  */
 export function useTimelineEvent<EventName extends keyof EngineEventMap>(
   eventName: EventName,

--- a/packages/react/src/hooks/core/useTimelineState.ts
+++ b/packages/react/src/hooks/core/useTimelineState.ts
@@ -1,21 +1,49 @@
+import type { TimelineState } from '@techsquidtv/canvas-timeline-core';
 import { useTimeline } from './useTimeline';
 
 /**
- * Reads the current synchronized timeline state.
+ * Reads the current synchronized {@link TimelineState} snapshot.
  *
- * This is a render-focused shortcut for components that need track, playhead,
- * zoom, scroll, marker, or playback state without calling engine methods. The
- * returned value updates when `TimelineProvider` receives engine state events.
+ * @remarks
+ *
+ * Use `useTimelineState` for low-frequency product chrome that needs a broad
+ * view of timeline content, viewport, playback, markers, or edit feedback
+ * without calling engine methods. The returned snapshot updates when
+ * {@link TimelineProvider} receives engine state events.
+ *
+ * Prefer narrower hooks when a component only needs one live value. For example,
+ * use {@link useTimelinePlayheadTime} for playback readouts and
+ * {@link useTimelineViewport} for viewport controls. See
+ * {@link https://canvastimeline.com/docs/react-hooks | React editor hooks} for
+ * the hook selection guide.
  *
  * @returns The latest `TimelineState` snapshot published by `TimelineProvider`.
  *
  * @example
  * ```tsx
- * const state = useTimelineState();
+ * import { useTimelineState } from '@techsquidtv/canvas-timeline-react';
  *
- * return <span>{state.tracks.length} tracks</span>;
+ * export function TimelineStatus() {
+ *   const state = useTimelineState();
+ *
+ *   return (
+ *     <dl>
+ *       <dt>Tracks</dt>
+ *       <dd>{state.tracks.length}</dd>
+ *       <dt>Playback</dt>
+ *       <dd>{state.playing ? 'Playing' : 'Paused'}</dd>
+ *       <dt>Zoom</dt>
+ *       <dd>{state.zoomScale}px/s</dd>
+ *     </dl>
+ *   );
+ * }
  * ```
+ *
+ * @see {@link TimelineState}
+ * @see {@link TimelineProvider}
+ * @see {@link useTimelinePlayheadTime}
+ * @see {@link useTimelineViewport}
  */
-export function useTimelineState() {
+export function useTimelineState(): TimelineState {
   return useTimeline().state;
 }

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframeDrag.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframeDrag.ts
@@ -33,7 +33,19 @@ export interface TimelineKeyframeDragMoveInput {
   viewportY: number;
 }
 
-/** Options accepted by `useTimelineKeyframeDrag`. */
+/**
+ * Options accepted by `useTimelineKeyframeDrag`.
+ *
+ * @remarks
+ *
+ * Geometry must match the renderer or keyframe interaction layer so horizontal
+ * pointer movement maps to timeline time and vertical movement maps to property
+ * value consistently. The hook edits values in preview mode while dragging and
+ * settles history when the drag ends.
+ *
+ * @see {@link useTimelineKeyframes}
+ * @see {@link https://canvastimeline.com/docs/keyframes | Keyframes}
+ */
 export interface UseTimelineKeyframeDragOptions extends TimelineInteractionGeometry {
   /** Keyframe affordance size in CSS pixels. Defaults to engine geometry. */
   keyframeSize?: number;
@@ -84,7 +96,44 @@ function clampRatio(value: number) {
 /**
  * Headless keyframe drag behavior shared by canvas and custom timeline UIs.
  *
+ * @remarks
+ *
+ * Use this hook when building custom DOM or canvas hit targets for keyframe
+ * points. The hook owns drag lifecycle, preview updates, value mapping, and
+ * settle behavior. It intentionally does not render handles; pair it with
+ * {@link useTimelineKeyframes} for keyframe geometry.
+ *
  * @param options - Drag geometry aligned with the renderer and hit-test layer.
+ * @returns Keyframe drag state and pointer command helpers.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineKeyframeDrag } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function KeyframeHandle({ clipId, keyframeId }: { clipId: string; keyframeId: string }) {
+ *   const drag = useTimelineKeyframeDrag();
+ *
+ *   return (
+ *     <button
+ *       type="button"
+ *       aria-pressed={drag.dragging}
+ *       onPointerDown={(event) =>
+ *         drag.startKeyframeDrag({
+ *           clipId,
+ *           keyframeId,
+ *           clientX: event.clientX,
+ *           viewportY: event.nativeEvent.offsetY,
+ *         })
+ *       }
+ *     >
+ *       Move keyframe
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineKeyframes}
+ * @see {@link https://canvastimeline.com/demos/keyframe-opacity | Keyframe opacity demo}
  */
 export function useTimelineKeyframeDrag(
   options: UseTimelineKeyframeDragOptions = {}

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframes.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframes.ts
@@ -19,13 +19,41 @@ import {
   type TimelineCommandResult,
 } from '../core/timelineCommandResult';
 
-/** Options accepted by `useTimelineKeyframes`. */
+/**
+ * Options accepted by `useTimelineKeyframes`.
+ *
+ * @remarks
+ *
+ * Use these options to scope keyframe reads to one clip, one property, selected
+ * clips, or visible viewport geometry. Geometry options should match the
+ * renderer and interaction layer so DOM overlays line up with canvas keyframe
+ * diamonds.
+ *
+ * @see {@link useTimelineKeyframeDrag}
+ * @see {@link https://canvastimeline.com/docs/keyframes | Keyframes}
+ */
 export interface UseTimelineKeyframesOptions extends TimelineKeyframeGeometryOptions {
   /** Optional clip id used to scope keyframe lists and commands. */
   clipId?: string;
 }
 
-/** Result returned by `useTimelineKeyframes`. */
+/**
+ * Result returned by `useTimelineKeyframes`.
+ *
+ * @remarks
+ *
+ * The result combines keyframe lists, viewport geometry, visible geometry, and
+ * mutation commands. Use it for keyframe inspectors, custom DOM overlays,
+ * property editors, and toolbar actions. For pointer-driven dragging, combine
+ * it with {@link useTimelineKeyframeDrag}; for Bezier easing handles, use
+ * {@link useTimelineKeyframeCurves}.
+ *
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries.
+ *
+ * @see {@link useTimelineKeyframeCurves}
+ * @see {@link https://canvastimeline.com/docs/keyframes | Keyframes}
+ */
 export interface UseTimelineKeyframesResult<TrackKind = string> {
   /** Clip-scoped keyframes for `clipId`, or all keyframes from visible rects when no clip is scoped. */
   keyframes: TimelineKeyframe[];
@@ -64,7 +92,63 @@ export interface UseTimelineKeyframesResult<TrackKind = string> {
 /**
  * Reads timeline keyframe geometry and exposes canonical keyframe commands.
  *
+ * @remarks
+ *
+ * `useTimelineKeyframes` is the main keyframe-domain hook. It reads geometry
+ * from the engine so custom overlays share the same clip, track, scroll, and
+ * zoom math as the canvas renderer. Mutation commands return
+ * {@link TimelineCommandResult} values and respect locked tracks.
+ *
  * @param options - Optional clip/property filters and renderer-aligned geometry settings.
+ * @template TrackKind - App-defined track kind values carried by returned track
+ * entries.
+ * @returns Keyframe lists, viewport geometry, visible geometry, property evaluation, and mutation commands.
+ *
+ * @example
+ * ```tsx
+ * import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+ * import { useTimelineKeyframes } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function OpacityKeyframeButton({ clipId }: { clipId: string }) {
+ *   const keyframes = useTimelineKeyframes({ clipId, property: 'opacity' });
+ *
+ *   return (
+ *     <button
+ *       type="button"
+ *       onClick={() =>
+ *         keyframes.setKeyframe({
+ *           clipId,
+ *           property: 'opacity',
+ *           time: fromSeconds(1),
+ *           value: 0.5,
+ *         })
+ *       }
+ *     >
+ *       Add opacity keyframe
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineKeyframes } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function SelectedKeyframeOverlay() {
+ *   const { keyframeRects } = useTimelineKeyframes({ selectedClipOnly: true });
+ *
+ *   return keyframeRects.map((entry) => (
+ *     <span
+ *       key={entry.keyframe.id}
+ *       style={{ left: entry.x, top: entry.y, width: entry.width, height: entry.height }}
+ *     />
+ *   ));
+ * }
+ * ```
+ *
+ * @see {@link useTimelineKeyframeDrag}
+ * @see {@link useTimelineKeyframeCurves}
+ * @see {@link https://canvastimeline.com/demos/keyframe-opacity | Keyframe opacity demo}
  */
 export function useTimelineKeyframes<TrackKind = string>(
   options: UseTimelineKeyframesOptions = {}

--- a/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
@@ -24,6 +24,17 @@ export type TimelineContentPlaybackStatus = 'idle' | 'playing' | 'paused' | 'con
 
 /**
  * Details passed to external media sync callbacks.
+ *
+ * @remarks
+ *
+ * `TimelineLayerSyncDetails` is emitted when playback starts, ticks, pauses,
+ * crosses a content gap, or changes rate. Adapter code should use `reason` to
+ * decide whether work can be skipped. For example, an audio adapter usually
+ * reschedules on `"play"` and `"rate"`, but can ignore ordinary `"tick"` calls
+ * while the same clip remains active.
+ *
+ * @template LayerName - Named media layer keys from
+ * {@link UseTimelineMediaPlaybackOptions.layers}.
  */
 export interface TimelineLayerSyncDetails<LayerName extends string = string> {
   /** Timeline time being synchronized. */
@@ -36,6 +47,24 @@ export interface TimelineLayerSyncDetails<LayerName extends string = string> {
 
 /**
  * Options for coordinating timeline playback with an external media clock.
+ *
+ * @remarks
+ *
+ * Use this hook when your preview surface owns the media clock. The hook tells
+ * {@link https://canvastimeline.com/packages/core/api/timeline-engine | TimelineEngine}
+ * to play with an external clock, reads timeline seconds from `getClockTime`,
+ * and calls `syncLayers` with an {@link ActiveLayerResult} whenever active
+ * clips need to be rendered, sought, or paused.
+ *
+ * Higher-level adapters such as `useHTMLTimelineMedia` and
+ * `useMediabunnyTimelineMedia` wrap this contract for common media stacks.
+ *
+ * @template LayerName - Named media layer keys inferred from `layers`, such as
+ * `"visuals" | "audio"`.
+ *
+ * @see {@link TimelineLayerSyncDetails}
+ * @see {@link useTimelineMediaSync}
+ * @see {@link https://canvastimeline.com/demos/media-preview-sync | Mediabunny media sync demo}
  */
 export interface UseTimelineMediaPlaybackOptions<LayerName extends string = string> {
   /** Returns current timeline seconds from the external media clock. */
@@ -50,7 +79,16 @@ export interface UseTimelineMediaPlaybackOptions<LayerName extends string = stri
   onStatus?: (status: TimelineContentPlaybackStatus) => void;
 }
 
-/** Result returned by `useTimelineMediaPlayback`. */
+/**
+ * Result returned by `useTimelineMediaPlayback`.
+ *
+ * @remarks
+ *
+ * These commands operate on the timeline engine and return
+ * {@link TimelineCommandResult} values so toolbar code can show disabled,
+ * content-gap, or unsupported-clock feedback without reading private engine
+ * state.
+ */
 export interface UseTimelineMediaPlaybackResult {
   /** Whether the timeline engine is currently playing against the external clock. */
   playing: boolean;
@@ -87,11 +125,54 @@ function isPromiseLike(value: MaybePromise<void> | undefined): boolean {
 /**
  * Coordinates timeline playback with an external media clock.
  *
+ * @remarks
+ *
  * The hook is media-library agnostic. Apps provide a clock and a single layer
  * sync callback while the hook advances the TimelineEngine playhead and decides
  * when active layer clips need to be resynchronized.
  *
  * @param options - External media clock, active layer selectors, sync callback, and status callback.
+ * @template LayerName - Named media layer keys inferred from `options.layers`,
+ * such as `"visuals" | "audio"`.
+ * @returns Timeline playback state and commands backed by the external media clock.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo, useRef } from 'react';
+ * import { useTimelineMediaPlayback } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * const previewLayers = {
+ *   visuals: { trackKind: 'visual' },
+ *   audio: { trackKind: 'audio' },
+ * } as const;
+ *
+ * export function CustomClockTransport() {
+ *   const clockSecondsRef = useRef(0);
+ *   const layers = useMemo(() => previewLayers, []);
+ *   const playback = useTimelineMediaPlayback({
+ *     layers,
+ *     getClockTime: () => clockSecondsRef.current,
+ *     stopClock: () => {
+ *       clockSecondsRef.current = 0;
+ *     },
+ *     syncLayers: ({ activeLayers, reason }) => {
+ *       const visualClip = activeLayers.primary.visuals?.clip;
+ *       console.info(reason, visualClip?.id ?? 'blank frame');
+ *     },
+ *   });
+ *
+ *   return (
+ *     <button type="button" onClick={() => playback.playing ? playback.pause() : playback.play()}>
+ *       {playback.playing ? 'Pause' : 'Play'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link ActiveLayerSelector}
+ * @see {@link ActiveLayerResult}
+ * @see {@link useTimelineMediaSync}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useTimelineMediaPlayback<LayerName extends string = string>(
   options: UseTimelineMediaPlaybackOptions<LayerName>

--- a/packages/react/src/hooks/playback/useTimelineMediaSync.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaSync.ts
@@ -16,6 +16,16 @@ import type { TimelineCommandResult } from '../core/timelineCommandResult';
 
 /**
  * Adapter callbacks used to connect timeline playback to an external media clock.
+ *
+ * @remarks
+ *
+ * Implement this adapter when your media surface owns decoding, rendering, or
+ * audio scheduling. {@link useTimelineMediaSync} calls these callbacks after it
+ * resolves active clips with {@link ActiveLayerSelector} records and
+ * {@link ActiveLayerResult} snapshots.
+ *
+ * @template LayerName - Named media layer keys from your `layers` object, such
+ * as `"visuals"` or `"audio"`.
  */
 export interface TimelineMediaSyncAdapter<LayerName extends string = string> {
   /** Returns current timeline seconds from the external media clock. */
@@ -41,6 +51,16 @@ export interface TimelineMediaSyncAdapter<LayerName extends string = string> {
 
 /**
  * Options for high-level timeline media synchronization.
+ *
+ * @remarks
+ *
+ * The `layers` record names the media outputs your adapter can synchronize.
+ * Those names flow through `LayerName`, allowing `activeLayers.primary.visuals`
+ * or `activeLayers.layers.audio` to stay typed from the same object.
+ * Each value is an {@link ActiveLayerSelector} passed through active layer
+ * lookup before adapter callbacks receive an {@link ActiveLayerResult}.
+ *
+ * @template LayerName - Named media layer keys inferred from `layers`.
  */
 export interface UseTimelineMediaSyncOptions<LayerName extends string = string> {
   /** Whether the external media adapter is loaded and ready to play. */
@@ -108,6 +128,15 @@ function withCauseMessage(message: string, cause: Error | undefined) {
 
 /**
  * Result returned by `useTimelineMediaSync`.
+ *
+ * @remarks
+ *
+ * Use the commands in this result for media-aware transport controls. The
+ * `activeLayers` snapshot is useful for custom status panels, preview badges,
+ * and adapter diagnostics.
+ *
+ * @template LayerName - Named media layer keys from
+ * {@link UseTimelineMediaSyncOptions.layers}.
  */
 export interface UseTimelineMediaSyncResult<LayerName extends string = string> {
   /** Active layers at the current playhead time. */
@@ -143,11 +172,66 @@ function createPlayFailure(
 /**
  * High-level synchronization for external media surfaces.
  *
+ * @remarks
+ *
  * The hook remains media-library agnostic: apps provide an adapter for decoding,
  * rendering, and audio scheduling, while the hook handles active layer lookup,
  * first-content seeking, external-clock playback, rate changes, and pause state.
+ * It builds on {@link useTimelineMediaPlayback} for external-clock playback.
+ * For packaged adapters, prefer the higher-level HTML and Mediabunny hooks first;
+ * use this hook when you are building a custom clock or preview surface.
  *
  * @param options - External media adapter, readiness state, active layers, and callbacks.
+ * @template LayerName - Named media layer keys inferred from `options.layers`,
+ * such as `"visuals" | "audio"`.
+ * @returns Media transport state, active layer data, and synchronized playback commands.
+ *
+ * @example
+ * ```tsx
+ * import { useMemo, useRef } from 'react';
+ * import { useTimelineMediaSync } from '@techsquidtv/canvas-timeline-react';
+ *
+ * const previewLayerSelectors = {
+ *   visuals: { trackKind: 'visual', sourceId: 'source-1' },
+ *   audio: { trackKind: 'audio', sourceId: 'source-1' },
+ * } as const;
+ *
+ * export function CustomMediaPreview() {
+ *   const mediaTimeRef = useRef(0);
+ *   const layers = useMemo(() => previewLayerSelectors, []);
+ *   const mediaSync = useTimelineMediaSync({
+ *     ready: true,
+ *     layers,
+ *     adapter: {
+ *       getClockTime: () => mediaTimeRef.current,
+ *       startClock: (timelineTime, playbackRate) => {
+ *         mediaTimeRef.current = timelineTime.v / timelineTime.r;
+ *         console.info(`Start media at ${playbackRate}x`);
+ *         return true;
+ *       },
+ *       stopClock: () => {
+ *         console.info('Pause external media');
+ *       },
+ *       syncLayers: ({ activeLayers }) => {
+ *         const visualClip = activeLayers.primary.visuals?.clip;
+ *         console.info(visualClip ? `Render ${visualClip.id}` : 'No visual clip');
+ *       },
+ *     },
+ *   });
+ *
+ *   return (
+ *     <button type="button" onClick={() => void mediaSync.play()}>
+ *       {mediaSync.playing ? 'Playing' : 'Play'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link ActiveLayerSelector}
+ * @see {@link ActiveLayerResult}
+ * @see {@link useTimelineMediaPlayback}
+ * @see {@link https://canvastimeline.com/demos/media-preview-sync | Mediabunny media sync demo}
+ * @see {@link https://canvastimeline.com/demos/html-media-sync | HTML media sync demo}
  */
 export function useTimelineMediaSync<LayerName extends string = string>(
   options: UseTimelineMediaSyncOptions<LayerName>

--- a/packages/react/src/hooks/selection/useTimelineKeyboard.ts
+++ b/packages/react/src/hooks/selection/useTimelineKeyboard.ts
@@ -52,10 +52,15 @@ export type TimelineKeyboardBindings = Partial<
 
 /** Keyboard-event fields used by the pure shortcut matcher. */
 export interface TimelineKeyboardEventLike {
+  /** `KeyboardEvent.key` value from a browser event or test double. */
   key: string;
+  /** Whether Alt/Option was held. */
   altKey?: boolean;
+  /** Whether Ctrl was held. */
   ctrlKey?: boolean;
+  /** Whether Meta/Command was held. */
   metaKey?: boolean;
+  /** Whether Shift was held. */
   shiftKey?: boolean;
 }
 
@@ -120,18 +125,27 @@ const timelineKeyboardCommandOrder = [
 
 /** Minimal keyboard preset: playback only. */
 export const minimalTimelineKeyboardBindings = {
+  /** Toggle timeline playback with the spacebar. */
   togglePlayback: [{ key: 'Space' }],
 } as const satisfies TimelineKeyboardBindings;
 
 /** Professional editor preset bindings that do not depend on frame rate or platform. */
 export const professionalEditorTimelineKeyboardBindings = {
+  /** Toggle timeline playback with the spacebar. */
   togglePlayback: [{ key: 'Space' }],
+  /** Mark the current playhead time as the In point. */
   setInPoint: [{ key: 'I' }],
+  /** Mark the current playhead time as the Out point. */
   setOutPoint: [{ key: 'O' }],
+  /** Add a marker at the current playhead time. */
   addMarker: [{ key: 'M' }],
+  /** Jump to the next marker. */
   seekToNextMarker: [{ key: 'M', shiftKey: true }],
+  /** Toggle magnetic snapping. */
   toggleSnapping: [{ key: 'S' }],
+  /** Zoom the timeline viewport in. */
   zoomIn: [{ key: '=' }],
+  /** Zoom the timeline viewport out. */
   zoomOut: [{ key: '-' }],
 } as const satisfies TimelineKeyboardBindings;
 

--- a/packages/react/src/hooks/selection/useTimelineSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineSelection.ts
@@ -5,7 +5,22 @@ import { deriveTimelineSelection, type TimelineSelectionState } from '../clips/t
 
 export type { TimelineSelectionState } from '../clips/timelineClipModel';
 
-/** Result returned by `useTimelineSelection`. */
+/**
+ * Result returned by `useTimelineSelection`.
+ *
+ * @remarks
+ *
+ * The result is the shared selection model used by clip inspectors, track
+ * headers, grouping controls, clipboard commands, and edit toolbars. It
+ * includes both primary selection fields and multi-selection arrays so product
+ * chrome can avoid re-deriving selection from raw tracks.
+ *
+ * @template TrackKind - App-defined track kind values carried by selected
+ * tracks.
+ *
+ * @see {@link useTimelineClips}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
+ */
 export interface UseTimelineSelectionResult<
   TrackKind = string,
 > extends TimelineSelectionState<TrackKind> {
@@ -24,7 +39,38 @@ export interface UseTimelineSelectionResult<
 /**
  * Provides the canonical selected clip/track model for timeline editor chrome.
  *
+ * @remarks
+ *
+ * Use this hook when UI needs selection state without the broader clip command
+ * surface from {@link useTimelineClips}. It is a good fit for inspectors,
+ * selection badges, grouped-clip panels, and toolbar enablement.
+ *
  * @returns Selected clip and track state plus selection commands.
+ * @template TrackKind - App-defined track kind values carried by selected
+ * tracks.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineSelection } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function SelectionSummary() {
+ *   const selection = useTimelineSelection();
+ *
+ *   if (!selection.hasSelection) {
+ *     return <p>No selection</p>;
+ *   }
+ *
+ *   return (
+ *     <p>
+ *       {selection.selectedClipIds.length} clips selected
+ *       {selection.selectedTrack ? ` on ${selection.selectedTrack.name}` : ''}
+ *     </p>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineClips}
+ * @see {@link https://canvastimeline.com/demos/clip-grouping-import | Clip grouping import demo}
  */
 export function useTimelineSelection<TrackKind = string>(): UseTimelineSelectionResult<TrackKind> {
   const { engine, state } = useTimeline();

--- a/packages/react/src/hooks/tracks/useTimelineTrack.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrack.ts
@@ -9,7 +9,21 @@ import { useTimeline } from '../core/useTimeline';
 import { useTimelineGeometryRevision } from '../core/useTimelineGeometryRevision';
 import { useTimelineTracks } from './useTimelineTracks';
 
-/** Result returned by `useTimelineTrack`. */
+/**
+ * Result returned by `useTimelineTrack`.
+ *
+ * @remarks
+ *
+ * The result is scoped to one track row and includes both state flags and
+ * row-level commands. It also includes `rect`, which is aligned with canvas
+ * track geometry for DOM overlays, resize handles, and track header layouts.
+ *
+ * @template TrackKind - App-defined track kind value carried by the requested
+ * track.
+ *
+ * @see {@link useTimelineTrackHeader}
+ * @see {@link useTimelineTracks}
+ */
 export interface UseTimelineTrackResult<TrackKind extends string = string> {
   /** Requested track id. */
   trackId: string;
@@ -68,8 +82,37 @@ export interface UseTimelineTrackResult<TrackKind extends string = string> {
 /**
  * Accesses one timeline track with canvas-aligned row geometry and commands.
  *
+ * @remarks
+ *
+ * Use this hook when a component owns controls for one specific row: mute,
+ * visibility, lock, targeted state, grouping, or row height. It returns safe
+ * no-op failure commands when the track id is missing, so header components can
+ * remain mounted while project data changes.
+ *
  * @param trackId - Track id to read and update.
  * @param options - Optional track geometry overrides matching the renderer.
+ * @template TrackKind - App-defined track kind value carried by the requested
+ * track.
+ * @returns Track row state, canvas-aligned geometry, and row-scoped commands.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineTrack } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function TrackMuteButton({ trackId }: { trackId: string }) {
+ *   const track = useTimelineTrack(trackId);
+ *
+ *   return (
+ *     <button type="button" aria-pressed={track.muted} onClick={() => track.toggleMute()}>
+ *       {track.muted ? 'Unmute' : 'Mute'} {track.name ?? track.trackId}
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineTracks}
+ * @see {@link useTimelineTrackHeader}
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
  */
 export function useTimelineTrack<TrackKind extends string = string>(
   trackId: string,

--- a/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
@@ -11,7 +11,19 @@ import type {
 import { useTimeline } from '../core/useTimeline';
 import { useTimelineGeometryRevision } from '../core/useTimelineGeometryRevision';
 
-/** Context passed to custom clip track-drop guards. */
+/**
+ * Context passed to custom clip track-drop guards.
+ *
+ * @remarks
+ *
+ * The context contains the clip being moved, the source row captured at drag
+ * start, and the candidate target row currently under the pointer. Use it to
+ * express app policy such as visual-only tracks, audio-only tracks, locked
+ * groups, or modifier-key cross-kind moves.
+ *
+ * @template TrackKind - App-defined track kind values carried by source and
+ * target tracks.
+ */
 export interface TimelineTrackDropContext<TrackKind = string> {
   /** Clip being moved. */
   clip: Clip;
@@ -35,12 +47,29 @@ export interface TimelineTrackDropResult {
   allowCrossKindTrackMove: boolean;
 }
 
-/** Custom policy for accepting or rejecting track drop targets. */
+/**
+ * Custom policy for accepting or rejecting track drop targets.
+ *
+ * @template TrackKind - App-defined track kind values carried by source and
+ * target tracks.
+ */
 export type TimelineTrackDropGuard<TrackKind = string> = (
   context: TimelineTrackDropContext<TrackKind>
 ) => boolean | TimelineTrackDropResult;
 
-/** Options accepted by `useTimelineTrackDropTargets`. */
+/**
+ * Options accepted by `useTimelineTrackDropTargets`.
+ *
+ * @remarks
+ *
+ * Geometry options should match the renderer and interaction layer. The optional
+ * guard runs after built-in checks for missing, locked, and same-kind tracks.
+ *
+ * @template TrackKind - App-defined track kind values carried by track targets.
+ *
+ * @see {@link TimelineTrackDropGuard}
+ * @see {@link useTimelineClipDrag}
+ */
 export interface UseTimelineTrackDropTargetsOptions<
   TrackKind = string,
 > extends TimelineTrackGeometryOptions {
@@ -48,7 +77,17 @@ export interface UseTimelineTrackDropTargetsOptions<
   canDropClipOnTrack?: TimelineTrackDropGuard<TrackKind>;
 }
 
-/** Result returned by `useTimelineTrackDropTargets`. */
+/**
+ * Result returned by `useTimelineTrackDropTargets`.
+ *
+ * @remarks
+ *
+ * Use this result to build custom track-row drop previews, or indirectly through
+ * {@link useTimelineClipDrag}. `trackTargets` are viewport-space rows in
+ * timeline order and `canDropClipOnTrack` applies both engine and app policy.
+ *
+ * @template TrackKind - App-defined track kind values carried by track targets.
+ */
 export interface UseTimelineTrackDropTargetsResult<TrackKind = string> {
   /** Viewport-space track rows in timeline order. */
   trackTargets: TimelineTrackHitTestResult<TrackKind>[];
@@ -100,7 +139,41 @@ function normalizeGuardResult(
 /**
  * Builds headless track drop targets for cross-track clip movement.
  *
+ * @remarks
+ *
+ * This hook is a geometry and policy helper for custom clip drag layers. It
+ * does not start pointer capture or mutate clips on its own; combine it with
+ * {@link useTimelineClipDrag} or your own pointer lifecycle when building custom
+ * interaction chrome.
+ *
  * @param options - Track geometry and optional drop policy used to resolve compatible tracks.
+ * @template TrackKind - App-defined track kind values carried by track targets.
+ * @returns Track hit targets, viewport hit testing, and drop-policy resolution helpers.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineTrackDropTargets } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function TrackDropOverlay({ clipId }: { clipId: string }) {
+ *   const targets = useTimelineTrackDropTargets({
+ *     canDropClipOnTrack: ({ sourceTrack, targetTrack }) => sourceTrack.kind === targetTrack.kind,
+ *   });
+ *
+ *   return targets.trackTargets.map((target) => {
+ *     const result = targets.canDropClipOnTrack(clipId, target.track.id);
+ *
+ *     return (
+ *       <div key={target.track.id} data-valid-drop-target={result.canDrop}>
+ *         {target.track.name ?? target.track.id}
+ *       </div>
+ *     );
+ *   });
+ * }
+ * ```
+ *
+ * @see {@link TimelineTrackDropContext}
+ * @see {@link useTimelineClipDrag}
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
  */
 export function useTimelineTrackDropTargets<TrackKind = string>(
   options: UseTimelineTrackDropTargetsOptions<TrackKind> = {}

--- a/packages/react/src/hooks/tracks/useTimelineTrackHeader.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackHeader.ts
@@ -2,10 +2,29 @@ import type { TimelineTrackGeometryOptions } from '@techsquidtv/canvas-timeline-
 import { useMemo, type HTMLAttributes } from 'react';
 import { useTimelineTrack, type UseTimelineTrackResult } from './useTimelineTrack';
 
-/** DOM props returned for a track header row. */
+/**
+ * DOM props returned for a track header row.
+ *
+ * @remarks
+ *
+ * These props provide semantic grouping, track data attributes, disabled state,
+ * and renderer-aligned height. Spread them onto the outer header row before
+ * layering app-specific buttons or labels inside.
+ */
 export type TimelineTrackHeaderRootProps = HTMLAttributes<HTMLDivElement>;
 
-/** Result returned by `useTimelineTrackHeader`. */
+/**
+ * Result returned by `useTimelineTrackHeader`.
+ *
+ * @remarks
+ *
+ * This result extends {@link UseTimelineTrackResult} with a computed display
+ * label and DOM root props. It is the hook behind `Timeline.TrackHeader` and is
+ * useful when building custom shadcn-like header rows.
+ *
+ * @template TrackKind - App-defined track kind value carried by the requested
+ * track.
+ */
 export interface UseTimelineTrackHeaderResult<
   TrackKind extends string = string,
 > extends UseTimelineTrackResult<TrackKind> {
@@ -18,8 +37,39 @@ export interface UseTimelineTrackHeaderResult<
 /**
  * Adapts one timeline track into DOM-ready track header state.
  *
+ * @remarks
+ *
+ * Use this hook for custom track header columns that should remain aligned with
+ * canvas row geometry. It reads row state from {@link useTimelineTrack}, derives
+ * a stable label, and returns root props with data attributes for styling
+ * selected, muted, locked, visible, targeted, and collapsed states.
+ *
  * @param trackId - Track id to bind.
  * @param options - Optional track geometry overrides matching the renderer.
+ * @template TrackKind - App-defined track kind value carried by the requested
+ * track.
+ * @returns Track row state plus header label and root DOM props.
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineTrackHeader } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function CustomTrackHeader({ trackId }: { trackId: string }) {
+ *   const header = useTimelineTrackHeader(trackId);
+ *
+ *   return (
+ *     <div {...header.rootProps}>
+ *       <span>{header.label}</span>
+ *       <button type="button" aria-pressed={header.locked} onClick={() => header.toggleLock()}>
+ *         Lock
+ *       </button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link useTimelineTrack}
+ * @see {@link https://canvastimeline.com/demos/timeline-editor-controls | Timeline editor controls demo}
  */
 export function useTimelineTrackHeader<TrackKind extends string = string>(
   trackId: string,

--- a/packages/react/src/hooks/tracks/useTimelineTracks.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTracks.ts
@@ -7,7 +7,22 @@ import {
   type TimelineCommandResult,
 } from '../core/timelineCommandResult';
 
-/** Result returned by `useTimelineTracks`. */
+/**
+ * Result returned by `useTimelineTracks`.
+ *
+ * @remarks
+ *
+ * Use this result for track lists, timeline sidebars, source-bin filters, and
+ * command bars that need to inspect or mutate the ordered track collection. For
+ * one row's DOM-ready state, use {@link useTimelineTrack} or
+ * {@link useTimelineTrackHeader} instead.
+ *
+ * @template TrackKind - App-defined track kind values carried by returned
+ * tracks, such as `"visual" | "audio"`.
+ *
+ * @see {@link https://canvastimeline.com/docs/tracks-and-clips | Tracks and clips}
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
+ */
 export interface UseTimelineTracksResult<TrackKind = string> {
   /** Current ordered track list. */
   tracks: Track<TrackKind>[];
@@ -44,7 +59,58 @@ export interface UseTimelineTracksResult<TrackKind = string> {
 /**
  * Accesses and manages the list of timeline tracks.
  *
+ * @remarks
+ *
+ * `useTimelineTracks` is the broad track-domain hook. It is useful for
+ * rendering track rows, building track header columns, grouping tracks, and
+ * wiring mute/visibility/lock controls. It returns command helpers that fail
+ * with {@link TimelineCommandResult} objects instead of throwing when a track is
+ * missing.
+ *
  * @returns Track collection state and commands for selecting and updating tracks.
+ * @template TrackKind - App-defined track kind values carried by returned
+ * tracks, such as `"visual" | "audio"`.
+ *
+ * @example
+ * ```tsx
+ * import { Timeline, useTimelineTracks } from '@techsquidtv/canvas-timeline-react';
+ *
+ * export function TrackRows() {
+ *   const { tracks } = useTimelineTracks();
+ *
+ *   return (
+ *     <Timeline.TrackList>
+ *       {tracks.map((track) => (
+ *         <Timeline.Track key={track.id} trackId={track.id} />
+ *       ))}
+ *     </Timeline.TrackList>
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * import { useTimelineTracks } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function TrackVisibilityMenu() {
+ *   const { tracks, toggleVisibility } = useTimelineTracks();
+ *
+ *   return tracks.map((track) => (
+ *     <label key={track.id}>
+ *       <input
+ *         type="checkbox"
+ *         checked={track.visible}
+ *         onChange={(event) => toggleVisibility(track.id, event.currentTarget.checked)}
+ *       />
+ *       {track.name ?? track.id}
+ *     </label>
+ *   ));
+ * }
+ * ```
+ *
+ * @see {@link useTimelineTrack}
+ * @see {@link useTimelineTrackHeader}
+ * @see {@link https://canvastimeline.com/demos/timeline-editor-controls | Timeline editor controls demo}
  */
 export function useTimelineTracks<TrackKind = string>(): UseTimelineTracksResult<TrackKind> {
   const { engine, state } = useTimeline();

--- a/packages/react/src/hooks/viewport/useTimelineTimePosition.ts
+++ b/packages/react/src/hooks/viewport/useTimelineTimePosition.ts
@@ -10,7 +10,18 @@ export type TimelineTimePositionEvent =
   | 'state:settled'
   | 'history:change';
 
-/** Options for `useTimelineTimePosition`. */
+/**
+ * Options for `useTimelineTimePosition`.
+ *
+ * @remarks
+ *
+ * Use this primitive for a small number of DOM affordances that should move
+ * with timeline time without causing React renders on every scroll, scrub, or
+ * playback tick. The engine converts time to viewport X coordinates; the hook
+ * writes the transform directly to the referenced element.
+ *
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
+ */
 export interface UseTimelineTimePositionOptions {
   /** Timeline engine that converts time to viewport-space pixels. */
   engine: TimelineEngine;
@@ -22,7 +33,11 @@ export interface UseTimelineTimePositionOptions {
   positionEvents?: TimelineTimePositionEvent[];
 }
 
-/** Result returned by `useTimelineTimePosition`. */
+/**
+ * Result returned by `useTimelineTimePosition`.
+ *
+ * @template T - HTMLElement type that receives the viewport-space transform.
+ */
 export interface UseTimelineTimePositionResult<T extends HTMLElement> {
   /** Ref for the element that should be translated in viewport coordinates. */
   ref: React.RefObject<T | null>;
@@ -52,6 +67,26 @@ function parsePositionEventsKey(positionEventsKey: string): TimelineTimePosition
  *
  * @param options - Timeline engine, time value, and events that should refresh the transform.
  * @returns Ref and imperative updater for the positioned element.
+ * @template T - HTMLElement type that receives the viewport-space transform.
+ *
+ * @example
+ * ```tsx
+ * import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
+ * import { useTimeline, useTimelineTimePosition } from '@techsquidtv/canvas-timeline-react/hooks';
+ *
+ * export function MarkerHead({ markerTime }: { markerTime: RationalTime }) {
+ *   const { engine } = useTimeline();
+ *   const position = useTimelineTimePosition<HTMLDivElement>({
+ *     engine,
+ *     time: markerTime,
+ *     positionEvents: ['render', 'state:settled'],
+ *   });
+ *
+ *   return <div ref={position.ref} className="marker-head" />;
+ * }
+ * ```
+ *
+ * @see {@link https://canvastimeline.com/docs/react-hooks | React editor hooks}
  */
 export function useTimelineTimePosition<T extends HTMLElement>({
   engine,

--- a/packages/react/src/tsconfig.json
+++ b/packages/react/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/renderer/src/TimelineCanvasLayer.tsx
+++ b/packages/renderer/src/TimelineCanvasLayer.tsx
@@ -9,13 +9,58 @@ import {
   type UseTimelineCanvasLayerOptions,
 } from './useTimelineCanvasLayer';
 
-/** Props for the package custom canvas layer component. */
+/**
+ * Props for the package custom canvas layer component.
+ *
+ * @remarks
+ *
+ * These props combine ordinary canvas attributes with the same drawing options
+ * accepted by {@link useTimelineCanvasLayer}. Use the component when the layer
+ * should fill its positioned parent automatically; use the hook directly when
+ * an app owns a bespoke canvas element or layout.
+ *
+ * @template TrackKind - App-defined track kind values carried by custom draw
+ * geometry.
+ */
 export interface TimelineCanvasLayerProps<TrackKind = string>
   extends
     Omit<CanvasHTMLAttributes<HTMLCanvasElement>, 'children'>,
     UseTimelineCanvasLayerOptions<TrackKind> {}
 
-/** App-owned canvas layer for drawing custom dense timeline visuals. */
+/**
+ * App-owned canvas layer for drawing custom dense timeline visuals.
+ *
+ * @remarks
+ *
+ * `TimelineCanvasLayer` renders an absolutely positioned, pointer-transparent
+ * canvas and wires it to timeline redraws through {@link useTimelineCanvasLayer}.
+ * Place it inside the same viewport stack as the primary renderer for overlays
+ * such as waveforms, transcript highlights, loudness meters, or clip analysis
+ * bands that should stay aligned with scroll and zoom.
+ *
+ * @example
+ * ```tsx
+ * import { TimelineCanvasLayer } from '@techsquidtv/canvas-timeline-renderer';
+ *
+ * export function LoudnessOverlay() {
+ *   return (
+ *     <TimelineCanvasLayer
+ *       overscanPixels={320}
+ *       draw={({ ctx, visibleClips }) => {
+ *         ctx.fillStyle = 'rgba(245, 158, 11, 0.3)';
+ *
+ *         for (const entry of visibleClips) {
+ *           ctx.fillRect(entry.x, entry.y + entry.height - 8, entry.width, 4);
+ *         }
+ *       }}
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @see {@link UseTimelineCanvasLayerOptions}
+ * @see {@link https://canvastimeline.com/docs/renderer-customization | Canvas renderer customization}
+ */
 export const TimelineCanvasLayer = React.forwardRef<HTMLCanvasElement, TimelineCanvasLayerProps>(
   function TimelineCanvasLayer(
     {

--- a/packages/renderer/src/theme.ts
+++ b/packages/renderer/src/theme.ts
@@ -1,5 +1,7 @@
 /**
  * Makes every nested property in a type optional.
+ *
+ * @template T - Object type whose nested properties should become optional.
  */
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];

--- a/packages/renderer/src/tsconfig.json
+++ b/packages/renderer/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/renderer/src/useTimelineCanvasLayer.ts
+++ b/packages/renderer/src/useTimelineCanvasLayer.ts
@@ -50,7 +50,19 @@ export interface TimelineCanvasLayerViewport {
   visibleDurationSeconds: number;
 }
 
-/** Context passed to a custom canvas layer draw callback. */
+/**
+ * Context passed to a custom canvas layer draw callback.
+ *
+ * @remarks
+ *
+ * The context contains the current timeline snapshot plus precomputed geometry
+ * so custom layers do not need to call engine hit-test APIs during every draw.
+ * Prefer `visibleClips` and `visibleKeyframes` for dense rendering; use the
+ * full rect arrays only for overlays that truly need offscreen state.
+ *
+ * @template TrackKind - App-defined track kind values carried by clip and
+ * keyframe geometry entries.
+ */
 export interface TimelineCanvasLayerDrawContext<TrackKind = string> {
   /** Canvas 2D context scaled to CSS pixels. */
   ctx: CanvasRenderingContext2D;
@@ -80,12 +92,30 @@ export interface TimelineCanvasLayerDrawContext<TrackKind = string> {
   requestDraw: () => void;
 }
 
-/** Draw callback used by custom canvas layers. */
+/**
+ * Draw callback used by custom canvas layers.
+ *
+ * @template TrackKind - App-defined track kind values carried by draw geometry.
+ */
 export type TimelineCanvasLayerDraw<TrackKind = string> = (
   context: TimelineCanvasLayerDrawContext<TrackKind>
 ) => void;
 
-/** Options for `useTimelineCanvasLayer`. */
+/**
+ * Options for `useTimelineCanvasLayer`.
+ *
+ * @remarks
+ *
+ * Use these options for dense app-owned visuals such as waveforms, subtitles,
+ * annotations, audio peaks, thumbnail strips, or analysis overlays. Geometry
+ * options should match the primary renderer so custom drawings line up with
+ * clip and keyframe positions.
+ *
+ * @template TrackKind - App-defined track kind values carried by draw geometry.
+ *
+ * @see {@link TimelineCanvasLayerDraw}
+ * @see {@link https://canvastimeline.com/docs/renderer-customization | Canvas renderer customization}
+ */
 export interface UseTimelineCanvasLayerOptions<
   TrackKind = string,
 > extends TimelineClipGeometryOptions {
@@ -142,7 +172,35 @@ function createViewport(state: TimelineState, maxContentTime: RationalTime, widt
  *
  * @param canvasRef - Ref for the app-owned canvas element to size and draw.
  * @param options - Drawing callback, geometry overrides, and redraw behavior.
+ * @template TrackKind - App-defined track kind values carried by draw geometry.
  * @returns Imperative handle for manually scheduling redraws.
+ *
+ * @example
+ * ```tsx
+ * import { useRef } from 'react';
+ * import { useTimelineCanvasLayer } from '@techsquidtv/canvas-timeline-renderer';
+ *
+ * export function WaveformLayer() {
+ *   const canvasRef = useRef<HTMLCanvasElement>(null);
+ *
+ *   useTimelineCanvasLayer(canvasRef, {
+ *     overscanPixels: 240,
+ *     draw: ({ ctx, visibleClips }) => {
+ *       ctx.fillStyle = 'rgba(20, 184, 166, 0.35)';
+ *
+ *       for (const entry of visibleClips) {
+ *         ctx.fillRect(entry.x, entry.y + entry.height / 2, entry.width, 2);
+ *       }
+ *     },
+ *   });
+ *
+ *   return <canvas ref={canvasRef} className="timeline-custom-canvas-layer" />;
+ * }
+ * ```
+ *
+ * @see {@link TimelineCanvasLayerDrawContext}
+ * @see {@link TimelineCanvasLayer}
+ * @see {@link https://canvastimeline.com/docs/renderer-customization | Canvas renderer customization}
  */
 export function useTimelineCanvasLayer<TrackKind = string>(
   canvasRef: RefObject<HTMLCanvasElement | null>,

--- a/packages/timeline/src/tsconfig.json
+++ b/packages/timeline/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/packages/utils/src/tsconfig.json
+++ b/packages/utils/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.check.base.json"
+}

--- a/scripts/check-vite-plus-custom-rules.mjs
+++ b/scripts/check-vite-plus-custom-rules.mjs
@@ -8,12 +8,46 @@ const hookFilePattern = /\.(?:cts|mts|ts|tsx)$/;
 const camelCasePattern = /^[a-z][a-zA-Z0-9]*$/;
 const kebabCasePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const pascalCasePattern = /^[A-Z][a-zA-Z0-9]*$/;
+const curatedReactApiSpecs = [
+  {
+    file: 'packages/react/src/Provider.tsx',
+    names: ['TimelineProvider', 'TimelineProviderProps'],
+    examples: ['TimelineProvider'],
+    returns: [],
+    remarksLinks: ['TimelineProvider', 'TimelineProviderProps'],
+  },
+  {
+    file: 'packages/react/src/hooks/core/useTimelineState.ts',
+    names: ['useTimelineState'],
+    examples: ['useTimelineState'],
+    returns: ['useTimelineState'],
+    remarksLinks: ['useTimelineState'],
+  },
+  {
+    file: 'packages/react/src/hooks/playback/useTimelineMediaSync.ts',
+    names: [
+      'TimelineMediaSyncAdapter',
+      'UseTimelineMediaSyncOptions',
+      'UseTimelineMediaSyncResult',
+      'useTimelineMediaSync',
+    ],
+    examples: ['useTimelineMediaSync'],
+    returns: ['useTimelineMediaSync'],
+    remarksLinks: [
+      'TimelineMediaSyncAdapter',
+      'UseTimelineMediaSyncOptions',
+      'useTimelineMediaSync',
+    ],
+  },
+];
 
 const files = execFileSync('git', ['ls-files'], { encoding: 'utf8' })
   .split('\n')
   .filter((file) => file.length > 0 && existsSync(file));
 
 const failures = [];
+
+runTsdocQualitySelfTest();
 
 for (const file of files) {
   if (!sourceFilePattern.test(file)) {
@@ -45,6 +79,24 @@ for (const file of files) {
   checkHookGrouping(sourceFile, sourceFile);
 }
 
+for (const spec of curatedReactApiSpecs) {
+  if (!existsSync(spec.file)) {
+    failures.push(`${spec.file}: curated React API TSDoc file is missing`);
+    continue;
+  }
+
+  const sourceText = readFileSync(spec.file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    spec.file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    spec.file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  checkCuratedApiTsdoc(sourceFile, spec, failures);
+}
+
 if (failures.length > 0) {
   console.error(failures.join('\n'));
   process.exit(1);
@@ -73,6 +125,282 @@ function checkHookGrouping(node, sourceFile) {
   }
 
   ts.forEachChild(node, (child) => checkHookGrouping(child, sourceFile));
+}
+
+function runTsdocQualitySelfTest() {
+  const passingSource = `
+/**
+ * Reads a value.
+ *
+ * @remarks
+ * See {@link OtherValue} before using this hook.
+ *
+ * @param input - Value to read.
+ * @template Value - Value type.
+ * @returns The current value.
+ *
+ * @example
+ * \`\`\`ts
+ * useGoodHook('id');
+ * \`\`\`
+ */
+export function useGoodHook<Value>(input: string): Value {
+  throw new Error(input);
+}
+`;
+  const failingSource = `
+/** Reads a value. */
+export function useBadHook<Value>(input: string): Value {
+  throw new Error(input);
+}
+`;
+  const passingFailures = [];
+  const failingFailures = [];
+  const passingFile = ts.createSourceFile(
+    'virtual-passing.ts',
+    passingSource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const failingFile = ts.createSourceFile(
+    'virtual-failing.ts',
+    failingSource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
+  checkCuratedApiTsdoc(
+    passingFile,
+    {
+      file: 'virtual-passing.ts',
+      names: ['useGoodHook'],
+      examples: ['useGoodHook'],
+      returns: ['useGoodHook'],
+      remarksLinks: ['useGoodHook'],
+    },
+    passingFailures
+  );
+  checkCuratedApiTsdoc(
+    failingFile,
+    {
+      file: 'virtual-failing.ts',
+      names: ['useBadHook'],
+      examples: ['useBadHook'],
+      returns: ['useBadHook'],
+      remarksLinks: ['useBadHook'],
+    },
+    failingFailures
+  );
+
+  if (passingFailures.length > 0) {
+    throw new Error(`TSDoc quality self-test should pass:\n${passingFailures.join('\n')}`);
+  }
+
+  if (
+    !failingFailures.some((failure) => failure.includes('@remarks')) ||
+    !failingFailures.some((failure) => failure.includes('@example')) ||
+    !failingFailures.some((failure) => failure.includes('@returns')) ||
+    !failingFailures.some((failure) => failure.includes('@param input')) ||
+    !failingFailures.some((failure) => failure.includes('@template Value'))
+  ) {
+    throw new Error(`TSDoc quality self-test did not catch expected failures.`);
+  }
+}
+
+function checkCuratedApiTsdoc(sourceFile, spec, outputFailures) {
+  const declarations = collectExportedDeclarations(sourceFile);
+
+  for (const name of spec.names) {
+    const declaration = declarations.get(name);
+
+    if (!declaration) {
+      outputFailures.push(`${spec.file}: missing exported API declaration ${name}`);
+      continue;
+    }
+
+    const tsdoc = tsdocForNode(declaration, sourceFile);
+
+    if (!tsdoc) {
+      outputFailures.push(`${spec.file}: ${name} must have a TSDoc block`);
+      continue;
+    }
+
+    if (!hasSummaryText(tsdoc)) {
+      outputFailures.push(`${spec.file}: ${name} must have a TSDoc summary`);
+    }
+
+    if (!tagText(tsdoc, 'remarks')) {
+      outputFailures.push(`${spec.file}: ${name} must include @remarks`);
+    }
+
+    if (spec.remarksLinks.includes(name) && !/\{@link\s+[^}]+\}/.test(tagText(tsdoc, 'remarks'))) {
+      outputFailures.push(`${spec.file}: ${name} @remarks must include a {@link ...} reference`);
+    }
+
+    if (spec.examples.includes(name) && !hasTag(tsdoc, 'example')) {
+      outputFailures.push(`${spec.file}: ${name} must include @example`);
+    }
+
+    if (spec.returns.includes(name) && !hasTag(tsdoc, 'returns')) {
+      outputFailures.push(`${spec.file}: ${name} must include @returns`);
+    }
+
+    checkParameters(sourceFile, spec.file, name, declaration, tsdoc, outputFailures);
+    checkTypeParameters(sourceFile, spec.file, name, declaration, tsdoc, outputFailures);
+    checkInterfaceMembers(sourceFile, spec.file, name, declaration, outputFailures);
+  }
+}
+
+function collectExportedDeclarations(sourceFile) {
+  const declarations = new Map();
+
+  for (const statement of sourceFile.statements) {
+    if (!isExportedStatement(statement)) {
+      continue;
+    }
+
+    const declaration = ts.isExportDeclaration(statement) ? undefined : statement;
+    const name = declarationName(declaration);
+
+    if (name && declaration) {
+      declarations.set(name, declaration);
+    }
+  }
+
+  return declarations;
+}
+
+function declarationName(node) {
+  if (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isClassDeclaration(node)) &&
+    node.name
+  ) {
+    return node.name.text;
+  }
+
+  return undefined;
+}
+
+function isExportedStatement(statement) {
+  return Boolean(
+    statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+  );
+}
+
+function tsdocForNode(node, sourceFile) {
+  const jsDocs = node.jsDoc ?? [];
+  const jsDoc = jsDocs.at(-1);
+
+  if (!jsDoc) {
+    return undefined;
+  }
+
+  return jsDoc.getFullText(sourceFile);
+}
+
+function hasSummaryText(tsdoc) {
+  const withoutDelimiters = tsdoc
+    .replace(/^\/\*\*/, '')
+    .replace(/\*\/$/, '')
+    .split('\n')
+    .map((line) => line.replace(/^\s*\* ?/, ''))
+    .join('\n');
+  const summary = withoutDelimiters.split(/\n\s*@/)[0]?.trim() ?? '';
+
+  return summary.length > 0;
+}
+
+function hasTag(tsdoc, tagName) {
+  return new RegExp(`@${tagName}\\b`).test(tsdoc);
+}
+
+function tagText(tsdoc, tagName) {
+  const match = tsdoc.match(
+    new RegExp(`@${tagName}\\b([\\s\\S]*?)(?=\\n\\s*\\*\\s*@|\\n\\s*@|\\*\\/)`)
+  );
+
+  return match?.[1]?.trim() ?? '';
+}
+
+function checkParameters(sourceFile, file, name, declaration, tsdoc, outputFailures) {
+  if (!ts.isFunctionDeclaration(declaration)) {
+    return;
+  }
+
+  for (const parameter of declaration.parameters) {
+    if (!ts.isIdentifier(parameter.name)) {
+      continue;
+    }
+
+    const parameterName = parameter.name.text;
+    const tag = tagText(tsdoc, 'param');
+    const hasParam = new RegExp(
+      `@param\\s+${escapeRegExp(parameterName)}\\b[\\s\\S]*?-\\s+\\S`
+    ).test(tsdoc);
+
+    if (!hasParam) {
+      outputFailures.push(`${file}: ${name} must document @param ${parameterName}`);
+    }
+
+    if (tag.length === 0) {
+      const position = sourceFile.getLineAndCharacterOfPosition(parameter.getStart(sourceFile));
+      outputFailures.push(
+        `${file}:${position.line + 1}:${position.character + 1}: ${name} @param ${parameterName} is empty`
+      );
+    }
+  }
+}
+
+function checkTypeParameters(sourceFile, file, name, declaration, tsdoc, outputFailures) {
+  const typeParameters = declaration.typeParameters ?? [];
+
+  for (const typeParameter of typeParameters) {
+    const typeParameterName = typeParameter.name.text;
+    const hasTemplate = new RegExp(
+      `@(template|typeParam)\\s+${escapeRegExp(typeParameterName)}\\b[\\s\\S]*?-\\s+\\S`
+    ).test(tsdoc);
+
+    if (!hasTemplate) {
+      const position = sourceFile.getLineAndCharacterOfPosition(
+        typeParameter.name.getStart(sourceFile)
+      );
+      outputFailures.push(
+        `${file}:${position.line + 1}:${position.character + 1}: ${name} must document @template ${typeParameterName}`
+      );
+    }
+  }
+}
+
+function checkInterfaceMembers(sourceFile, file, name, declaration, outputFailures) {
+  if (!ts.isInterfaceDeclaration(declaration)) {
+    return;
+  }
+
+  for (const member of declaration.members) {
+    const memberName = member.name?.getText(sourceFile);
+
+    if (!memberName) {
+      continue;
+    }
+
+    const tsdoc = tsdocForNode(member, sourceFile);
+
+    if (!tsdoc || !hasSummaryText(tsdoc)) {
+      const position = sourceFile.getLineAndCharacterOfPosition(member.getStart(sourceFile));
+      outputFailures.push(
+        `${file}:${position.line + 1}:${position.character + 1}: ${name}.${memberName} must have a TSDoc summary`
+      );
+    }
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isHookStatement(statement) {

--- a/scripts/check-vite-plus-custom-rules.mjs
+++ b/scripts/check-vite-plus-custom-rules.mjs
@@ -231,11 +231,13 @@ function checkCuratedApiTsdoc(sourceFile, spec, outputFailures) {
       outputFailures.push(`${spec.file}: ${name} must have a TSDoc summary`);
     }
 
-    if (!tagText(tsdoc, 'remarks')) {
+    const remarks = tagText(tsdoc, 'remarks');
+
+    if (!remarks) {
       outputFailures.push(`${spec.file}: ${name} must include @remarks`);
     }
 
-    if (spec.remarksLinks.includes(name) && !/\{@link\s+[^}]+\}/.test(tagText(tsdoc, 'remarks'))) {
+    if (spec.remarksLinks.includes(name) && remarks && !/\{@link\s+[^}]+\}/.test(remarks)) {
       outputFailures.push(`${spec.file}: ${name} @remarks must include a {@link ...} reference`);
     }
 
@@ -338,16 +340,19 @@ function checkParameters(sourceFile, file, name, declaration, tsdoc, outputFailu
     }
 
     const parameterName = parameter.name.text;
-    const tag = tagText(tsdoc, 'param');
-    const hasParam = new RegExp(
-      `@param\\s+${escapeRegExp(parameterName)}\\b[\\s\\S]*?-\\s+\\S`
-    ).test(tsdoc);
+    const paramBlock = tsdoc.match(
+      new RegExp(
+        `@param\\s+${escapeRegExp(parameterName)}\\b([\\s\\S]*?)(?=\\n\\s*\\*\\s*@|\\n\\s*@|\\*\\/)`
+      )
+    );
+    const paramText = paramBlock?.[1]?.trim() ?? '';
+    const hasDescription = /-\s+\S/.test(paramText);
 
-    if (!hasParam) {
+    if (!paramBlock) {
       outputFailures.push(`${file}: ${name} must document @param ${parameterName}`);
     }
 
-    if (tag.length === 0) {
+    if (paramBlock && !hasDescription) {
       const position = sourceFile.getLineAndCharacterOfPosition(parameter.getStart(sourceFile));
       outputFailures.push(
         `${file}:${position.line + 1}:${position.character + 1}: ${name} @param ${parameterName} is empty`

--- a/tools/oxlint-plugin-canvas-timeline.mjs
+++ b/tools/oxlint-plugin-canvas-timeline.mjs
@@ -313,7 +313,7 @@ function checkReactApiDeclaration(context, options, node) {
     reportTsdoc(context, node, 'missingRemarks', { name });
   }
 
-  if (options.remarksLinkNames.includes(name) && !/\{@link\s+[^}]+\}/.test(remarks)) {
+  if (options.remarksLinkNames.includes(name) && remarks && !/\{@link\s+[^}]+\}/.test(remarks)) {
     reportTsdoc(context, node, 'missingRemarksLink', { name });
   }
 

--- a/tools/oxlint-plugin-canvas-timeline.mjs
+++ b/tools/oxlint-plugin-canvas-timeline.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 const defaultOptions = {
   maxImplementationExports: 12,
   maxDomainBarrelExports: 30,
@@ -5,6 +7,27 @@ const defaultOptions = {
   checkPatterns: ['(^|/)packages/'],
   allowFiles: [],
   allowPatterns: [],
+};
+const reactApiTsdocDefaultOptions = {
+  requiredNames: [
+    'TimelineProvider',
+    'TimelineProviderProps',
+    'TimelineMediaSyncAdapter',
+    'UseTimelineMediaSyncOptions',
+    'UseTimelineMediaSyncResult',
+    'useTimelineMediaSync',
+    'useTimelineState',
+  ],
+  exampleNames: ['TimelineProvider', 'useTimelineMediaSync', 'useTimelineState'],
+  returnNames: ['useTimelineMediaSync', 'useTimelineState'],
+  remarksLinkNames: [
+    'TimelineProvider',
+    'TimelineProviderProps',
+    'TimelineMediaSyncAdapter',
+    'UseTimelineMediaSyncOptions',
+    'useTimelineMediaSync',
+    'useTimelineState',
+  ],
 };
 
 const exportCountingRule = {
@@ -150,12 +173,99 @@ const exportCountingRule = {
   },
 };
 
+const reactApiTsdocRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require useful TSDoc on curated public React API declarations, including examples and inline links.',
+      recommended: false,
+    },
+    defaultOptions: [reactApiTsdocDefaultOptions],
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          requiredNames: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          exampleNames: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          returnNames: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          remarksLinkNames: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      },
+    ],
+    messages: {
+      missingDoc: '{{name}} must have a TSDoc block.',
+      missingSummary: '{{name}} must have a TSDoc summary.',
+      missingRemarks: '{{name}} must include @remarks.',
+      missingRemarksLink: '{{name}} @remarks must include a {@link ...} reference.',
+      missingExample: '{{name}} must include @example.',
+      missingReturn: '{{name}} must include @returns.',
+      missingParam: '{{name}} must document @param {{param}}.',
+      missingTemplate: '{{name}} must document @template {{param}}.',
+      missingMemberDoc: '{{name}}.{{member}} must have a TSDoc summary.',
+    },
+  },
+  createOnce(context) {
+    const options = normalizeReactApiTsdocOptions(context.options?.[0]);
+    let checkedNames = new Set();
+
+    function check(node) {
+      const name = declarationName(node);
+      if (name && checkedNames.has(name)) {
+        return;
+      }
+      if (name) {
+        checkedNames.add(name);
+      }
+      checkReactApiDeclaration(context, options, node);
+    }
+
+    return {
+      before() {
+        checkedNames = new Set();
+      },
+      ExportNamedDeclaration(node) {
+        check(node.declaration ?? node);
+      },
+      FunctionDeclaration(node) {
+        if (isExportedNode(node)) {
+          check(node);
+        }
+      },
+      TSInterfaceDeclaration(node) {
+        if (isExportedNode(node)) {
+          check(node);
+        }
+      },
+      TSTypeAliasDeclaration(node) {
+        if (isExportedNode(node)) {
+          check(node);
+        }
+      },
+    };
+  },
+};
+
 export default {
   meta: {
     name: 'canvas-timeline',
   },
   rules: {
     'max-exports-per-module': exportCountingRule,
+    'react-api-tsdoc': reactApiTsdocRule,
   },
 };
 
@@ -167,6 +277,170 @@ function normalizeOptions(rawOptions) {
     allowFiles: rawOptions?.allowFiles ?? defaultOptions.allowFiles,
     allowPatterns: rawOptions?.allowPatterns ?? defaultOptions.allowPatterns,
   };
+}
+
+function normalizeReactApiTsdocOptions(rawOptions) {
+  return {
+    ...reactApiTsdocDefaultOptions,
+    ...rawOptions,
+    requiredNames: rawOptions?.requiredNames ?? reactApiTsdocDefaultOptions.requiredNames,
+    exampleNames: rawOptions?.exampleNames ?? reactApiTsdocDefaultOptions.exampleNames,
+    returnNames: rawOptions?.returnNames ?? reactApiTsdocDefaultOptions.returnNames,
+    remarksLinkNames: rawOptions?.remarksLinkNames ?? reactApiTsdocDefaultOptions.remarksLinkNames,
+  };
+}
+
+function checkReactApiDeclaration(context, options, node) {
+  const name = declarationName(node);
+
+  if (!name || !options.requiredNames.includes(name)) {
+    return;
+  }
+
+  const doc = tsdocForNode(context, node);
+
+  if (!doc) {
+    reportTsdoc(context, node, 'missingDoc', { name });
+    return;
+  }
+
+  if (!hasSummaryText(doc)) {
+    reportTsdoc(context, node, 'missingSummary', { name });
+  }
+
+  const remarks = tagText(doc, 'remarks');
+  if (!remarks) {
+    reportTsdoc(context, node, 'missingRemarks', { name });
+  }
+
+  if (options.remarksLinkNames.includes(name) && !/\{@link\s+[^}]+\}/.test(remarks)) {
+    reportTsdoc(context, node, 'missingRemarksLink', { name });
+  }
+
+  if (options.exampleNames.includes(name) && !hasTag(doc, 'example')) {
+    reportTsdoc(context, node, 'missingExample', { name });
+  }
+
+  if (options.returnNames.includes(name) && !hasTag(doc, 'returns')) {
+    reportTsdoc(context, node, 'missingReturn', { name });
+  }
+
+  for (const param of functionParameterNames(node)) {
+    if (!new RegExp(`@param\\s+${escapeRegExp(param)}\\b[\\s\\S]*?-\\s+\\S`).test(doc)) {
+      reportTsdoc(context, node, 'missingParam', { name, param });
+    }
+  }
+
+  for (const param of typeParameterNames(node)) {
+    if (
+      !new RegExp(`@(template|typeParam)\\s+${escapeRegExp(param)}\\b[\\s\\S]*?-\\s+\\S`).test(doc)
+    ) {
+      reportTsdoc(context, node, 'missingTemplate', { name, param });
+    }
+  }
+}
+
+function reportTsdoc(context, node, messageId, data) {
+  context.report({
+    node,
+    messageId,
+    data,
+  });
+}
+
+function declarationName(node) {
+  return node?.id?.name ?? node?.name?.name ?? node?.name ?? undefined;
+}
+
+function isExportedNode(node) {
+  return node.modifiers?.some((modifier) => modifier.type === 'ExportKeyword') ?? false;
+}
+
+function tsdocForNode(context, node) {
+  const name = declarationName(node);
+
+  if (name && context.filename) {
+    const scannedDoc = tsdocForDeclaration(context.filename, name);
+
+    if (scannedDoc) {
+      return scannedDoc;
+    }
+  }
+
+  const comments =
+    context.sourceCode?.getCommentsBefore?.(node) ??
+    context.getSourceCode?.().getCommentsBefore?.(node) ??
+    node.leadingComments ??
+    [];
+  const comment = comments
+    .filter((candidate) => candidate.type === 'Block' || candidate.type === 'BlockComment')
+    .at(-1);
+  const text = comment?.value ?? comment?.text;
+
+  if (typeof text === 'string') {
+    return text;
+  }
+
+  return undefined;
+}
+
+function tsdocForDeclaration(fileName, name) {
+  try {
+    const source = readFileSync(fileName, 'utf8');
+    const escapedName = escapeRegExp(name);
+    const declarationMatch = source.match(
+      new RegExp(`export\\s+(?:async\\s+)?(?:function|interface|type|class)\\s+${escapedName}\\b`)
+    );
+
+    if (declarationMatch?.index === undefined) {
+      return undefined;
+    }
+
+    const beforeDeclaration = source.slice(0, declarationMatch.index);
+
+    return beforeDeclaration.match(/\/\*\*[\s\S]*?\*\/\s*$/)?.[0];
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSummaryText(doc) {
+  return (
+    doc
+      .split(/\n\s*\*\s*@/)[0]
+      ?.replaceAll('*', '')
+      .trim().length > 0
+  );
+}
+
+function hasTag(doc, tagName) {
+  return new RegExp(`@${tagName}\\b`).test(doc);
+}
+
+function tagText(doc, tagName) {
+  const match = doc.match(new RegExp(`@${tagName}\\b([\\s\\S]*?)(?=\\n\\s*\\*\\s*@|\\n\\s*@|$)`));
+
+  return match?.[1]?.trim() ?? '';
+}
+
+function functionParameterNames(node) {
+  if (node.type !== 'FunctionDeclaration') {
+    return [];
+  }
+
+  return (node.params ?? [])
+    .map((param) => param.name ?? param.argument?.name)
+    .filter((name) => typeof name === 'string');
+}
+
+function typeParameterNames(node) {
+  return (node.typeParameters?.params ?? node.typeParameters?.items ?? [])
+    .map((param) => param.name?.name ?? param.name)
+    .filter((name) => typeof name === 'string');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function shouldCheckFile(fileName, options) {

--- a/tsconfig.check.base.json
+++ b/tsconfig.check.base.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["packages/**/*.ts", "packages/**/*.tsx", "test-utils/**/*.ts"],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -344,6 +344,7 @@ export default defineConfig({
               ],
             },
           ],
+          'canvas-timeline/react-api-tsdoc': 'error',
           'typescript/ban-ts-comment': [
             'error',
             {


### PR DESCRIPTION
## Summary

- Expand public API TSDoc across React hooks, provider APIs, core events/state, renderer helpers, and media adapters with links, remarks, examples, and generic descriptions.
- Teach generated API docs and copied Markdown to preserve inline {@link ...} references as usable links.
- Add targeted custom-rule and docs-generation validation so missing summaries, examples, links, params, returns, and type parameter descriptions are caught before shipping.
- Add checker tsconfigs so type-aware lint covers package tests through workspace aliases.

## Release Impact

- Packages/API: Documentation-only public package surface improvements; no runtime package behavior change and no version bump.
- Docs/demos: API reference rendering and copied Markdown output are improved.
- Breaking changes: None in runtime/API behavior.
- Checklist areas reviewed: 1, 2, 3, 6, 8.

## Validation

- vp check
- vp exec changeset status --since=origin/main
- printf '%s\n' 'docs: improve React API TSDoc enforcement' | vp exec commitlint --verbose