### PR TITLE
chore: harden public type boundaries

### DIFF
--- a/.changeset/public-type-boundaries.md
+++ b/.changeset/public-type-boundaries.md
@@ -1,0 +1,9 @@
+---
+---
+
+Harden public type boundaries before the first public release.
+
+Remaining public `unknown` surfaces are documented as intentional opaque
+metadata, third-party control commit details, or error normalization inputs.
+Avoidable production type assertions were removed or centralized behind narrow
+track-kind helper boundaries.

--- a/.github/docs/public-release-checklist.md
+++ b/.github/docs/public-release-checklist.md
@@ -65,11 +65,15 @@ Last verified against repository contents on 2026-07-08.
   - [x] Add or confirm `noFallthroughCasesInSwitch: true`.
   - [ ] Keep `skipLibCheck` only if it is a deliberate toolchain tradeoff.
 - [x] Keep `typescript/no-explicit-any` enforced.
-- [ ] Review every public `unknown` use and keep only deliberate extensibility points, such as metadata or external callback payloads.
-- [ ] Review all type assertions in production code.
-  - [ ] Eliminate avoidable casts.
-  - [ ] Replace unsafe casts with narrow helper functions where useful.
-  - [ ] Keep test-only casts isolated to tests.
+- [x] Review every public `unknown` use and keep only deliberate extensibility points, such as metadata or external callback payloads.
+  - [x] Core metadata records document app-owned `Record<string, unknown>` values as intentionally opaque.
+  - [x] React scalar/range control commit details use a named `TimelineControlCommitDetails` alias for third-party event metadata that Canvas Timeline forwards but does not inspect.
+- [x] Review all type assertions in production code.
+  - [x] Eliminate avoidable casts.
+    - [x] Removed redundant React pointer-event, active-pointer array, forwarded-ref, renderer worker context, media sync active-layer, and timeline event handler assertions.
+  - [x] Replace unsafe casts with narrow helper functions where useful.
+    - [x] Centralized track-kind generic assertions behind core and React track access helpers.
+  - [x] Keep test-only casts isolated to tests.
 - [ ] Resolve or explicitly justify every lint ignore, `ts-expect-error`, and custom Knip ignore.
 - [ ] Keep `knip` in CI and review ignored files before release.
 - [x] Keep duplicate exported types and helpers out of the package graph.

--- a/apps/www/src/content/docs/react-hooks.mdx
+++ b/apps/www/src/content/docs/react-hooks.mdx
@@ -139,6 +139,12 @@ Use control adapters when composing semantic UI:
   headless keyframe geometry, tangent handles, commands, property evaluation, and
   drag previews for custom keyframe editors.
 
+Control adapter `onValueCommitted` callbacks receive the committed value plus
+opaque `TimelineControlCommitDetails` forwarded from the underlying control
+primitive. Canvas Timeline settles the engine before forwarding that metadata,
+but does not inspect it; narrow the details in application code when a specific
+control library documents extra fields.
+
 Keyboard behavior from these hooks is opt-in and scoped to the element that
 spreads the returned props. Canvas Timeline does not install global hotkeys or
 override application shortcuts.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -441,6 +441,10 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
   private editResolution: TimelineResolvedEdit | null = null;
   private pendingClipMoveCommitEvent: ClipMoveEvent | null = null;
 
+  private getTracks<TrackKind = string>(): Track<TrackKind>[] {
+    return this.state.tracks as Track<TrackKind>[];
+  }
+
   /**
    * Creates an instance of the TimelineEngine.
    *
@@ -1790,7 +1794,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     }
 
     for (const rect of this.getTrackRects(input)) {
-      const track = this.state.tracks[rect.trackIndex] as Track<TrackKind> | undefined;
+      const track = this.getTracks<TrackKind>()[rect.trackIndex];
       if (track === undefined) {
         continue;
       }
@@ -2018,7 +2022,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     let y = resolvedGeometry.rulerHeight - this.state.scrollTop;
 
     for (let trackIndex = 0; trackIndex < this.state.tracks.length; trackIndex++) {
-      const track = this.state.tracks[trackIndex] as Track<TrackKind>;
+      const track = this.getTracks<TrackKind>()[trackIndex];
       const trackHeight = this.getTrackViewportHeight(track, resolvedGeometry);
 
       for (let clipIndex = 0; clipIndex < track.clips.length; clipIndex++) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -785,7 +785,12 @@ export interface TimelineSnapTarget {
   priority?: number;
   /** Optional human-readable target label for UI status. */
   label?: string;
-  /** Lightweight application metadata for custom targets. */
+  /**
+   * Lightweight application metadata for custom snap targets.
+   *
+   * Values stay `unknown` because the core engine snapshots and carries this
+   * record without interpreting app-owned domain data.
+   */
   metadata?: Record<string, unknown>;
 }
 
@@ -1342,7 +1347,12 @@ export interface TimelineEditPreview {
   affectedRanges: TimelineEditAffectedRange[];
   /** Clip-level consequences available to renderer and headless UI affordances. */
   impacts: TimelineEditImpact[];
-  /** Lightweight app/UI metadata for custom edit guides. */
+  /**
+   * Lightweight app/UI metadata for custom edit guides.
+   *
+   * Values stay `unknown` because the core engine forwards this record without
+   * interpreting app-owned domain data.
+   */
   guideMetadata?: Record<string, unknown>;
 }
 
@@ -1395,7 +1405,12 @@ export interface Clip {
   snap?: false | ClipSnapOptions;
   /** Clip-scoped property keyframes positioned at absolute timeline times. */
   keyframes?: TimelineKeyframe[];
-  /** Arbitrary custom application metadata attached to this clip. */
+  /**
+   * Arbitrary custom application metadata attached to this clip.
+   *
+   * Values stay `unknown` because Canvas Timeline preserves this record through
+   * snapshots and edits while leaving the schema to the host application.
+   */
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/mediabunny-adapter/src/index.ts
+++ b/packages/mediabunny-adapter/src/index.ts
@@ -125,7 +125,7 @@ interface MediabunnySourceController {
   audioSink: Mediabunny.AudioBufferSink | null;
   audioContext: AudioContext | null;
   gainNode: GainNode | null;
-  audioBufferIterator: AsyncGenerator<Mediabunny.WrappedAudioBuffer, void, unknown> | null;
+  audioBufferIterator: AsyncGenerator<Mediabunny.WrappedAudioBuffer, void, void> | null;
   queuedAudioNodes: Set<AudioBufferSourceNode>;
   timelineTimeAtStart: number;
   audioContextStartTime: number | null;

--- a/packages/react/src/components/playhead/PlayheadArea.tsx
+++ b/packages/react/src/components/playhead/PlayheadArea.tsx
@@ -58,7 +58,7 @@ export const PlayheadArea = React.forwardRef<
     }
   };
 
-  const handlePointerDown = (e: React.PointerEvent) => {
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (e.pointerType !== 'touch' && e.button !== 0) {
       return;
     }
@@ -74,12 +74,12 @@ export const PlayheadArea = React.forwardRef<
       return;
     }
 
-    const target = e.currentTarget as HTMLElement;
     const rect = internalRef.current?.getBoundingClientRect();
     if (!rect) {
       return;
     }
 
+    const target = e.currentTarget;
     engine.pause();
     target.setPointerCapture(e.pointerId);
     e.preventDefault();

--- a/packages/react/src/components/surface/Root.tsx
+++ b/packages/react/src/components/surface/Root.tsx
@@ -89,13 +89,12 @@ export const Root = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
     const startZoomScale = useRef(1);
     const startPinchDistance = useRef(0);
 
-    const handlePointerDown = (e: React.PointerEvent) => {
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.target === internalRef.current) {
         engine.selectClip(null);
       }
 
-      const target = e.currentTarget as HTMLElement;
-      target.setPointerCapture(e.pointerId);
+      e.currentTarget.setPointerCapture(e.pointerId);
 
       activePointers.current.set(e.pointerId, {
         clientX: e.clientX,
@@ -110,7 +109,7 @@ export const Root = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
         startScrollTop.current = engine.scrollTop;
       } else if (activePointers.current.size === 2) {
         isDragging.current = false;
-        const pts = Array.from(activePointers.current.values()) as ActivePointer[];
+        const pts = Array.from(activePointers.current.values());
         const dx = pts[0].clientX - pts[1].clientX;
         const dy = pts[0].clientY - pts[1].clientY;
         startPinchDistance.current = Math.hypot(dx, dy);
@@ -120,7 +119,7 @@ export const Root = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
       }
     };
 
-    const handlePointerMove = (e: React.PointerEvent) => {
+    const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
       const pt = activePointers.current.get(e.pointerId);
       if (!pt) {
         return;
@@ -135,7 +134,7 @@ export const Root = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
         engine.setScrollLeft(Math.max(0, startScrollLeft.current - deltaX));
         engine.setScrollTop(Math.max(0, startScrollTop.current - deltaY));
       } else if (activePointers.current.size === 2) {
-        const pts = Array.from(activePointers.current.values()) as ActivePointer[];
+        const pts = Array.from(activePointers.current.values());
         const dx = pts[0].clientX - pts[1].clientX;
         const dy = pts[0].clientY - pts[1].clientY;
         const currentDistance = Math.hypot(dx, dy);
@@ -169,10 +168,9 @@ export const Root = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
       }
     };
 
-    const handlePointerUp = (e: React.PointerEvent) => {
-      const target = e.currentTarget as HTMLElement;
+    const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
       try {
-        target.releasePointerCapture(e.pointerId);
+        e.currentTarget.releasePointerCapture(e.pointerId);
       } catch {
         // Ignore
       }

--- a/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
@@ -4,6 +4,7 @@ import type { Clip, Track } from '@techsquidtv/canvas-timeline-core';
 import { addRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
 import { getClipAccessibleDescription, getClipAccessibleName } from '#react/accessibility';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import { useTimelineClips } from '#react/hooks/clips/useTimelineClips';
 import { useTimelineEditCommands } from '#react/hooks/editing/useTimelineEditCommands';
 import { useTimelineSnapping } from '#react/hooks/editing/useTimelineSnapping';
@@ -220,7 +221,7 @@ export function useTimelineClipNavigation<TrackKind = string>(
       }
 
       const nextTrackIndex = activeClip.trackIndex + delta;
-      const nextTrack = (state.tracks as Track<TrackKind>[])[nextTrackIndex];
+      const nextTrack = getTimelineTracks<TrackKind>(state.tracks)[nextTrackIndex];
       if (!nextTrack || nextTrack.clips.length === 0) {
         return activeClip;
       }
@@ -283,7 +284,9 @@ export function useTimelineClipNavigation<TrackKind = string>(
         return timelineCommandFail('not-found');
       }
 
-      const nextTrack = (state.tracks as Track<TrackKind>[])[found.trackIndex + deltaTrackIndex];
+      const nextTrack = getTimelineTracks<TrackKind>(state.tracks)[
+        found.trackIndex + deltaTrackIndex
+      ];
       if (!nextTrack) {
         return timelineCommandFail('invalid-track');
       }

--- a/packages/react/src/hooks/clips/useTimelineClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineClips.ts
@@ -5,10 +5,10 @@ import type {
   TimelineEngine,
   TimelineClipGroup,
   TimelineInteractionGeometry,
-  Track,
 } from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
 import { flattenTimelineClips, type TimelineClipEntry } from '#react/hooks/clips/timelineClipModel';
 import {
@@ -177,7 +177,7 @@ export function useTimelineClips<TrackKind = string>(): UseTimelineClipsResult<T
   } = useTimelineSelection<TrackKind>();
 
   const clips = useMemo(
-    () => flattenTimelineClips(state.tracks as Track<TrackKind>[]),
+    () => flattenTimelineClips(getTimelineTracks<TrackKind>(state.tracks)),
     [state.tracks]
   );
 

--- a/packages/react/src/hooks/core/index.ts
+++ b/packages/react/src/hooks/core/index.ts
@@ -1,4 +1,5 @@
 export * from '#react/hooks/core/timelineCommandResult';
+export * from '#react/hooks/core/timelineControlEvents';
 export * from '#react/hooks/core/usePlaybackEffect';
 export * from '#react/hooks/core/useTimeline';
 export * from '#react/hooks/core/useTimelineEvent';

--- a/packages/react/src/hooks/core/timelineControlEvents.ts
+++ b/packages/react/src/hooks/core/timelineControlEvents.ts
@@ -1,0 +1,10 @@
+/**
+ * Opaque interaction metadata forwarded by third-party scalar and range controls.
+ *
+ * @remarks
+ *
+ * Canvas Timeline does not inspect this value because each control primitive can
+ * supply different commit details. Consumers that know their control library's
+ * event shape can narrow it inside their callback before reading fields.
+ */
+export type TimelineControlCommitDetails = unknown;

--- a/packages/react/src/hooks/core/timelineScalarControlProps.ts
+++ b/packages/react/src/hooks/core/timelineScalarControlProps.ts
@@ -1,3 +1,5 @@
+import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
+
 export interface TimelineScalarControlState {
   label: string;
   max: number;
@@ -12,7 +14,7 @@ export interface TimelineScalarControlPropsOptions {
   setValue: (value: number) => void;
   commit: (value?: number) => void;
   getAriaValueText: (value: number) => string;
-  onValueCommitted?: (value: number[], eventDetails?: unknown) => void;
+  onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
   onEmptyCommit?: () => void;
 }
 
@@ -36,7 +38,7 @@ export function createTimelineScalarControlProps({
           setValue(values[0]);
         }
       },
-      onValueCommitted: (values: number[], eventDetails?: unknown) => {
+      onValueCommitted: (values: number[], eventDetails?: TimelineControlCommitDetails) => {
         if (values[0] !== undefined) {
           commit(values[0]);
         } else {

--- a/packages/react/src/hooks/core/timelineTrackState.ts
+++ b/packages/react/src/hooks/core/timelineTrackState.ts
@@ -1,0 +1,14 @@
+import type { TimelineState, Track } from '@techsquidtv/canvas-timeline-core';
+
+/**
+ * Returns timeline tracks with the app's track-kind type applied at the hook boundary.
+ *
+ * Timeline state stores tracks with the package default track-kind type. React
+ * hooks reintroduce the consumer's narrower `TrackKind` generic when returning
+ * typed track collections and clip metadata.
+ */
+export function getTimelineTracks<TrackKind = string>(
+  tracks: TimelineState['tracks']
+): Track<TrackKind>[] {
+  return tracks as Track<TrackKind>[];
+}

--- a/packages/react/src/hooks/core/useTimelineEvent.ts
+++ b/packages/react/src/hooks/core/useTimelineEvent.ts
@@ -10,10 +10,9 @@ import { useTimeline } from '#react/hooks/core/useTimeline';
  * @see {@link useTimelineEvent}
  * @see {@link https://canvastimeline.com/docs/events-and-lifecycle | Events and lifecycle}
  */
-export type TimelineEventHandler<EventName extends keyof EngineEventMap> =
-  EngineEventMap[EventName] extends void
-    ? () => void
-    : (payload: EngineEventMap[EventName]) => void;
+export type TimelineEventHandler<EventName extends keyof EngineEventMap> = (
+  payload: EngineEventMap[EventName]
+) => void;
 
 /** Options for `useTimelineEvent`. */
 export interface TimelineEventOptions {
@@ -31,7 +30,8 @@ export interface TimelineEventOptions {
  * changes. Use it for low-level integration work such as analytics, custom
  * status panels, or imperative bridges. Prefer focused hooks such as
  * {@link useTimelinePlayheadTime} or {@link useTimelineClipDropFeedback} when a
- * public hook already exists for the state you need.
+ * public hook already exists for the state you need. Events with `void`
+ * payloads can still use zero-argument handlers.
  *
  * @param eventName - TimelineEngine event name to subscribe to.
  * @param handler - Callback invoked with the typed event payload.
@@ -73,8 +73,8 @@ export function useTimelineEvent<EventName extends keyof EngineEventMap>(
       return;
     }
 
-    return engine.on(eventName, ((payload: EngineEventMap[EventName]) => {
-      (handlerRef.current as (payload: EngineEventMap[EventName]) => void)(payload);
-    }) as (payload: EngineEventMap[EventName]) => void);
+    return engine.on(eventName, (payload) => {
+      handlerRef.current(payload);
+    });
   }, [enabled, engine, eventName]);
 }

--- a/packages/react/src/hooks/playback/useTimelineMediaSync.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaSync.ts
@@ -239,7 +239,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
   const { adapter, layers, onError, ready = true } = options;
   const adapterSeek = adapter.seek;
   const { engine } = useTimeline();
-  const activeLayers = useActiveLayers({ layers });
+  const activeLayers = useActiveLayers<LayerName>({ layers });
   const adapterRef = useRef(adapter);
   const layersRef = useRef(layers);
   const initialSeekScheduledRef = useRef(false);
@@ -418,7 +418,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
   return useMemo(
     () => ({
       /** Active layers at the current playhead time. */
-      activeLayers: activeLayers as ActiveLayerResult<LayerName>,
+      activeLayers,
       /** Whether synchronized timeline/media playback is currently running. */
       playing: syncPlayback.playing,
       /** Current synchronized playback speed multiplier. */

--- a/packages/react/src/hooks/playback/useTimelinePlayheadControl.ts
+++ b/packages/react/src/hooks/playback/useTimelinePlayheadControl.ts
@@ -19,10 +19,11 @@ export interface TimelinePlayheadControlOptions {
   /** Accessible label for the playhead control. */
   label?: string;
   /**
-   * Called after a Base UI-style value commit has settled the engine.
+   * Called after the hook applies a committed control value to the engine.
    *
-   * `eventDetails` is forwarded from the consumer's scalar control primitive
-   * and stays opaque to Canvas Timeline.
+   * When the underlying scalar control provides commit details, Canvas Timeline
+   * forwards them unchanged as the second argument and does not read their
+   * fields.
    */
   onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }

--- a/packages/react/src/hooks/playback/useTimelinePlayheadControl.ts
+++ b/packages/react/src/hooks/playback/useTimelinePlayheadControl.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { clamp, fromSeconds, toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import { formatTimelineTimeValue } from '#react/accessibility';
+import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { createTimelineScalarControlProps } from '#react/hooks/core/timelineScalarControlProps';
 import { useTimeline } from '#react/hooks/core/useTimeline';
 import { useTimelinePlayheadTime } from '#react/hooks/playback/useTimelinePlayheadTime';
@@ -17,8 +18,13 @@ export interface TimelinePlayheadControlOptions {
   step?: number;
   /** Accessible label for the playhead control. */
   label?: string;
-  /** Called after a Base UI-style value commit has settled the engine. */
-  onValueCommitted?: (value: number[], eventDetails?: unknown) => void;
+  /**
+   * Called after a Base UI-style value commit has settled the engine.
+   *
+   * `eventDetails` is forwarded from the consumer's scalar control primitive
+   * and stays opaque to Canvas Timeline.
+   */
+  onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }
 
 /**

--- a/packages/react/src/hooks/selection/useTimelineSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineSelection.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
-import type { Track } from '@techsquidtv/canvas-timeline-core';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import {
   deriveTimelineSelection,
   type TimelineSelectionState,
@@ -78,7 +78,7 @@ export interface UseTimelineSelectionResult<
 export function useTimelineSelection<TrackKind = string>(): UseTimelineSelectionResult<TrackKind> {
   const { engine, state } = useTimeline();
   const selection = useMemo(
-    () => deriveTimelineSelection(state.tracks as Track<TrackKind>[], state.clipGroups),
+    () => deriveTimelineSelection(getTimelineTracks<TrackKind>(state.tracks), state.clipGroups),
     [state.clipGroups, state.tracks]
   );
 

--- a/packages/react/src/hooks/tracks/useTimelineTrack.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrack.ts
@@ -9,6 +9,7 @@ import {
   type TimelineCommandResult,
 } from '#react/hooks/core/timelineCommandResult';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
 import { useTimelineTracks } from '#react/hooks/tracks/useTimelineTracks';
 
@@ -126,7 +127,7 @@ export function useTimelineTrack<TrackKind extends string = string>(
   const revision = useTimelineGeometryRevision();
   const trackSnapshot = useMemo(() => {
     void revision;
-    const tracks = state.tracks as Track<TrackKind>[];
+    const tracks = getTimelineTracks<TrackKind>(state.tracks);
     const trackIndex = tracks.findIndex((candidate) => candidate.id === trackId);
     const track = trackIndex === -1 ? null : tracks[trackIndex];
 

--- a/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
@@ -9,6 +9,7 @@ import type {
   TrackHitTestInput,
 } from '@techsquidtv/canvas-timeline-core';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
 
 /**
@@ -201,7 +202,7 @@ export function useTimelineTrackDropTargets<TrackKind = string>(
 
   const trackTargets = useMemo(() => {
     void revision;
-    const tracks = state.tracks as Track<TrackKind>[];
+    const tracks = getTimelineTracks<TrackKind>(state.tracks);
     return engine
       .getTrackRects({ ...geometry, viewportWidth })
       .map((rect) => {
@@ -234,13 +235,12 @@ export function useTimelineTrackDropTargets<TrackKind = string>(
         return { canDrop: false, reason: 'not-found', allowCrossKindTrackMove: false };
       }
 
+      const tracks = getTimelineTracks<TrackKind>(state.tracks);
       const sourceTrack =
         sourceTrackId === undefined
-          ? (found.track as Track<TrackKind>)
-          : ((state.tracks as Track<TrackKind>[]).find((track) => track.id === sourceTrackId) ??
-            null);
-      const targetTrack =
-        (state.tracks as Track<TrackKind>[]).find((track) => track.id === targetTrackId) ?? null;
+          ? tracks[found.trackIndex]
+          : (tracks.find((track) => track.id === sourceTrackId) ?? null);
+      const targetTrack = tracks.find((track) => track.id === targetTrackId) ?? null;
 
       if (!sourceTrack || !targetTrack) {
         return { canDrop: false, reason: 'invalid-track', allowCrossKindTrackMove: false };
@@ -249,12 +249,8 @@ export function useTimelineTrackDropTargets<TrackKind = string>(
         return { canDrop: false, reason: 'locked', allowCrossKindTrackMove: false };
       }
 
-      const sourceTrackIndex = (state.tracks as Track<TrackKind>[]).findIndex(
-        (track) => track.id === sourceTrack.id
-      );
-      const targetTrackIndex = (state.tracks as Track<TrackKind>[]).findIndex(
-        (track) => track.id === targetTrack.id
-      );
+      const sourceTrackIndex = tracks.findIndex((track) => track.id === sourceTrack.id);
+      const targetTrackIndex = tracks.findIndex((track) => track.id === targetTrack.id);
       const sameKind = sourceTrack.kind === targetTrack.kind;
 
       if (!sameKind && !customCanDropClipOnTrack) {

--- a/packages/react/src/hooks/tracks/useTimelineTracks.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTracks.ts
@@ -1,6 +1,7 @@
 import type { Track } from '@techsquidtv/canvas-timeline-core';
 import { useCallback, useMemo } from 'react';
 import { useTimeline } from '#react/hooks/core/useTimeline';
+import { getTimelineTracks } from '#react/hooks/core/timelineTrackState';
 import {
   timelineCommandFail,
   timelineCommandOk,
@@ -114,26 +115,20 @@ export interface UseTimelineTracksResult<TrackKind = string> {
  */
 export function useTimelineTracks<TrackKind = string>(): UseTimelineTracksResult<TrackKind> {
   const { engine, state } = useTimeline();
-  const tracks = useMemo(() => state.tracks as Track<TrackKind>[], [state.tracks]);
+  const tracks = useMemo(() => getTimelineTracks<TrackKind>(state.tracks), [state.tracks]);
   const selectedTrack = useMemo(() => tracks.find((track) => track.selected) || null, [tracks]);
   const visibleTracks = useMemo(() => tracks.filter((track) => track.visible), [tracks]);
   const hiddenTracks = useMemo(() => tracks.filter((track) => !track.visible), [tracks]);
   const targetedTracks = useMemo(() => tracks.filter((track) => track.targeted), [tracks]);
-  const tracksByGroupId = useMemo(
-    () =>
-      tracks.reduce(
-        (accumulator, track) => {
-          const groupId = track.groupId || 'ungrouped';
-          if (!accumulator[groupId]) {
-            accumulator[groupId] = [];
-          }
-          accumulator[groupId].push(track);
-          return accumulator;
-        },
-        {} as Record<string, Track<TrackKind>[]>
-      ),
-    [tracks]
-  );
+  const tracksByGroupId = useMemo(() => {
+    const groupedTracks: Record<string, Track<TrackKind>[]> = {};
+    for (const track of tracks) {
+      const groupId = track.groupId || 'ungrouped';
+      groupedTracks[groupId] ??= [];
+      groupedTracks[groupId].push(track);
+    }
+    return groupedTracks;
+  }, [tracks]);
 
   const selectTrack = useCallback(
     (trackId: string | null) => {

--- a/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { clamp, fromSeconds, toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import { formatTimelineRangeValue, formatTimelineTimeValue } from '#react/accessibility';
+import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { useTimeline } from '#react/hooks/core/useTimeline';
 
 /**
@@ -19,8 +20,16 @@ export interface TimelineInOutRangeControlOptions {
   inLabel?: string;
   /** Accessible label for the out-point thumb. */
   outLabel?: string;
-  /** Called after a Base UI-style value commit has settled the engine. */
-  onValueCommitted?: (value: readonly number[], eventDetails?: unknown) => void;
+  /**
+   * Called after a Base UI-style value commit has settled the engine.
+   *
+   * `eventDetails` is forwarded from the consumer's range control primitive
+   * and stays opaque to Canvas Timeline.
+   */
+  onValueCommitted?: (
+    value: readonly number[],
+    eventDetails?: TimelineControlCommitDetails
+  ) => void;
 }
 
 /**
@@ -167,7 +176,10 @@ export function useTimelineInOutRangeControl(options: TimelineInOutRangeControlO
         step: control.step,
         value: control.value,
         onValueChange: setValue,
-        onValueCommitted: (values: readonly number[], eventDetails?: unknown) => {
+        onValueCommitted: (
+          values: readonly number[],
+          eventDetails?: TimelineControlCommitDetails
+        ) => {
           preparedSnapIndexRef.current = null;
           engine.settle();
           onValueCommitted?.(values, eventDetails);

--- a/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
@@ -21,10 +21,11 @@ export interface TimelineInOutRangeControlOptions {
   /** Accessible label for the out-point thumb. */
   outLabel?: string;
   /**
-   * Called after a Base UI-style value commit has settled the engine.
+   * Called after the hook applies a committed range value to the engine.
    *
-   * `eventDetails` is forwarded from the consumer's range control primitive
-   * and stays opaque to Canvas Timeline.
+   * When the underlying range control provides commit details, Canvas Timeline
+   * forwards them unchanged as the second argument and does not read their
+   * fields.
    */
   onValueCommitted?: (
     value: readonly number[],

--- a/packages/react/src/hooks/viewport/useTimelinePanControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelinePanControl.ts
@@ -18,10 +18,11 @@ export interface TimelinePanControlOptions {
   /** Accessible label for the pan control. */
   label?: string;
   /**
-   * Called after a Base UI-style value commit has settled the engine.
+   * Called after the hook applies a committed control value to the engine.
    *
-   * `eventDetails` is forwarded from the consumer's scalar control primitive
-   * and stays opaque to Canvas Timeline.
+   * When the underlying scalar control provides commit details, Canvas Timeline
+   * forwards them unchanged as the second argument and does not read their
+   * fields.
    */
   onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }

--- a/packages/react/src/hooks/viewport/useTimelinePanControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelinePanControl.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { clamp, round } from '@techsquidtv/canvas-timeline-utils';
+import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { createTimelineScalarControlProps } from '#react/hooks/core/timelineScalarControlProps';
 import { useTimeline } from '#react/hooks/core/useTimeline';
 import { useTimelineScrollLeft } from '#react/hooks/viewport/useTimelineScrollLeft';
@@ -16,8 +17,13 @@ export interface TimelinePanControlOptions {
   step?: number;
   /** Accessible label for the pan control. */
   label?: string;
-  /** Called after a Base UI-style value commit has settled the engine. */
-  onValueCommitted?: (value: number[], eventDetails?: unknown) => void;
+  /**
+   * Called after a Base UI-style value commit has settled the engine.
+   *
+   * `eventDetails` is forwarded from the consumer's scalar control primitive
+   * and stays opaque to Canvas Timeline.
+   */
+  onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }
 
 function formatPanValue(value: number) {

--- a/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
@@ -18,10 +18,11 @@ export interface TimelineZoomControlOptions {
   /** Accessible label for the zoom control. */
   label?: string;
   /**
-   * Called after a Base UI-style value commit has settled the engine.
+   * Called after the hook applies a committed control value to the engine.
    *
-   * `eventDetails` is forwarded from the consumer's scalar control primitive
-   * and stays opaque to Canvas Timeline.
+   * When the underlying scalar control provides commit details, Canvas Timeline
+   * forwards them unchanged as the second argument and does not read their
+   * fields.
    */
   onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }

--- a/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { clamp, round } from '@techsquidtv/canvas-timeline-utils';
+import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { createTimelineScalarControlProps } from '#react/hooks/core/timelineScalarControlProps';
 import { useTimeline } from '#react/hooks/core/useTimeline';
 import { useTimelineZoomScale } from '#react/hooks/viewport/useTimelineZoomScale';
@@ -16,8 +17,13 @@ export interface TimelineZoomControlOptions {
   step?: number;
   /** Accessible label for the zoom control. */
   label?: string;
-  /** Called after a Base UI-style value commit has settled the engine. */
-  onValueCommitted?: (value: number[], eventDetails?: unknown) => void;
+  /**
+   * Called after a Base UI-style value commit has settled the engine.
+   *
+   * `eventDetails` is forwarded from the consumer's scalar control primitive
+   * and stays opaque to Canvas Timeline.
+   */
+  onValueCommitted?: (value: number[], eventDetails?: TimelineControlCommitDetails) => void;
 }
 
 function formatZoomValue(value: number) {

--- a/packages/renderer/src/TimelineCanvasLayer.tsx
+++ b/packages/renderer/src/TimelineCanvasLayer.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useRef,
-  type CanvasHTMLAttributes,
-  type MutableRefObject,
-} from 'react';
+import React, { useCallback, useRef, type CanvasHTMLAttributes } from 'react';
 import {
   useTimelineCanvasLayer,
   type UseTimelineCanvasLayerOptions,
@@ -86,7 +81,7 @@ export const TimelineCanvasLayer = React.forwardRef<HTMLCanvasElement, TimelineC
         if (typeof forwardedRef === 'function') {
           forwardedRef(node);
         } else if (forwardedRef) {
-          (forwardedRef as MutableRefObject<HTMLCanvasElement | null>).current = node;
+          forwardedRef.current = node;
         }
       },
       [forwardedRef]

--- a/packages/renderer/src/worker.ts
+++ b/packages/renderer/src/worker.ts
@@ -71,7 +71,7 @@ self.onmessage = (event: MessageEvent<CanvasRendererWorkerMessage>) => {
   const message = event.data;
   if (message.type === 'INIT') {
     canvas = message.canvas;
-    ctx = canvas?.getContext('2d', { alpha: false }) as OffscreenCanvasRenderingContext2D;
+    ctx = canvas.getContext('2d', { alpha: false });
     state = message.state;
     dpr = message.dpr || 1;
     keyframesRequested = message.keyframesRequested ?? Boolean(message.options?.showKeyframes);


### PR DESCRIPTION
## Summary

- Document intentional public unknown surfaces for app metadata and third-party control commit details.
- Centralize generic track-kind assertions and remove avoidable production casts in React, renderer, and media paths.
- Update the public release checklist and React hooks docs with the reviewed type-boundary guidance.

## Release Impact

- Packages/API: React hooks now expose the named TimelineControlCommitDetails type; core metadata unknowns are documented as intentional opaque app-owned records.
- Docs/demos: React hooks docs mention opaque control commit details; no demo behavior changes.
- Breaking changes: Pre-public-release type/API hardening only; no compatibility aliases or fallback exports were added.
- Checklist areas reviewed: public release checklist sections 1, 2, 8, and 10.

## Validation

- vp run repo:check
- vp test
- vp run changeset:status
- git push pre-push hook ran vp run ci successfully, including package validation and coverage thresholds.