### PR TITLE
ci: pin latest GitHub Actions

### DIFF
--- a/.changeset/update-github-actions.md
+++ b/.changeset/update-github-actions.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Update GitHub Actions workflow action majors and deploy-docs runtime setup without changing published package contents.
+Pin GitHub Actions workflow actions to verified latest tags and update deploy-docs runtime setup without changing published package contents.

--- a/.changeset/update-github-actions.md
+++ b/.changeset/update-github-actions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update GitHub Actions workflow action majors and deploy-docs runtime setup without changing published package contents.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -36,7 +36,7 @@ jobs:
 
       - name: Restore Vite Task cache
         id: vite-task-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -55,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -70,7 +70,7 @@ jobs:
 
       - name: Restore Vite Task cache
         id: vite-task-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           # Quality and build save in parallel, so scope primary keys by job while
@@ -84,7 +84,7 @@ jobs:
 
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
@@ -98,12 +98,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -113,7 +113,7 @@ jobs:
 
       - name: Restore Vite Task cache
         id: vite-task-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           # Quality and build save in parallel, so scope primary keys by job while
@@ -129,7 +129,7 @@ jobs:
         run: vp run repo:package:validate
 
       - name: Upload docs build
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: docs-build
           path: apps/www/dist/client
@@ -138,7 +138,7 @@ jobs:
 
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
@@ -163,16 +163,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           run-install: false
 
       - name: Download docs build
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8.0.1
         with:
           name: docs-build
           path: apps/www/dist/client
@@ -183,7 +183,7 @@ jobs:
       - name: Deploy production docs to Cloudflare Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy-production
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@v4.0.0
         with:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
@@ -195,7 +195,7 @@ jobs:
       - name: Deploy preview docs to Cloudflare Pages
         if: github.event_name == 'pull_request' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy-preview
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@v4.0.0
         with:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: vp run repo:package:validate
 
       - name: Upload docs build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: docs-build
           path: apps/www/dist/client
@@ -165,8 +165,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '24'
+          run-install: false
+
       - name: Download docs build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: docs-build
           path: apps/www/dist/client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && !inputs.snapshot && vars.ENABLE_PACKAGE_PUBLISH == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -50,7 +50,7 @@ jobs:
 
       - name: Restore Vite Task cache
         id: vite-task-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create release PR or publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.9.0
         with:
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'
@@ -81,7 +81,7 @@ jobs:
 
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
@@ -93,12 +93,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.snapshot && vars.ENABLE_PACKAGE_PUBLISH == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true
@@ -108,7 +108,7 @@ jobs:
 
       - name: Restore Vite Task cache
         id: vite-task-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Save Vite Task cache
         if: success()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v6.1.0
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,16 +23,16 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.0
         with:
           languages: javascript-typescript
           build-mode: none
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.0
         with:
           category: '/language:javascript-typescript'
 
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@v1.15.0
         with:
           node-version: '24'
           cache: true


### PR DESCRIPTION
## Summary

- Pin every GitHub Action reference in `.github/workflows` to the verified latest exact tag.
- Keep the docs deploy job on Node 24 before Corepack/Wrangler runs so deploy tooling matches the repo engine requirement.
- Add an empty changeset for this CI-only PR.

## Verified Action Versions

| Action repository | Verified latest tag | Current workflow uses |
| --- | --- | --- |
| `actions/checkout` | `v7.0.0` via `gh api repos/actions/checkout/releases/latest` | 10 |
| `voidzero-dev/setup-vp` | `v1.15.0` via `gh api repos/voidzero-dev/setup-vp/releases/latest` | 9 |
| `actions/cache` | `v6.1.0` via `gh api repos/actions/cache/releases/latest` | 10 (`restore`/`save`) |
| `actions/upload-artifact` | `v7.0.1` via `gh api repos/actions/upload-artifact/releases/latest` | 1 |
| `actions/download-artifact` | `v8.0.1` via `gh api repos/actions/download-artifact/releases/latest` | 1 |
| `cloudflare/wrangler-action` | `v4.0.0` via `gh api repos/cloudflare/wrangler-action/releases/latest` | 2 |
| `github/codeql-action` | `v4.37.0` via `gh api repos/github/codeql-action/git/matching-refs/tags/v4` semver tag filter | 2 (`init`/`analyze`) |
| `changesets/action` | `v1.9.0` via `gh api repos/changesets/action/releases/latest` | 1 |

## Release Impact

- Packages/API: None.
- Docs/demos: Docs deploy workflow only.
- Breaking changes: GitHub Action exact-version upgrades in CI/release/security workflows; no runtime package compatibility aliases or fallbacks added.
- Checklist areas reviewed: sections 6 and 11.

## Validation

- `ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].each { |f| YAML.load_file(f) }"`
- `rg --no-filename -o "uses: [^ ]+@[^ ]+" .github/workflows | sed 's/^uses: //' | sort | uniq -c`
- `rg -n "uses: [^ ]+@v[0-9]+$" .github/workflows` returned no floating major refs
- `vp run repo:check`
- `vp exec changeset status --since=origin/main`
- `printf '%s\\n' "ci: pin latest GitHub Actions" | vp exec commitlint --verbose`
- pre-push hook ran broader repo validation and package smoke checks successfully.