### PR TITLE
ci: fix full editor demo deploy artifact

### DIFF
--- a/.changeset/fix-full-editor-demo-ci-base.md
+++ b/.changeset/fix-full-editor-demo-ci-base.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the docs CI build path so the staged full editor demo uses its production route base and fails the build when emitted assets are missing or root-based.

--- a/apps/full-editor-demo/package.json
+++ b/apps/full-editor-demo/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vp build",
+    "build:docs": "env CANVAS_TIMELINE_FULL_EDITOR_BASE=/demos/full-editor-demo/ vp build",
     "clean": "rm -rf dist",
     "dev": "vp dev --host=0.0.0.0",
     "preview": "vp preview --host=0.0.0.0",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -10,15 +10,16 @@
   },
   "scripts": {
     "dev": "vp run docs:api && astro dev --port=4321 --host=0.0.0.0",
-    "build": "vp run docs:sponsors && vp run docs:api && vp run docs:demos && vp run docs:links && vp run docs:registry && vp run docs:og && vp run docs:editor && astro build",
+    "build": "vp run docs:sponsors && vp run docs:api && vp run docs:demos && vp run docs:links && vp run docs:registry && vp run docs:og && vp run docs:editor && astro build && vp run docs:editor:verify",
     "preview": "astro preview --host=0.0.0.0",
     "docs:api": "node scripts/generate-api-reference.mjs",
     "docs:links": "node scripts/verify-links.mjs",
     "docs:sponsors": "tsx scripts/sync-sponsors.ts",
     "docs:demos": "node scripts/verify-demos.mjs",
-    "docs:editor": "env CANVAS_TIMELINE_FULL_EDITOR_BASE=/demos/full-editor-demo/ vp run --filter @techsquidtv/canvas-timeline-full-editor-demo build && node scripts/stage-full-editor-demo.mjs",
+    "docs:editor": "vp run --filter @techsquidtv/canvas-timeline-full-editor-demo build:docs && node scripts/stage-full-editor-demo.mjs",
     "docs:registry": "node ../../scripts/verify-react-registry.mjs",
     "docs:og": "tsx scripts/generate-open-graph.ts",
+    "docs:editor:verify": "node scripts/verify-full-editor-demo-build.mjs",
     "docs:demo:new": "node scripts/scaffold-demo.mjs",
     "clean": "rm -rf .astro dist .generated public/open-graph public/demos/full-editor-demo public/full-editor-demo"
   },

--- a/apps/www/scripts/verify-full-editor-demo-build.mjs
+++ b/apps/www/scripts/verify-full-editor-demo-build.mjs
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const appRoot = resolve(import.meta.dirname, '..');
+const distRoot = join(appRoot, 'dist/client');
+const demoRoute = '/demos/full-editor-demo/';
+const demoIndexPath = join(distRoot, 'demos/full-editor-demo/index.html');
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+if (!existsSync(demoIndexPath)) {
+  fail(`Missing full editor demo build at ${relative(appRoot, demoIndexPath)}.`);
+  process.exit();
+}
+
+const html = readFileSync(demoIndexPath, 'utf8');
+const assetPaths = [
+  ...new Set(
+    [...html.matchAll(/\b(?:src|href)="([^"]+)"/gu)]
+      .map((match) => match[1])
+      .filter((value) => value.includes('/assets/'))
+  ),
+];
+
+if (assetPaths.length === 0) {
+  fail('Full editor demo build does not reference any emitted assets.');
+}
+
+for (const assetPath of assetPaths) {
+  if (!assetPath.startsWith(`${demoRoute}assets/`)) {
+    fail(
+      `Full editor demo asset uses the wrong base path: ${assetPath}. Expected ${demoRoute}assets/.`
+    );
+    continue;
+  }
+
+  const assetFilePath = join(distRoot, assetPath.slice(1));
+  if (!existsSync(assetFilePath)) {
+    fail(
+      `Full editor demo asset is referenced but missing: ${relative(dirname(demoIndexPath), assetFilePath)}.`
+    );
+  }
+}
+
+if (process.exitCode) {
+  process.exit();
+}
+
+console.info(`Verified ${assetPaths.length} full editor demo build assets.`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,8 +64,7 @@ export default defineConfig({
         dependsOn: ['build:core', 'build:react', 'build:utils'],
       },
       'build:full-editor-demo': {
-        command: 'vp build',
-        cwd: 'apps/full-editor-demo',
+        command: 'vp run --filter @techsquidtv/canvas-timeline-full-editor-demo build:docs',
         input: [
           'apps/full-editor-demo/index.html',
           'apps/full-editor-demo/package.json',
@@ -116,7 +115,7 @@ export default defineConfig({
       'build:www': {
         command: 'node -e ""',
         cache: false,
-        dependsOn: ['build:www:astro'],
+        dependsOn: ['build:www:verify-full-editor-demo'],
       },
       'build:www:astro': {
         command: 'vp exec astro build',
@@ -131,6 +130,17 @@ export default defineConfig({
           'docs:og',
           'docs:editor',
         ],
+      },
+      'build:www:verify-full-editor-demo': {
+        command: 'vp run docs:editor:verify',
+        cwd: 'apps/www',
+        dependsOn: ['build:www:astro'],
+        input: [
+          'apps/www/dist/client/demos/full-editor-demo/index.html',
+          'apps/www/dist/client/demos/full-editor-demo/assets/**',
+          'apps/www/scripts/verify-full-editor-demo-build.mjs',
+        ],
+        output: [],
       },
       'coverage:package': {
         command: 'node scripts/check-package-coverage.mjs',


### PR DESCRIPTION
## Summary

- Build the full editor demo with the production docs route base from the root Vite+ task graph.
- Add a docs build verifier that fails when the embedded full-editor HTML points at root /assets or references missing emitted chunks.
- Add an empty changeset for this CI/docs pipeline fix.

## Release Impact

- Packages/API: None.
- Docs/demos: Fixes the production full-editor demo artifact generated by CI.
- Breaking changes: None.
- Checklist areas reviewed: CI/docs deploy path and demo build verification.

## Validation

- `vp check --fix vite.config.ts apps/www/package.json apps/www/scripts/verify-full-editor-demo-build.mjs .changeset/fix-full-editor-demo-ci-base.md`
- `vp run build:www`
- `node apps/www/scripts/verify-full-editor-demo-build.mjs`
- `vp run ci:quality`
- pre-push package smoke