### PR TITLE
docs: humanize package pages

### DIFF
--- a/.changeset/humanize-package-docs.md
+++ b/.changeset/humanize-package-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Humanize package landing pages, tighten the Mediabunny adapter docs, and keep the docs demo copy aligned with the recommended media setup path.

--- a/apps/www/src/content/docs/react-hooks.mdx
+++ b/apps/www/src/content/docs/react-hooks.mdx
@@ -6,7 +6,7 @@ order: 25
 ---
 
 The React package exposes hooks for binding product chrome, interaction layers,
-media preview surfaces, and accessible controls to a shared `TimelineEngine`.
+media monitors, and accessible controls to a shared `TimelineEngine`.
 This page explains how to choose timeline hooks imported from
 `@techsquidtv/canvas-timeline-react/hooks`; the maintained catalog lives in the
 [React registry Hook groups](/packages/react/registry#hook-groups), with

--- a/apps/www/src/data/packages.ts
+++ b/apps/www/src/data/packages.ts
@@ -1,13 +1,15 @@
 import { packageResourceLinks } from './site';
 
-interface PackageExport {
-  path: string;
-  description: string;
+interface PackageExample {
+  title: string;
+  code: string;
+  lang?: string;
 }
 
-interface PackageImportExample {
-  label: string;
-  code: string;
+interface PackageUsage {
+  title: string;
+  body: string;
+  steps: string[];
 }
 
 interface PackageLink {
@@ -16,21 +18,9 @@ interface PackageLink {
   description?: string;
 }
 
-interface PackageSourceLink {
-  label: string;
-  href: string;
-}
-
-interface PackageDescriptionLink {
-  label: string;
-  href: string;
-}
-
-interface PackageIntegrationGuide {
-  mentalModel: string;
-  steps: string[];
-  example: PackageImportExample;
-  demoNotes: string[];
+interface PackageLinkGroup {
+  title: string;
+  links: PackageLink[];
 }
 
 export interface PackageDoc {
@@ -39,16 +29,23 @@ export interface PackageDoc {
   shortName: string;
   purpose: string;
   description: string;
-  descriptionLinks?: PackageDescriptionLink[];
   installCommand: string;
-  sourceLinks: PackageSourceLink[];
-  whenToUse: string[];
-  commonImports: PackageImportExample[];
-  usageNotes: string[];
-  integrationGuide?: PackageIntegrationGuide;
-  exports: PackageExport[];
-  relatedGuides: PackageLink[];
-  nextSteps: PackageLink[];
+  overview: string[];
+  useCasesTitle?: string;
+  useCases?: string[];
+  usage: PackageUsage;
+  example: PackageExample;
+  linkGroups: PackageLinkGroup[];
+}
+
+function packageLinks(slug: Parameters<typeof packageResourceLinks>[0]): PackageLinkGroup {
+  return {
+    title: 'Package links',
+    links: packageResourceLinks(slug).map((link) => ({
+      title: link.label,
+      href: link.href,
+    })),
+  };
 }
 
 export const packageDocs: PackageDoc[] = [
@@ -60,76 +57,65 @@ export const packageDocs: PackageDoc[] = [
     description:
       'Start here when you want the common Canvas Timeline experience without choosing lower-level package boundaries up front.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline',
-    sourceLinks: packageResourceLinks('timeline'),
-    whenToUse: [
-      'You are building a standard React timeline editor and want a toolkit-oriented starter experience.',
-      'You prefer importing the core engine, state managers, DOM interaction controls, and canvas renderers from a single wrapper package.',
-      'You want one import path before splitting your integration across focused package entrypoints.',
+    overview: [
+      'The main package is the easiest way to start a Canvas Timeline editor. It re-exports the core engine, React bindings, renderer, and time utilities from one dependency so early app code can stay focused on the editor experience.',
+      'As your project grows, you can keep using this package or switch individual imports to the focused packages below. The runtime pieces are the same; the split package paths are there when you want sharper ownership boundaries.',
     ],
-    commonImports: [
-      {
-        label: 'Common editor path',
-        code: `import {
+    useCasesTitle: 'Start here when',
+    useCases: [
+      'You are building a React timeline editor and want the common engine, UI bindings, renderer, and utilities together.',
+      'You want one install path while you are still proving out the editor shape.',
+      'You expect to use the default React interaction chrome and canvas renderer.',
+    ],
+    usage: {
+      title: 'Start with the assembled editor surface',
+      body: 'Create a `TimelineEngine`, provide it with `TimelineProvider`, render the canvas with `CanvasRenderer`, and layer the React interaction components above it. Import `styles.css` when you want the packaged structural CSS plus the default token-driven chrome.',
+      steps: [
+        'Create the engine with your initial tracks, clips, markers, and duration.',
+        'Wrap the editor UI in `TimelineProvider`.',
+        'Render `Timeline.Root`, `CanvasRenderer`, and the timeline interaction components your product needs.',
+        'Import `@techsquidtv/canvas-timeline/styles.css` once in the app entry or demo source.',
+      ],
+    },
+    example: {
+      title: 'Minimal editor setup',
+      lang: 'tsx',
+      code: `import {
   CanvasRenderer,
   Timeline,
   TimelineEngine,
   TimelineProvider,
   fromSeconds,
-} from '@techsquidtv/canvas-timeline';`,
-      },
+} from '@techsquidtv/canvas-timeline';
+import '@techsquidtv/canvas-timeline/styles.css';
+
+const engine = new TimelineEngine({
+  duration: fromSeconds(30),
+  tracks: [],
+});
+
+export function Editor() {
+  return (
+    <TimelineProvider engine={engine}>
+      <Timeline.Root>
+        <CanvasRenderer />
+        <Timeline.PlayheadArea />
+        <Timeline.PlayheadGrabber />
+        <Timeline.ClipInteractionLayer />
+      </Timeline.Root>
+    </TimelineProvider>
+  );
+}`,
+    },
+    linkGroups: [
       {
-        label: 'Shadcn-compatible styles',
-        code: `import '@techsquidtv/canvas-timeline/styles.css';`,
+        title: 'Keep reading',
+        links: [
+          { title: 'Getting started', href: '/docs/getting-started' },
+          { title: 'Packages overview', href: '/docs/packages-overview' },
+        ],
       },
-      {
-        label: 'Headless styling path',
-        code: `import '@techsquidtv/canvas-timeline/base.css';`,
-      },
-      {
-        label: 'Focused subpath imports',
-        code: `import { TimelineEngine } from '@techsquidtv/canvas-timeline/core';
-import { TimelineProvider } from '@techsquidtv/canvas-timeline/react';
-import { CanvasRenderer } from '@techsquidtv/canvas-timeline/renderer';`,
-      },
-    ],
-    usageNotes: [
-      'Provides a single toolkit entry point containing core, React, renderer, and utils APIs, simplifying initial installation and setup.',
-      'Supports subpath imports (e.g., `@techsquidtv/canvas-timeline/core`) to allow incremental refinement toward focused package boundaries without modifying dependencies.',
-      'Use `styles.css` when your app defines shadcn-compatible semantic tokens; it themes the reusable timeline surface, interaction chrome, scrollbars, and optional shell/control utilities while product chrome remains application CSS.',
-    ],
-    exports: [
-      { path: '.', description: 'Common public APIs from core, React, renderer, and utils.' },
-      { path: './core', description: 'Core state and editing engine re-exports.' },
-      { path: './react', description: 'React provider, hooks, and components re-exports.' },
-      {
-        path: './html-media',
-        description: 'Native single-element HTML media/audio timeline media adapter re-export.',
-      },
-      { path: './renderer', description: 'Canvas renderer and theme re-exports.' },
-      { path: './utils', description: 'Rational time and shared math re-exports.' },
-      {
-        path: './base.css',
-        description: 'Structural interaction geometry without default visuals.',
-      },
-      {
-        path: './theme.css',
-        description: 'Shadcn-token-driven visual theme for interaction chrome and timeline tokens.',
-      },
-      {
-        path: './styles.css',
-        description: 'Structural styles plus shadcn-compatible interaction chrome.',
-      },
-    ],
-    relatedGuides: [
-      { title: 'Getting started', href: '/docs/getting-started' },
-      { title: 'Packages overview', href: '/docs/packages-overview' },
-    ],
-    nextSteps: [
-      {
-        title: 'Generated API reference',
-        href: '/packages/timeline/api',
-        description: 'Review exported symbols and re-exported package surfaces.',
-      },
+      packageLinks('timeline'),
     ],
   },
   {
@@ -140,25 +126,33 @@ import { CanvasRenderer } from '@techsquidtv/canvas-timeline/renderer';`,
     description:
       'Use the core package when your integration needs the timeline model and editing operations without React or canvas rendering concerns.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-core',
-    sourceLinks: packageResourceLinks('core'),
-    whenToUse: [
-      'You are building a timeline in a non-React environment (e.g., Vue, Svelte, or native platforms) and need to own rendering yourself.',
-      'You want a clean, framework-agnostic engine to manage track models, edit history, snapping, and clipboard operations.',
-      'You need to write fast, isolated unit tests around timeline business logic without loading browser DOM elements or UI chrome.',
+    overview: [
+      'The core package is the timeline model and editor brain without a view layer. It owns tracks, clips, markers, selections, edits, playback state, snapping, history, and active-content queries.',
+      'Use it directly when React is not the right boundary, or when you want tests and non-visual logic to run without pulling in DOM components.',
     ],
-    commonImports: [
-      {
-        label: 'Engine and state types',
-        code: `import {
-  TimelineEngine,
-  type TimelineEditCommand,
-  type TimelineState,
-  type Track,
-} from '@techsquidtv/canvas-timeline-core';`,
-      },
-      {
-        label: 'Typed edit commands',
-        code: `import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+    useCasesTitle: 'Reach for core when',
+    useCases: [
+      'You are building a timeline in another UI framework or platform.',
+      'You want isolated tests for edits, snapping, history, or playback behavior.',
+      'You need to keep timeline state serializable and separate from app-owned media metadata.',
+    ],
+    usage: {
+      title: 'Own the model, bring your own UI',
+      body: 'Instantiate `TimelineEngine` with plain timeline data, then call engine commands from your UI or service layer. Keep media URLs, files, waveforms, and transcripts in application storage keyed by stable ids such as `clip.sourceId`.',
+      steps: [
+        'Represent all times as `RationalTime` values, usually created with helpers from `@techsquidtv/canvas-timeline-utils`.',
+        'Use stable ids for tracks and clips; do not derive ids from array positions.',
+        'Use engine commands to preview, commit, cancel, undo, and redo edits.',
+        'Subscribe to engine events when your UI needs to react to state changes.',
+      ],
+    },
+    example: {
+      title: 'Preview and commit an edit',
+      lang: 'ts',
+      code: `import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+
+const engine = new TimelineEngine({ tracks: [] });
 
 const preview = engine.previewEdit({
   type: 'move',
@@ -169,38 +163,16 @@ const preview = engine.previewEdit({
 if (preview.valid) {
   engine.commitEdit(preview.command);
 }`,
-      },
+    },
+    linkGroups: [
       {
-        label: 'Snapping helpers',
-        code: `import { SnapIndex } from '@techsquidtv/canvas-timeline-core/snapping';`,
+        title: 'Keep reading',
+        links: [
+          { title: 'System architecture', href: '/docs/architecture' },
+          { title: 'Tracks and clips', href: '/docs/tracks-and-clips' },
+        ],
       },
-    ],
-    usageNotes: [
-      'Manages the serializable `TimelineState` source of truth, encapsulating tracks, clips, playback cursor, markers, and range selection.',
-      'Encapsulates typed edit commands (`validateEdit`, `previewEdit`, `commitEdit`, and `cancelEdit`), playback loops, history stacks (undo/redo), and typed snapping logic in a UI-agnostic environment.',
-      'Ideal for headless testing or custom platform integrations (such as Node.js or alternative rendering engines) due to zero DOM or UI dependencies.',
-    ],
-    exports: [
-      { path: '.', description: 'Types, engine, and snapping utilities.' },
-      { path: './engine', description: 'TimelineEngine entrypoint.' },
-      { path: './types', description: 'Track, Clip, Marker, and TimelineState types.' },
-      { path: './snapping', description: 'SnapIndex helpers for snapping and lookups.' },
-    ],
-    relatedGuides: [
-      { title: 'System architecture', href: '/docs/architecture' },
-      { title: 'API reference', href: '/packages/core/api' },
-    ],
-    nextSteps: [
-      {
-        title: 'Generated API reference',
-        href: '/packages/core/api',
-        description: 'Inspect TimelineEngine, TimelineState, and core utility symbols.',
-      },
-      {
-        title: 'System architecture',
-        href: '/docs/architecture',
-        description: 'Use this guide for the model-level language shared across packages.',
-      },
+      packageLinks('core'),
     ],
   },
   {
@@ -211,93 +183,73 @@ if (preview.valid) {
     description:
       'Use the React package when you want to bind a TimelineEngine to React controls while keeping rendering choices flexible.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-react',
-    sourceLinks: packageResourceLinks('react'),
-    whenToUse: [
-      'You already have a `TimelineEngine` instance and want to bind its state reactively to React components and controls.',
-      'You want built-in hooks to track playback cursor position, selected clips, viewport state, undo/redo stacks, and clipboard actions.',
-      'You need pointer-captured, CSS-styleable interaction layers like selection boxes, drag-and-trim handles, playhead scrubbers, and customized scrollbars.',
+    overview: [
+      'The React package connects a `TimelineEngine` to React components and hooks. It provides the provider, timeline namespace components, interaction layers, scrollbars, range controls, and focused hooks that product UI can compose.',
+      'It does not force a particular renderer. Pair it with the canvas renderer for the default high-performance surface, or use the hooks and interaction primitives with custom rendering.',
     ],
-    commonImports: [
-      {
-        label: 'Provider and hooks',
-        code: `import {
+    useCasesTitle: 'Use React bindings for',
+    useCases: [
+      'You already have a `TimelineEngine` and want React components to observe and control it.',
+      'You need package-owned interaction chrome such as playhead grabbers, clip handles, range controls, or scrollbars.',
+      'You want headless hooks for editing, selection, keyframes, playback, viewport, and track state.',
+    ],
+    usage: {
+      title: 'Bind the engine to React',
+      body: 'Wrap your editor in `TimelineProvider`, render `Timeline.Root`, then add the package components that match your surface. Keep dense clip and ruler rendering on canvas; use React for low-count controls and active affordances.',
+      steps: [
+        'Create or receive a `TimelineEngine` instance outside the leaf interaction components.',
+        'Wrap the editor with `TimelineProvider`.',
+        'Use `Timeline` components for playhead, range, track, scrollbar, and clip interaction chrome.',
+        'Use hooks when your product toolbar, inspector, or shortcuts need direct state and commands.',
+      ],
+    },
+    example: {
+      title: 'React interaction layer',
+      lang: 'tsx',
+      code: `import type { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import {
   Timeline,
   TimelineProvider,
   useTimeline,
-} from '@techsquidtv/canvas-timeline-react';`,
-      },
+} from '@techsquidtv/canvas-timeline-react';
+import '@techsquidtv/canvas-timeline-react/styles.css';
+
+function Tracks() {
+  const { state } = useTimeline();
+
+  return (
+    <Timeline.TrackList>
+      {state.tracks.map((track) => (
+        <Timeline.Track key={track.id} trackId={track.id} />
+      ))}
+    </Timeline.TrackList>
+  );
+}
+
+export function TimelineChrome({ engine }: { engine: TimelineEngine }) {
+  return (
+    <TimelineProvider engine={engine}>
+      <Timeline.Root>
+        <Timeline.PlayheadArea />
+        <Timeline.PlayheadGrabber />
+        <Tracks />
+        <Timeline.ClipInteractionLayer />
+        <Timeline.RangeSelector />
+      </Timeline.Root>
+    </TimelineProvider>
+  );
+}`,
+    },
+    linkGroups: [
       {
-        label: 'Shadcn-compatible styles',
-        code: `import '@techsquidtv/canvas-timeline-react/styles.css';`,
+        title: 'Keep reading',
+        links: [
+          { title: 'React editor hooks', href: '/docs/react-hooks' },
+          { title: 'React registry', href: '/packages/react/registry' },
+          { title: 'Demos overview', href: '/docs/demos-overview' },
+        ],
       },
-      {
-        label: 'Headless styling path',
-        code: `import '@techsquidtv/canvas-timeline-react/base.css';`,
-      },
-      {
-        label: 'Hook-only entrypoint',
-        code: `import {
-  useTimelineClips,
-  useTimelineEditCommands,
-  useTimelineEditImpacts,
-  useTimelineEditMode,
-  useTimelineEditPreview,
-  useTimelineRangeSelection,
-} from '@techsquidtv/canvas-timeline-react/hooks';`,
-      },
-    ],
-    usageNotes: [
-      'Binds `TimelineEngine` state and controls to React contexts and hooks (`useTimeline`) for reactive UI updates and property synchronization.',
-      'Provides headless edit-command hooks so product gestures can validate, preview, commit, and cancel typed edits through `TimelineEngine`.',
-      'Styles low-frequency interaction chrome (e.g., scrollbars, drag handles, active overlays) using CSS, keeping DOM nodes minimal and high-frequency rendering off the main thread.',
-      'Leverages `Timeline.ClipInteractionLayer` with pointer capture and hit testing to handle complex gestures (selection, drag, trim) without spawning per-clip DOM trees.',
-      'Provides building blocks like `Timeline.PlayheadArea` and `Timeline.PlayheadGrabber` to facilitate dragging behavior and layout composition.',
-      'Provides an accessible Base UI-backed range selector (`Timeline.RangeSelector`) for loop and selection bounds.',
-      'Use the native HTML media adapter package for one `HTMLMediaElement`; embedded video audio is supported by the element, while separate visual/audio track sync needs a custom multi-element adapter.',
-    ],
-    exports: [
-      { path: '.', description: 'Provider, context, hooks, and Timeline component namespace.' },
-      { path: './hooks', description: 'Hook-only entrypoint.' },
-      { path: './components', description: 'Component-only entrypoint.' },
-      {
-        path: './base.css',
-        description: 'Structural interaction geometry without default visuals.',
-      },
-      {
-        path: './theme.css',
-        description: 'Shadcn-token-driven visual theme for interaction chrome and timeline tokens.',
-      },
-      {
-        path: './styles.css',
-        description: 'Structural styles plus shadcn-compatible interaction chrome.',
-      },
-    ],
-    relatedGuides: [
-      { title: 'Getting started', href: '/docs/getting-started' },
-      { title: 'HTML Media Adapter Sync', href: '/demos/html-media-sync' },
-      { title: 'Demos overview', href: '/docs/demos-overview' },
-    ],
-    nextSteps: [
-      {
-        title: 'HTML Media Adapter Sync',
-        href: '/demos/html-media-sync',
-        description: 'See the native HTML media adapter driving timeline playback.',
-      },
-      {
-        title: 'React registry',
-        href: '/packages/react/registry',
-        description: 'Browse focused docs for component patterns and hook groups.',
-      },
-      {
-        title: 'Generated API reference',
-        href: '/packages/react/api',
-        description: 'Review provider, hook, and component exports.',
-      },
-      {
-        title: 'Demos overview',
-        href: '/docs/demos-overview',
-        description: 'Browse React-focused docs demos and their source-backed examples.',
-      },
+      packageLinks('react'),
     ],
   },
   {
@@ -306,90 +258,64 @@ if (preview.valid) {
     shortName: 'HTML Media Adapter',
     purpose: 'HTMLMediaElement adapter for timeline media playback.',
     description:
-      'Use the HTML media adapter when you want a simple HTML media or audio element to drive or follow Canvas Timeline playback.',
+      'Use the HTML media adapter when one native video or audio element should follow Canvas Timeline playback.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-html-media-adapter',
-    sourceLinks: packageResourceLinks('html-media-adapter'),
-    whenToUse: [
-      'You are building a standard video or audio preview player using a native HTML5 `<video>` or `<audio>` element.',
-      'You want simple playback synchronization without the weight of decoding frameworks or canvas-drawn video sinks.',
+    overview: [
+      'The HTML media adapter maps timeline clips to one mounted `HTMLMediaElement`. It seeks the element to the active clip source time, lets the native media clock drive playback, and keeps object URLs out of timeline state.',
+      'This is the right adapter for straightforward previews. If you need decoded frames on a canvas, custom Mediabunny inputs, or timeline-clocked audio playback outside a native media element, use the Mediabunny adapter instead.',
     ],
-    commonImports: [
-      {
-        label: 'High-level React sync hook',
-        code: `import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-adapter';`,
-      },
-      {
-        label: 'Low-level React adapter hook',
-        code: `import { useHTMLMediaAdapter } from '@techsquidtv/canvas-timeline-html-media-adapter';`,
-      },
-      {
-        label: 'Imperative adapter factory',
-        code: `import { createHTMLMediaAdapter } from '@techsquidtv/canvas-timeline-html-media-adapter';`,
-      },
+    useCasesTitle: 'Choose this adapter for',
+    useCases: [
+      'Your preview is a single native `<video>` or `<audio>` element.',
+      'Browser-native media loading, controls, and embedded audio are enough for the editor preview.',
+      'You want URL, `Blob`, or `File` sources keyed by `clip.sourceId` without managing object URLs yourself.',
     ],
-    usageNotes: [
-      'Use this adapter for simple native single-element sync; embedded video audio is handled by the same HTMLMediaElement.',
-      'The adapter maps `clip.sourceId` to one configured media source and keeps Blob/File object URLs out of timeline state.',
-      'Use `useHTMLTimelineMedia` for the common React path; use `useHTMLMediaAdapter`, `createHTMLMediaAdapter`, and `useTimelineMediaSync` when you need custom clocks or nonstandard sync behavior.',
-      'For decoded frame access, canvas preview rendering, or separate visual/audio source scheduling, use the Mediabunny adapter instead.',
-    ],
-    integrationGuide: {
-      mentalModel:
-        'Canvas Timeline owns tracks, clips, source time mapping, playback intent, and the active playhead. The HTML media adapter owns one mounted HTMLMediaElement, loads the active clip source into that element, seeks it to the clip source time, and reports the element clock back to timeline playback.',
+    usage: {
+      title: 'Connect one media element to timeline playback',
+      body: 'Use `useHTMLTimelineMedia` for the normal React path. It creates the adapter, wires it to timeline playback, and returns transport helpers for play, pause, and rate controls.',
       steps: [
-        'Give each media clip a stable `sourceId`; this is the join key between timeline state and your media sources.',
-        'Create a `sources` record where each key is a `sourceId` and each value is a URL, Blob, or File.',
-        'Attach a React ref to one `<video>` or `<audio>` element.',
-        'Pass `ref`, `sources`, and your active layer selector to `useHTMLTimelineMedia` inside a `TimelineProvider`.',
-        'Use the returned transport helpers for play, pause, and playback-rate UI.',
+        'Give each media clip a stable `sourceId`.',
+        'Create a `sources` record where each key is a source id and each value is a URL, `Blob`, or `File`.',
+        'Attach a ref to one `<video>` or `<audio>` element.',
+        'Pass the ref, sources, and layer selector to `useHTMLTimelineMedia` inside a `TimelineProvider`.',
       ],
-      example: {
-        label: 'Minimal React sync',
-        code: `import { useRef } from 'react';
+    },
+    example: {
+      title: 'Native video preview',
+      lang: 'tsx',
+      code: `import { useRef } from 'react';
 import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-adapter';
 
 const sources = { 'clip-source-main': '/media/preview.mp4' };
-const previewLayers = {
+const layers = {
   visuals: { trackKind: 'visual', sourceId: 'clip-source-main' },
 } as const;
 
-// Render inside <TimelineProvider engine={engine}>.
 export function NativePreview() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const media = useHTMLTimelineMedia({
     ref: videoRef,
     sources,
-    layers: previewLayers,
+    layers,
   });
 
   return <video ref={videoRef} playsInline onClick={() => void media.play()} />;
 }`,
-      },
-      demoNotes: [
-        'The HTML Media Adapter Sync demo uses `useHTMLTimelineMedia` with `videoRef` as the single preview surface controlled by the adapter.',
-        '`sampleSourceId` appears in both the clip data and the `sources` record, showing how `clip.sourceId` selects the media URL.',
-        'The visual layer selector tells the high-level hook which active timeline clip should drive the native element.',
-        'The rate buttons and readouts come from timeline transport state plus native element events, not from duplicated media state in the timeline.',
-      ],
     },
-    exports: [
-      { path: '.', description: 'React adapter hooks, imperative adapter factory, and types.' },
-    ],
-    relatedGuides: [
-      { title: 'HTML Media Adapter Sync demo', href: '/demos/html-media-sync' },
-      { title: 'System architecture', href: '/docs/architecture' },
-    ],
-    nextSteps: [
+    linkGroups: [
       {
-        title: 'HTML Media Adapter Sync demo',
-        href: '/demos/html-media-sync',
-        description: 'See the HTML media adapter driving timeline playback.',
+        title: 'See it running',
+        links: [
+          {
+            title: 'HTML Media Adapter Sync demo',
+            href: '/demos/html-media-sync',
+            description:
+              'A source-backed demo of one native video element following timeline playback.',
+          },
+          { title: 'System architecture', href: '/docs/architecture' },
+        ],
       },
-      {
-        title: 'Generated API reference',
-        href: '/packages/html-media-adapter/api',
-        description: 'Review hook, function, and adapter exports.',
-      },
+      packageLinks('html-media-adapter'),
     ],
   },
   {
@@ -398,94 +324,62 @@ export function NativePreview() {
     shortName: 'Mediabunny Adapter',
     purpose: 'Optional Mediabunny adapter for timeline media playback and frame access.',
     description:
-      'Use the Mediabunny adapter when timeline clips need to drive decoded video frames, local media files, and Web Audio scheduling through Mediabunny.',
-    descriptionLinks: [{ label: 'Mediabunny', href: 'https://mediabunny.dev/' }],
+      'Use the Mediabunny adapter when your editor needs decoded canvas frames, local media inputs, or a timeline-aware media monitor instead of one native media element.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-mediabunny-adapter mediabunny',
-    sourceLinks: [
-      ...packageResourceLinks('mediabunny-adapter'),
-      { label: 'Mediabunny docs', href: 'https://mediabunny.dev/' },
+    overview: [
+      'The Mediabunny adapter is for timeline preview monitors that need decoded media, not just a mounted `<video>` tag. It uses Mediabunny to open sources and decode frames and audio buffers, paints video frames to a canvas, queues decoded audio through Web Audio against the timeline clock, and exposes frame and duration state for monitor UI.',
+      'In React, start with `useMediabunnyTimelineMedia`. It creates the adapter and connects it to timeline playback. Drop down to `useMediabunnyAdapter` or `createMediabunnyAdapter` only when you are building custom sync, sharing an adapter between controls, or owning lifecycle outside React.',
     ],
-    whenToUse: [
-      'You already use Mediabunny and want Canvas Timeline clips to drive decoded video frames and audio playback.',
-      'You need local `Blob` or `File` sources mapped by `clip.sourceId` without putting media objects in timeline state.',
-      'You want lower-level frame access for custom canvas composition while keeping timeline playback synchronized.',
-    ],
-    commonImports: [
-      {
-        label: 'High-level React sync hook',
-        code: `import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';`,
-      },
-      {
-        label: 'Low-level React adapter hook',
-        code: `import { useMediabunnyAdapter } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';`,
-      },
-      {
-        label: 'Imperative adapter',
-        code: `import {
-  createMediabunnyAdapter,
-} from '@techsquidtv/canvas-timeline-mediabunny-adapter';`,
-      },
-    ],
-    usageNotes: [
-      '`mediabunny` is a peer dependency; the high-level hook lazy-loads it in the browser by default, while low-level APIs can still receive an explicit module or loader for dependency control.',
-      'The adapter maps `clip.sourceId` to Mediabunny sources and keeps heavy media objects outside serialized timeline state.',
-      'Use `useMediabunnyTimelineMedia` for the common React path; use `useMediabunnyAdapter`, `createMediabunnyAdapter`, and `useTimelineMediaSync` when you need custom clock or layer synchronization.',
-      'For ordinary single-element playback, prefer the native HTML media adapter from `@techsquidtv/canvas-timeline-html-media-adapter`.',
-    ],
-    integrationGuide: {
-      mentalModel:
-        'Canvas Timeline still owns the timeline state, active clips, source offsets, and playback intent. The Mediabunny adapter owns decoded media inputs, frame sinks, optional audio scheduling, and the media clock needed to render the active visual/audio clips in sync.',
+    usage: {
+      title: 'Decode media without putting media in timeline state',
+      body: 'Timeline clips keep lightweight `sourceId` values. Your app keeps the actual files, URLs, or Mediabunny inputs outside the timeline and passes matching source descriptors to the adapter.',
       steps: [
-        'Give timeline media clips stable `sourceId` values and keep media files, blobs, or Mediabunny inputs in application state.',
-        'Build a `sources` array where each item has an `id` matching a clip `sourceId` plus `url`, `blob`, `input`, or `createInput`.',
-        'Attach a `canvasRef` when decoded video frames should be painted to a preview canvas.',
-        'Pass `canvasRef`, `sources`, and your visual/audio layer selectors to `useMediabunnyTimelineMedia` inside a `TimelineProvider`.',
-        'Pass a custom `mediabunny` module or loader only when you need explicit dependency control; otherwise the hook uses a browser lazy import.',
+        'Give each media clip a stable `sourceId`.',
+        'Create a `sources` array where each descriptor has an `id` matching a clip source id.',
+        'Attach a canvas ref for decoded video frames.',
+        'Pass the canvas ref, sources, and visual/audio layer selectors to `useMediabunnyTimelineMedia` inside a `TimelineProvider`.',
+        'Use the returned transport helpers for playback and the returned duration/frame state for preview UI.',
       ],
-      example: {
-        label: 'Minimal React sync',
-        code: `import { useRef } from 'react';
+    },
+    example: {
+      title: 'Decoded canvas preview',
+      lang: 'tsx',
+      code: `import { useRef } from 'react';
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 
-const sources = [{ id: 'clip-source-main', url: '/media/preview.mp4' }];
-const previewLayers = {
-  visuals: { trackKind: 'visual', sourceId: 'clip-source-main' },
-  audio: { trackKind: 'audio', sourceId: 'clip-source-main' },
+const sourceId = 'clip-source-main';
+const sources = [{ id: sourceId, url: '/media/preview.mp4' }] as const;
+const layers = {
+  visuals: { trackKind: 'visual', sourceId },
+  audio: { trackKind: 'audio', sourceId },
 } as const;
 
-// Render inside <TimelineProvider engine={engine}>.
 export function DecodedPreview() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const media = useMediabunnyTimelineMedia({
     canvasRef,
     sources,
-    layers: previewLayers,
+    layers,
   });
 
   return <canvas ref={canvasRef} width={1280} height={720} onClick={() => void media.play()} />;
 }`,
-      },
-      demoNotes: [
-        'The Mediabunny Adapter Sync demo uses `useMediabunnyTimelineMedia` so the visible code matches the recommended setup path.',
-        '`sampleSourceId` appears in the visual/audio clips and in the Mediabunny source descriptors, showing the same `clip.sourceId` join key.',
-        'The `canvasRef` preview receives decoded frames while the high-level hook returns the transport controls, status, duration, and last-frame readouts.',
-        'The status panel reads `durationBySourceId` and `lastFrameTime`, which are useful for preview UI but do not need to be copied into timeline state.',
-      ],
     },
-    exports: [
-      { path: '.', description: 'Imperative Mediabunny timeline adapter and types.' },
-      { path: './react', description: 'React hook for creating and disposing the adapter.' },
-    ],
-    relatedGuides: [
-      { title: 'Mediabunny Adapter Sync demo', href: '/demos/media-preview-sync' },
-      { title: 'System architecture', href: '/docs/architecture' },
-    ],
-    nextSteps: [
+    linkGroups: [
       {
-        title: 'Mediabunny Adapter Sync demo',
-        href: '/demos/media-preview-sync',
-        description: 'See Mediabunny driving timeline media playback.',
+        title: 'See it running',
+        links: [
+          {
+            title: 'Mediabunny Adapter Sync demo',
+            href: '/demos/media-preview-sync',
+            description:
+              'A source-backed demo of decoded canvas frames, timeline-clocked audio, and transport controls.',
+          },
+          { title: 'Mediabunny docs', href: 'https://mediabunny.dev/' },
+          { title: 'System architecture', href: '/docs/architecture' },
+        ],
       },
+      packageLinks('mediabunny-adapter'),
     ],
   },
   {
@@ -494,58 +388,57 @@ export function DecodedPreview() {
     shortName: 'Renderer',
     purpose: 'Canvas rendering and worker-backed drawing primitives.',
     description:
-      'Use the renderer when you want the default canvas-backed timeline visuals with the shared theme helpers.',
+      'Use the renderer when you want the default canvas-backed timeline visuals with shared theme helpers.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-renderer',
-    sourceLinks: packageResourceLinks('renderer'),
-    whenToUse: [
-      'You need to render hundreds of clips, track lines, ticks, or markers without incurring the layout thrashing and DOM overhead of standard HTML nodes.',
-      'You want to use React and CSS for low-count interaction surfaces (scrollbars, drag handles, active overlays) while delegating high-frequency drawings to an offscreen thread.',
-      'You require pre-defined color presets, helper functions for generating stable clip colors, or automatic resolution of CSS/shadcn variables into canvas paint settings.',
+    overview: [
+      'The renderer draws the dense parts of a timeline: clips, track lanes, ruler ticks, markers, snap lines, and feedback overlays. It keeps those visuals on canvas so zooming, scrolling, and playback do not create hundreds of DOM nodes.',
+      'Pair it with the React package for the default split: canvas for dense visuals, React and CSS for low-count interaction chrome.',
     ],
-    commonImports: [
+    useCasesTitle: 'Use the renderer when',
+    useCases: [
+      'You want the default Canvas Timeline drawing pipeline.',
+      'You need worker-backed rendering for dense clip and ruler surfaces.',
+      'You want renderer theme helpers that resolve CSS and shadcn-style tokens into canvas colors.',
+    ],
+    usage: {
+      title: 'Render dense timeline visuals on canvas',
+      body: 'Place `CanvasRenderer` inside `Timeline.Root` while a `TimelineProvider` is active. Let the renderer own repeated visual drawing and keep product controls, inspectors, and interaction affordances in React.',
+      steps: [
+        'Create a `TimelineEngine` with tracks, clips, markers, and viewport state.',
+        'Render `CanvasRenderer` inside the timeline root.',
+        'Import package styles from the React or main package so DOM chrome has structural CSS.',
+        'Customize renderer theme options only when app-level tokens are not enough.',
+      ],
+    },
+    example: {
+      title: 'Canvas renderer inside a timeline',
+      lang: 'tsx',
+      code: `import type { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { Timeline, TimelineProvider } from '@techsquidtv/canvas-timeline-react';
+import { CanvasRenderer } from '@techsquidtv/canvas-timeline-renderer';
+
+export function TimelineCanvas({ engine }: { engine: TimelineEngine }) {
+  return (
+    <TimelineProvider engine={engine}>
+      <Timeline.Root>
+        <CanvasRenderer />
+        <Timeline.PlayheadGrabber />
+        <Timeline.ClipInteractionLayer />
+      </Timeline.Root>
+    </TimelineProvider>
+  );
+}`,
+    },
+    linkGroups: [
       {
-        label: 'Renderer and theme',
-        code: `import {
-  CanvasRenderer,
-  createTimelineRendererTheme,
-  defaultTimelineRendererTheme,
-  getPresetColor,
-} from '@techsquidtv/canvas-timeline-renderer';`,
+        title: 'Keep reading',
+        links: [
+          { title: 'Renderer customization', href: '/docs/renderer-customization' },
+          { title: 'System architecture', href: '/docs/architecture' },
+          { title: 'Demos', href: '/demos' },
+        ],
       },
-      {
-        label: 'Theme-only entrypoint',
-        code: `import {
-  createTimelineRendererTheme,
-  defaultTimelineRendererTheme,
-  resolveTimelineRendererThemeFromElement,
-} from '@techsquidtv/canvas-timeline-renderer/theme';`,
-      },
-    ],
-    usageNotes: [
-      'Worker-Backed Offscreen Rendering: `CanvasRenderer` automatically instantiates a Web Worker and uses `transferControlToOffscreen()` to render drawing frames off the main thread, maintaining a fluid 60 FPS.',
-      'High-DPI Sizing: Uses `ResizeObserver` to monitor viewport layout changes and scales the canvas bitmap width and height by `window.devicePixelRatio` for sharp rendering on high-density displays.',
-      'CSS Variable Synchronization: Resolves documented `--timeline-*` variables first, then shadcn semantic tokens such as `--background`, `--accent`, `--foreground`, `--primary`, and `--ring`, to apply application themes into canvas drawing contexts.',
-      'Optimized Theme Resolution: Queries computed styles on mount or when the `themeKey` changes, avoiding expensive layout thrashing/DOM queries during live scroll, zoom, or scrub operations.',
-      'Custom Theme Settings: Supports extensive canvas visual customization through the `theme` prop (covering clip backgrounds, ruler fonts, grid lines, and feedback guides).',
-      'Optional Overlays: Allows hiding standard canvas overlays (`showInOutPoints`, `showSnapLines`, `showClipDropFeedback`) or opting into renderer-only In/Out endpoint strokes (`showInOutBoundaryLines`) when custom React/DOM layers are not used.',
-    ],
-    exports: [
-      { path: '.', description: 'CanvasRenderer and theme exports.' },
-      {
-        path: './theme',
-        description: 'Default renderer theme, color presets, and preset color helper.',
-      },
-    ],
-    relatedGuides: [
-      { title: 'System architecture', href: '/docs/architecture' },
-      { title: 'Demos', href: '/demos' },
-    ],
-    nextSteps: [
-      {
-        title: 'Generated API reference',
-        href: '/packages/renderer/api',
-        description: 'Inspect CanvasRenderer and renderer theme symbols.',
-      },
+      packageLinks('renderer'),
     ],
   },
   {
@@ -554,53 +447,53 @@ export function DecodedPreview() {
     shortName: 'Utils',
     purpose: 'Rational time and shared math helpers.',
     description:
-      'Use the utility package when you need stable time conversions or math helpers without importing the editor layers.',
+      'Use the utility package when you need stable time conversions or math helpers without importing editor layers.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-utils',
-    sourceLinks: packageResourceLinks('utils'),
-    whenToUse: [
-      'You need to perform time operations (addition, subtraction, scaling) using exact `RationalTime` fractions rather than float seconds.',
-      'You require extremely lightweight time conversions, formatting (e.g., timecodes), or rounding helpers without importing any UI/editor dependencies.',
-      'You want to share identical time-parsing logic across both your core application state (like server exports or video playback APIs) and your timeline components.',
+    overview: [
+      'The utility package contains rational-time helpers and small shared math functions. It is intentionally light so apps, tests, server export code, and package internals can agree on timeline time math without importing React or the engine.',
+      'Use these helpers at the edges of your app when converting from seconds, frame counts, timecode strings, or UI input into the rational time values expected by Canvas Timeline.',
     ],
-    commonImports: [
-      {
-        label: 'Time helpers',
-        code: `import {
+    useCasesTitle: 'Use the utilities for',
+    useCases: [
+      'You need exact `RationalTime` values instead of floating-point seconds.',
+      'You are formatting or parsing timeline time outside the React components.',
+      'You want shared clamp, rounding, and arithmetic helpers without editor dependencies.',
+    ],
+    usage: {
+      title: 'Convert at the app boundary',
+      body: 'Keep timeline state in rational time. Convert from seconds or timecode when data enters the timeline, then convert back only for display, media APIs, or export code that requires decimal seconds.',
+      steps: [
+        'Use `fromSeconds` when creating timeline state from ordinary media durations or UI values.',
+        'Use `toSeconds` when passing playhead or clip times to browser media APIs.',
+        'Use formatting helpers for readouts and editable timecode fields.',
+      ],
+    },
+    example: {
+      title: 'Rational time helpers',
+      lang: 'ts',
+      code: `import {
+  addRational,
   formatTime,
   fromSeconds,
   toSeconds,
-} from '@techsquidtv/canvas-timeline-utils';`,
-      },
+} from '@techsquidtv/canvas-timeline-utils';
+
+const start = fromSeconds(12);
+const duration = fromSeconds(3.5);
+const end = addRational(start, duration);
+
+console.log(formatTime(end));
+console.log(toSeconds(end));`,
+    },
+    linkGroups: [
       {
-        label: 'Time-only entrypoint',
-        code: `import { fromSeconds } from '@techsquidtv/canvas-timeline-utils/time';`,
+        title: 'Keep reading',
+        links: [
+          { title: 'Rational time', href: '/docs/rational-time' },
+          { title: 'Getting started', href: '/docs/getting-started' },
+        ],
       },
-    ],
-    usageNotes: [
-      'Implements pure `RationalTime` arithmetic and conversion functions to eliminate decimal precision drifting and ensure frame-perfect math.',
-      'Lightweight and decoupled, suitable for usage in backend services, export routines, or external metadata stores that require time semantic compatibility.',
-      'Provides core utilities like `fromSeconds`, `toSeconds`, and `formatTime` alongside shared math functions such as clamping and rounding.',
-    ],
-    exports: [
-      { path: '.', description: 'Time and math helper exports.' },
-      { path: './time', description: 'RationalTime conversions and formatting.' },
-      { path: './math', description: 'Shared clamp and rounding helpers.' },
-    ],
-    relatedGuides: [
-      { title: 'Getting started', href: '/docs/getting-started' },
-      { title: 'API reference', href: '/packages/utils/api' },
-    ],
-    nextSteps: [
-      {
-        title: 'Generated API reference',
-        href: '/packages/utils/api',
-        description: 'Inspect fromSeconds, toSeconds, formatTime, and shared math helpers.',
-      },
-      {
-        title: 'Getting started',
-        href: '/docs/getting-started',
-        description: 'See the utilities in the context of the main editor path.',
-      },
+      packageLinks('utils'),
     ],
   },
 ];

--- a/apps/www/src/demos/media-preview-sync/MediaTimelineSync.tsx
+++ b/apps/www/src/demos/media-preview-sync/MediaTimelineSync.tsx
@@ -14,25 +14,23 @@ import {
   demoMarkers,
   demoTracks,
   sampleDurationSeconds,
-  sampleMediaUrls,
+  sampleMediaSource,
   sampleSourceId,
 } from './timeline-demo-data';
 import type { DemoMetrics } from '../demo-instrumentation';
 import '@techsquidtv/canvas-timeline-react/styles.css';
 
-// Demo configuration
+// Timeline layer selectors tell the adapter which active clips should drive preview outputs.
 const playbackRates = [0.5, 1, 2] as const;
 const previewLayerSelectors = {
   visuals: { trackKind: 'visual', sourceId: sampleSourceId },
   audio: { trackKind: 'audio', sourceId: sampleSourceId },
 } as const;
 
-// Display helpers
 function formatRenderedFrame(seconds: number | null) {
   return seconds === null ? 'Pending' : formatMediabunnyTime(seconds);
 }
 
-// Timeline chrome
 function TimelineLayers() {
   const { state } = useTimeline();
 
@@ -51,7 +49,6 @@ function TimelineLayers() {
   );
 }
 
-// Mediabunny preview and timeline sync
 function MediaSyncSurface({ metrics }: { metrics?: DemoMetrics }) {
   const playheadTime = useTimelinePlayheadTime();
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -59,8 +56,8 @@ function MediaSyncSurface({ metrics }: { metrics?: DemoMetrics }) {
   const decodeMetricReportedRef = useRef(false);
   const [playbackError, setPlaybackError] = useState<string | null>(null);
 
-  // Adapter setup
-  const sources = useMemo(() => sampleMediaUrls.map((url) => ({ id: sampleSourceId, url })), []);
+  // The source id joins app-owned media descriptors to timeline clips without storing media in timeline state.
+  const sources = useMemo(() => [sampleMediaSource], []);
   const {
     ready,
     status,

--- a/apps/www/src/demos/media-preview-sync/timeline-demo-data.ts
+++ b/apps/www/src/demos/media-preview-sync/timeline-demo-data.ts
@@ -5,7 +5,7 @@ import { getDemoClipColor } from '../demo-clip-colors';
 export const sampleSourceId = 'big-buck-bunny-preview';
 
 const sampleMediaUrl = '/demo-media/big-buck-bunny-preview.webm';
-export const sampleMediaUrls = [sampleMediaUrl] as const;
+export const sampleMediaSource = { id: sampleSourceId, url: sampleMediaUrl } as const;
 export const sampleDurationSeconds = 66.06;
 
 export const demoTracks: Track<'visual' | 'audio'>[] = [

--- a/apps/www/src/lib/inline-prose.ts
+++ b/apps/www/src/lib/inline-prose.ts
@@ -1,0 +1,24 @@
+function escapeHtml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function inlineProseHtml(value: string) {
+  const parts: string[] = [];
+  const codePattern = /`([^`\n]+)`/g;
+  let cursor = 0;
+
+  for (const match of value.matchAll(codePattern)) {
+    const matchIndex = match.index ?? 0;
+    parts.push(escapeHtml(value.slice(cursor, matchIndex)));
+    parts.push(`<code>${escapeHtml(match[1] ?? '')}</code>`);
+    cursor = matchIndex + match[0].length;
+  }
+
+  parts.push(escapeHtml(value.slice(cursor)));
+  return parts.join('');
+}

--- a/apps/www/src/lib/structured-data.test.ts
+++ b/apps/www/src/lib/structured-data.test.ts
@@ -95,6 +95,7 @@ describe('structured data helpers', () => {
       name: '@techsquidtv/canvas-timeline-react',
       url: 'https://canvastimeline.com/packages/react',
       codeRepository: 'https://github.com/techsquidtv/canvas-timeline/tree/main/packages/react',
+      keywords: 'React, You need React bindings., Wrap editors in TimelineProvider.',
       targetProduct: {
         '@type': 'SoftwareApplication',
         installUrl: 'https://www.npmjs.com/package/@techsquidtv/canvas-timeline-react',
@@ -163,22 +164,33 @@ function createPackageDoc(): PackageDoc {
     purpose: 'React provider and hooks.',
     description: 'React package for Canvas Timeline.',
     installCommand: 'pnpm add @techsquidtv/canvas-timeline-react',
-    sourceLinks: [
+    overview: ['React package overview.'],
+    useCasesTitle: 'Use React bindings for',
+    useCases: ['You need React bindings.', 'Wrap editors in `TimelineProvider`.'],
+    usage: {
+      title: 'Bind the engine to React',
+      body: 'Use the provider and hooks.',
+      steps: ['Wrap the editor in `TimelineProvider`.'],
+    },
+    example: {
+      title: 'Example',
+      code: 'export function Example() {}',
+    },
+    linkGroups: [
       {
-        label: 'NPM',
-        href: 'https://www.npmjs.com/package/@techsquidtv/canvas-timeline-react',
-      },
-      {
-        label: 'GitHub',
-        href: 'https://github.com/techsquidtv/canvas-timeline/tree/main/packages/react',
+        title: 'Package links',
+        links: [
+          {
+            title: 'NPM',
+            href: 'https://www.npmjs.com/package/@techsquidtv/canvas-timeline-react',
+          },
+          {
+            title: 'GitHub',
+            href: 'https://github.com/techsquidtv/canvas-timeline/tree/main/packages/react',
+          },
+        ],
       },
     ],
-    whenToUse: ['You need React bindings.'],
-    commonImports: [],
-    usageNotes: [],
-    exports: [],
-    relatedGuides: [],
-    nextSteps: [],
   };
 }
 

--- a/apps/www/src/lib/structured-data.ts
+++ b/apps/www/src/lib/structured-data.ts
@@ -163,6 +163,10 @@ function createTechArticleStructuredData(input: ArticleStructuredDataInput): Jso
   };
 }
 
+function stripInlineCodeMarkers(value: string): string {
+  return value.replace(/`([^`\n]+)`/g, '$1');
+}
+
 export function createDocsArticleStructuredData(input: ArticleStructuredDataInput): JsonLdObject {
   return createTechArticleStructuredData(input);
 }
@@ -244,13 +248,15 @@ export function createPackageIndexStructuredData(
 }
 
 export function createPackageStructuredData(packageDoc: PackageDoc): JsonLdObject {
+  const packageLinks = packageDoc.linkGroups.flatMap((group) => group.links);
+
   return createSoftwareSourceCodeStructuredData({
     name: packageDoc.name,
     description: packageDoc.description,
     url: `/packages/${packageDoc.slug}`,
-    codeRepository: packageDoc.sourceLinks.find((link) => link.label === 'GitHub')?.href,
-    installUrl: packageDoc.sourceLinks.find((link) => link.label === 'NPM')?.href,
-    keywords: [packageDoc.shortName, ...packageDoc.whenToUse],
+    codeRepository: packageLinks.find((link) => link.title === 'GitHub')?.href,
+    installUrl: packageLinks.find((link) => link.title === 'NPM')?.href,
+    keywords: [packageDoc.shortName, ...(packageDoc.useCases ?? []).map(stripInlineCodeMarkers)],
     runtimePlatform: 'React',
     codeSampleType: packageDoc.installCommand,
   });

--- a/apps/www/src/pages/packages/[slug].astro
+++ b/apps/www/src/pages/packages/[slug].astro
@@ -3,8 +3,8 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import CodeBlock from '@/components/CodeBlock.astro';
 import PackageManagerTabs from '@/components/PackageManagerTabs.astro';
 import { packageDocs, type PackageDoc } from '@/data/packages';
-import { groupApiSymbols, groupNameForApiSymbol } from '@/lib/api-symbol-groups';
-import { apiPackageHref, apiReference, apiSymbolHref } from '@/lib/api-reference';
+import { apiPackageHref } from '@/lib/api-reference';
+import { inlineProseHtml } from '@/lib/inline-prose';
 import { createPackageStructuredData } from '@/lib/structured-data';
 
 interface Props {
@@ -22,75 +22,28 @@ const { packageDoc } = Astro.props;
 const packageApiHref = apiPackageHref(packageDoc.slug);
 const packageInstallPackages = packageDoc.installCommand.replace(/^pnpm add\s+/, '');
 
-// Resolve exported symbols for the current package
-const packageRef = apiReference.packages.find((p) => p.slug === packageDoc.slug);
-const symbols = packageRef ? packageRef.symbols : [];
-const sortedSymbolGroups = groupApiSymbols(packageDoc.slug, symbols);
-
-const commonEntryPointNames: Partial<Record<string, string[]>> = {
-  timeline: [
-    'TimelineEngine',
-    'TimelineProvider',
-    'Timeline',
-    'CanvasRenderer',
-    'fromSeconds',
-    'useTimeline',
-  ],
-  core: ['TimelineEngine', 'TimelineState', 'Track', 'Clip', 'fromSeconds', 'SpatialIndex'],
-  react: [
-    'TimelineProvider',
-    'Timeline',
-    'useTimeline',
-    'useTimelineState',
-    'useTimelinePlayback',
-    'TimecodeField',
-  ],
-  renderer: ['CanvasRenderer', 'CanvasRendererProps', 'createTimelineRendererTheme'],
-  utils: ['fromSeconds', 'toSeconds', 'formatTime', 'formatTimecode', 'addRational'],
-  'html-media-adapter': [
-    'useHTMLTimelineMedia',
-    'createHTMLMediaAdapter',
-    'useHTMLMediaAdapter',
-    'HTMLMediaAdapter',
-  ],
-  'mediabunny-adapter': [
-    'useMediabunnyTimelineMedia',
-    'createMediabunnyAdapter',
-    'useMediabunnyAdapter',
-    'MediabunnyAdapter',
-  ],
-};
-
-const commonEntryPoints = (commonEntryPointNames[packageDoc.slug] ?? [])
-  .map((symbolName) => symbols.find((symbol) => symbol.name === symbolName))
-  .filter(Boolean) as typeof symbols;
-
 const seoTitles: Record<string, string> = {
   timeline: 'React Timeline Editor Component - @techsquidtv/canvas-timeline',
-  core: 'Headless Timeline Editor React Engine - @techsquidtv/canvas-timeline-core',
+  core: 'Timeline Editor Core Engine - @techsquidtv/canvas-timeline-core',
   react: 'React Timeline Component Hooks & UI - @techsquidtv/canvas-timeline-react',
-  renderer: '60fps Canvas React Timeline Renderer - @techsquidtv/canvas-timeline-renderer',
-  utils: 'React Timeline Rational Time Utilities - @techsquidtv/canvas-timeline-utils',
+  renderer: '60fps Canvas Timeline Renderer - @techsquidtv/canvas-timeline-renderer',
+  utils: 'Timeline Rational Time Utilities - @techsquidtv/canvas-timeline-utils',
   'html-media-adapter': 'React Timeline Component Media Sync - @techsquidtv/canvas-timeline-html-media-adapter',
   'mediabunny-adapter': 'React Timeline Component Mediabunny Adapter - @techsquidtv/canvas-timeline-mediabunny-adapter',
 };
 
 const seoH1s: Record<string, string> = {
   timeline: 'Canvas React Timeline Editor & Component',
-  core: 'React Timeline Editor Core Engine',
+  core: 'Timeline Editor Core Engine',
   react: 'Canvas React Timeline Editor UI Bindings',
-  renderer: 'React Timeline Canvas Rendering Engine',
-  utils: 'React Timeline Math & Time Utilities',
+  renderer: 'Timeline Canvas Rendering Engine',
+  utils: 'Timeline Math & Time Utilities',
   'html-media-adapter': 'HTML Media Sync Adapter',
   'mediabunny-adapter': 'Mediabunny Audio & Video Sync Adapter',
 };
 
 const seoTitle = seoTitles[packageDoc.slug] || packageDoc.name;
 const seoH1 = seoH1s[packageDoc.slug] || packageDoc.name;
-const descriptionLink = packageDoc.descriptionLinks?.[0];
-const descriptionParts = descriptionLink
-  ? packageDoc.description.split(descriptionLink.label)
-  : [packageDoc.description];
 const structuredData = createPackageStructuredData(packageDoc);
 ---
 
@@ -129,299 +82,144 @@ const structuredData = createPackageStructuredData(packageDoc);
       </p>
 
       <!-- Description -->
-      <p class="mt-3 text-base text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-        {descriptionLink ? (
-          <>
-            {descriptionParts.map((part, index) => (
-              <>
-                {part}
-                {index < descriptionParts.length - 1 && (
-                  <a
-                    href={descriptionLink.href}
-                    rel="noreferrer"
-                    target="_blank"
-                    class="text-foreground underline decoration-border underline-offset-4 hover:text-primary hover:decoration-primary"
-                  >
-                    {descriptionLink.label}
-                  </a>
-                )}
-              </>
-            ))}
-          </>
-        ) : (
-          packageDoc.description
-        )}
-      </p>
+      <p
+        class="mt-3 text-base text-muted-foreground max-w-3xl mx-auto leading-relaxed"
+        set:html={inlineProseHtml(packageDoc.description)}
+      />
     </div>
   </section>
 
   <!-- Main Content Layout -->
   <div class="container-page px-4 py-12 md:py-16">
     <div class="grid grid-cols-1 lg:grid-cols-12 gap-12 items-start">
-      
       <!-- Main Content Column -->
-      <article class="lg:col-span-8 space-y-12">
-        
-        <!-- Installation Section -->
+      <article class="detail-main lg:col-span-8 space-y-12">
+        <section aria-labelledby="overview-heading">
+          <h2 id="overview-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
+            Overview
+          </h2>
+          <div class="max-w-3xl space-y-4">
+            {packageDoc.overview.map((paragraph) => (
+              <p
+                class="text-sm md:text-base text-muted-foreground leading-relaxed text-left"
+                set:html={inlineProseHtml(paragraph)}
+              />
+            ))}
+          </div>
+        </section>
+
         <section aria-labelledby="install-heading">
           <h2 id="install-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
-            Installation
+            Install
           </h2>
           <PackageManagerTabs packages={packageInstallPackages} />
         </section>
 
-        <!-- When to Use Section -->
-        <section aria-labelledby="when-to-use-heading">
-          <h2 id="when-to-use-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
-            When to use it
-          </h2>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {packageDoc.whenToUse.map((item) => (
-              <div class="flex gap-3 bg-muted/20 border border-border/60 rounded-xl p-4 text-left">
-                <svg class="w-5 h-5 text-emerald-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                <span class="text-sm text-foreground/80 leading-relaxed">{item}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <!-- Integration Guide Section -->
-        {packageDoc.integrationGuide && (
-          <section aria-labelledby="integration-guide-heading" class="space-y-6">
-            <div class="max-w-3xl text-left">
-              <h2 id="integration-guide-heading" class="text-xl md:text-2xl font-bold text-foreground">
-                How it fits together
-              </h2>
-              <p class="mt-3 text-sm text-muted-foreground leading-relaxed">
-                {packageDoc.integrationGuide.mentalModel}
-              </p>
-            </div>
-
-            <div class="grid grid-cols-1 gap-4">
-              <div class="border border-border/60 rounded-xl bg-muted/10 p-5 text-left">
-                <h3 class="text-sm font-bold text-foreground">Setup flow</h3>
-                <ol class="mt-4 space-y-3">
-                  {packageDoc.integrationGuide.steps.map((step, index) => (
-                    <li class="flex gap-3 text-sm text-muted-foreground leading-relaxed">
-                      <span class="mt-0.5 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
-                        {index + 1}
-                      </span>
-                      <span>{step}</span>
-                    </li>
-                  ))}
-                </ol>
-              </div>
-
-              <CodeBlock
-                code={packageDoc.integrationGuide.example.code}
-                lang="tsx"
-                title={packageDoc.integrationGuide.example.label}
-              />
-
-              <div class="border border-border/60 rounded-xl bg-card p-5 text-left">
-                <h3 class="text-sm font-bold text-foreground">What to look for in the demo</h3>
-                <ul class="mt-4 space-y-3">
-                  {packageDoc.integrationGuide.demoNotes.map((note) => (
-                    <li class="flex gap-3 text-sm text-muted-foreground leading-relaxed">
-                      <span class="text-primary mt-1 select-none font-bold">•</span>
-                      <span>{note}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
+        {packageDoc.useCases && packageDoc.useCasesTitle && (
+          <section aria-labelledby="use-cases-heading">
+            <h2 id="use-cases-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
+              {packageDoc.useCasesTitle}
+            </h2>
+            <ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {packageDoc.useCases.map((item) => (
+                <li class="flex gap-3 bg-muted/20 border border-border/60 rounded-xl p-4 text-left">
+                  <svg class="w-5 h-5 text-emerald-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span
+                    class="text-sm text-foreground/80 leading-relaxed"
+                    set:html={inlineProseHtml(item)}
+                  />
+                </li>
+              ))}
+            </ul>
           </section>
         )}
 
-        <!-- Common Imports Section -->
-        <section aria-labelledby="imports-heading">
-          <h2 id="imports-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
-            Common imports
-          </h2>
-          <div class="space-y-6">
-            {
-              packageDoc.commonImports.map((example) => (
-                <CodeBlock code={example.code} lang="ts" title={example.label} />
-              ))
-            }
+        <section aria-labelledby="usage-heading" class="space-y-5">
+          <div class="max-w-3xl text-left">
+            <h2 id="usage-heading" class="text-xl md:text-2xl font-bold text-foreground">
+              Usage
+            </h2>
+            <h3 class="mt-4 text-base font-bold text-foreground">{packageDoc.usage.title}</h3>
+            <p
+              class="mt-2 text-sm md:text-base text-muted-foreground leading-relaxed"
+              set:html={inlineProseHtml(packageDoc.usage.body)}
+            />
           </div>
-        </section>
 
-        <!-- Usage Notes Section -->
-        <section aria-labelledby="usage-notes-heading">
-          <h2 id="usage-notes-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
-            Usage notes
-          </h2>
-          <ul class="space-y-3 pl-1">
-            {packageDoc.usageNotes.map((item) => (
-              <li class="flex gap-3 text-sm text-muted-foreground text-left leading-relaxed">
-                <span class="text-primary mt-1 select-none font-bold">•</span>
-                <span>{item}</span>
+          <ol class="grid grid-cols-1 gap-3">
+            {packageDoc.usage.steps.map((step, index) => (
+              <li class="flex gap-3 text-sm text-muted-foreground leading-relaxed border border-border/60 rounded-xl bg-muted/10 p-4">
+                <span class="mt-0.5 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
+                  {index + 1}
+                </span>
+                <span set:html={inlineProseHtml(step)} />
               </li>
             ))}
-          </ul>
+          </ol>
         </section>
 
-        <!-- Public API Surface Section -->
-        <section aria-labelledby="api-surface-heading" class="space-y-6">
-          <div class="max-w-3xl text-left border-t border-border pt-8">
-            <h2 id="api-surface-heading" class="text-xl md:text-2xl font-bold text-foreground">
-              API Surface
-            </h2>
-            <p class="mt-2 text-sm text-muted-foreground leading-relaxed">
-              Explore the key components, hooks, and classes exported by this package. Click any symbol to view its full TSDoc parameter signatures.
-            </p>
-          </div>
-
-          {commonEntryPoints.length > 0 && (
-            <div class="space-y-3">
-              <h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Key Entry Points</h3>
-              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {commonEntryPoints.map((symbol) => (
-                  <a
-                    href={apiSymbolHref(packageDoc.slug, symbol.slug)}
-                    class="group bg-card border border-border rounded-xl p-4 flex flex-col justify-between hover:border-primary hover:shadow-sm transition-all duration-300 text-left"
-                  >
-                    <div>
-                      <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-primary/10 text-primary mb-2">
-                        {groupNameForApiSymbol(packageDoc.slug, symbol)}
-                      </span>
-                      <strong class="block text-sm font-bold text-foreground group-hover:text-primary transition-colors">
-                        {symbol.name}
-                      </strong>
-                      <p class="mt-1 text-xs text-muted-foreground leading-normal line-clamp-2">
-                        {symbol.summary || 'No description summary.'}
-                      </p>
-                    </div>
-                  </a>
-                ))}
-              </div>
-            </div>
-          )}
-
+        <section aria-labelledby="example-heading">
+          <h2 id="example-heading" class="text-xl md:text-2xl font-bold text-foreground mb-4">
+            Example
+          </h2>
+          <CodeBlock
+            code={packageDoc.example.code}
+            lang={packageDoc.example.lang ?? 'tsx'}
+            title={packageDoc.example.title}
+          />
         </section>
-
-        <!-- Subpath Imports Section -->
-        <section aria-labelledby="subpaths-heading" class="space-y-4">
-          <div class="max-w-3xl text-left border-t border-border pt-8">
-            <h2 id="subpaths-heading" class="text-xl md:text-2xl font-bold text-foreground">
-              Subpath Imports
-            </h2>
-            <p class="mt-2 text-sm text-muted-foreground leading-relaxed">
-              Import specific files or modules directly to reduce bundle size or target specialized package layers.
-            </p>
-          </div>
-          <div class="overflow-x-auto rounded-xl border border-border bg-card">
-            <table class="w-full text-left border-collapse text-sm">
-              <thead>
-                <tr class="border-b border-border bg-muted/30">
-                  <th class="p-4 font-semibold text-foreground">Import Path</th>
-                  <th class="p-4 font-semibold text-foreground">Description</th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-border/60">
-                {packageDoc.exports.map((item) => (
-                  <tr class="hover:bg-muted/10 transition-colors">
-                    <td class="p-4 font-mono text-xs text-primary whitespace-nowrap">
-                      {packageDoc.name}{item.path === '.' ? '' : item.path.replace('.', '')}
-                    </td>
-                    <td class="p-4 text-muted-foreground leading-relaxed">{item.description}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-
       </article>
 
       <!-- Sidebar Column -->
-      <aside class="lg:col-span-4 space-y-6 lg:sticky lg:top-24">
-        
-        <!-- API Reference CTA Card -->
+      <aside class="detail-aside lg:col-span-4 space-y-6 lg:sticky lg:top-24">
         <div class="bg-primary/5 border border-primary/20 rounded-xl p-5 flex flex-col justify-between hover:shadow-md transition-all duration-300">
           <div>
-            <h3 class="text-sm font-bold text-foreground">API Reference</h3>
+            <h3 class="text-sm font-bold text-foreground">API reference</h3>
             <p class="mt-2 text-xs text-muted-foreground leading-relaxed">
-              Open the generated, comprehensive developer reference for {packageDoc.name}.
+              Generated reference for every public symbol exported by {packageDoc.name}.
             </p>
           </div>
           <a class="mt-4 inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground font-semibold text-xs hover:opacity-90 transition-all shadow-sm" href={packageApiHref}>
-            Open API Reference
+            Open API reference
             <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" />
             </svg>
           </a>
         </div>
 
-        <!-- Source Links Card -->
-        <div class="bg-card border border-border rounded-xl p-5">
-          <h3 class="text-sm font-bold text-foreground mb-3">Source Code</h3>
-          <div class="flex flex-col gap-2">
-            {
-              packageDoc.sourceLinks.map((link) => (
+        {packageDoc.linkGroups.map((group) => (
+          <div class="bg-card border border-border rounded-xl p-5">
+            <h3 class="text-sm font-bold text-foreground mb-3">{group.title}</h3>
+            <div class="flex flex-col gap-2">
+              {group.links.map((link) => (
                 <a
                   href={link.href}
-                  rel="noreferrer"
-                  target="_blank"
-                  class="inline-flex items-center justify-between p-2.5 rounded-lg border border-border/60 hover:border-primary/40 hover:bg-muted/10 transition-all text-xs text-foreground/80 font-medium"
+                  rel={link.href.startsWith('http') ? 'noreferrer' : undefined}
+                  target={link.href.startsWith('http') ? '_blank' : undefined}
+                  class="group block text-left p-3 rounded-lg border border-border/60 hover:border-primary/40 hover:bg-muted/10 transition-all"
                 >
-                  <span>{link.label}</span>
-                  <svg class="w-3.5 h-3.5 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                  </svg>
-                </a>
-              ))
-            }
-          </div>
-        </div>
-
-        <!-- Related Guides Card -->
-        {packageDoc.relatedGuides.length > 0 && (
-          <div class="bg-card border border-border rounded-xl p-5">
-            <h3 class="text-sm font-bold text-foreground mb-3">Related Guides</h3>
-            <div class="flex flex-col gap-2">
-              {
-                packageDoc.relatedGuides.map((guide) => (
-                  <a
-                    href={guide.href}
-                    class="inline-flex items-center justify-between p-2.5 rounded-lg border border-border/60 hover:border-primary/40 hover:bg-muted/10 transition-all text-xs text-foreground/80 font-medium"
-                  >
-                    <span>{guide.title}</span>
-                    <svg class="w-3.5 h-3.5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                  <span class="flex items-center justify-between gap-3">
+                    <strong class="text-xs text-foreground group-hover:text-primary transition-colors">
+                      {link.title}
+                    </strong>
+                    <svg class="w-3.5 h-3.5 flex-shrink-0 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                      <path stroke-linecap="round" stroke-linejoin="round" d={link.href.startsWith('http') ? 'M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14' : 'M9 5l7 7-7 7'} />
                     </svg>
-                  </a>
-                ))
-              }
+                  </span>
+                  {link.description && (
+                    <span
+                      class="block text-[11px] text-muted-foreground mt-1 leading-normal"
+                      set:html={inlineProseHtml(link.description)}
+                    />
+                  )}
+                </a>
+              ))}
             </div>
           </div>
-        )}
-
-        <!-- Next Steps Card -->
-        {packageDoc.nextSteps.length > 0 && (
-          <div class="bg-card border border-border rounded-xl p-5">
-            <h3 class="text-sm font-bold text-foreground mb-3">Next Steps</h3>
-            <div class="flex flex-col gap-3">
-              {
-                packageDoc.nextSteps.map((link) => (
-                  <a
-                    href={link.href}
-                    class="group block text-left p-3 rounded-lg border border-border/60 hover:border-primary/40 hover:bg-muted/10 transition-all"
-                  >
-                    <strong class="block text-xs text-foreground group-hover:text-primary transition-colors">{link.title}</strong>
-                    {link.description && <span class="block text-[11px] text-muted-foreground mt-1 leading-normal">{link.description}</span>}
-                  </a>
-                ))
-              }
-            </div>
-          </div>
-        )}
-
+        ))}
       </aside>
-
     </div>
   </div>
 </BaseLayout>

--- a/packages/mediabunny-adapter/README.md
+++ b/packages/mediabunny-adapter/README.md
@@ -15,29 +15,47 @@ pnpm add @techsquidtv/canvas-timeline-mediabunny-adapter mediabunny
 
 `mediabunny` and React are peer dependencies. The high-level React hook can lazy-load Mediabunny in the browser by default, while lower-level APIs can receive an explicit module or loader.
 
+## Choosing an API
+
+- Start with `useMediabunnyTimelineMedia` in React apps. It creates the adapter, connects it to timeline playback, and returns play/pause/rate controls plus decoded-frame status.
+- Use `useMediabunnyAdapter` only when you want React lifecycle management but will wire `adapter.syncAdapter` into `useTimelineMediaSync` yourself.
+- Use `createMediabunnyAdapter` outside React or when custom infrastructure owns canvas assignment, transport wiring, and disposal.
+- Use the HTML media adapter instead when one native `<video>` or `<audio>` element is enough.
+
 ```tsx
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 ```
 
 ## Features
 
-- Drive decoded video frames, local media files, and Web Audio scheduling from timeline clips.
+- Use Mediabunny to decode video frames and audio buffers, then keep canvas drawing and Web Audio playback aligned with timeline clips.
 - Map `clip.sourceId` values to Mediabunny sources without storing heavy media objects in timeline state.
-- Build custom canvas preview composition while keeping timeline playback synchronized.
+- Build a custom timeline preview monitor without storing files, blobs, or decoded frames in timeline state.
 
 ## Quick Start
 
 ```tsx
 import { useRef } from 'react';
+import type { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { TimelineProvider } from '@techsquidtv/canvas-timeline-react';
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 
-const sources = [{ id: 'clip-source-main', url: '/media/preview.mp4' }];
+const sourceId = 'clip-source-main';
+const sources = [{ id: sourceId, url: '/media/preview.mp4' }] as const;
 const previewLayers = {
-  visuals: { trackKind: 'visual', sourceId: 'clip-source-main' },
-  audio: { trackKind: 'audio', sourceId: 'clip-source-main' },
+  visuals: { trackKind: 'visual', sourceId },
+  audio: { trackKind: 'audio', sourceId },
 } as const;
 
-export function DecodedPreview() {
+export function DecodedPreviewApp({ engine }: { engine: TimelineEngine }) {
+  return (
+    <TimelineProvider engine={engine}>
+      <DecodedPreview />
+    </TimelineProvider>
+  );
+}
+
+function DecodedPreview() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const media = useMediabunnyTimelineMedia({
     canvasRef,
@@ -49,9 +67,7 @@ export function DecodedPreview() {
 }
 ```
 
-```ts
-import { createMediabunnyAdapter } from '@techsquidtv/canvas-timeline-mediabunny-adapter';
-```
+Each item in `sources` uses an `id` that matches timeline clip `sourceId` values. For local files or custom Mediabunny setup, replace the URL descriptor with a `blob`, `input`, or `createInput` descriptor that keeps the same join key.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Reworks package landing pages around Overview, Install, Usage, Example, and curated links.
- Adds a tiny trusted inline prose renderer so package copy can render inline code without full Markdown.
- Tightens Mediabunny adapter README, package copy, and demo source guidance around the React media hook and source ids.

## Release Impact

- Runtime APIs: no public API or export changes.
- Docs/data: breaking internal docs-data shape change for package landing pages.
- Changeset: empty changeset; no package bump expected.
- Checklist areas reviewed: release checklist sections 0, 3, 5, 8, and 9.

## Validation

- pnpm check
- vp run --filter @techsquidtv/canvas-timeline-www docs:demos
- vp run --filter @techsquidtv/canvas-timeline-www build
- pnpm changeset:status
- git diff --check