### PR TITLE
docs(www): update sponsor account

### DIFF
--- a/.changeset/update-sponsor-account.md
+++ b/.changeset/update-sponsor-account.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update Canvas Timeline sponsor links and sponsor sync configuration to use the KyleTryon GitHub Sponsors account.

--- a/apps/www/src/data/site.ts
+++ b/apps/www/src/data/site.ts
@@ -104,8 +104,8 @@ const packageResources = {
 
 const sponsorship = {
   label: 'Sponsor Canvas Timeline',
-  href: 'https://github.com/sponsors/techsquidtv',
-  accountLogin: 'techsquidtv',
+  href: 'https://github.com/sponsors/KyleTryon',
+  accountLogin: 'KyleTryon',
   projectName: 'Canvas Timeline',
   tiers: [
     {


### PR DESCRIPTION
## Summary

- Point Canvas Timeline sponsorship links to `https://github.com/sponsors/KyleTryon`.
- Update the sponsor sync account login to `KyleTryon`.
- Add an empty changeset for the required Changeset status check.

## Release Impact

- Packages/API: None.
- Docs/demos: Updates docs-site sponsor navigation, sponsor band, structured data, and sponsor sync target through shared site data.
- Breaking changes: None.
- Checklist areas reviewed: 0, 3, 7, 8.

## Validation

- `rg -n "sponsors/techsquidtv|sponsors/TechSquidTV|accountLogin: 'techsquidtv'|accountLogin: 'TechSquidTV'" -S .` returned no matches.\n- `vp check`\n- `vp run --filter @techsquidtv/canvas-timeline-www docs:links`\n- `vp run ci` via pre-push hook