### PR TITLE
perf(demo): reduce full editor playback churn

### DIFF
--- a/.changeset/full-editor-playback-churn.md
+++ b/.changeset/full-editor-playback-churn.md
@@ -1,0 +1,4 @@
+---
+---
+
+Reduce full editor demo playback-time React churn without changing published package output.

--- a/apps/full-editor-demo/src/components/timeline/TimelineCommandBar.tsx
+++ b/apps/full-editor-demo/src/components/timeline/TimelineCommandBar.tsx
@@ -4,7 +4,7 @@ import {
   useTimelineClips,
   useTimelineEditCommands,
   useTimelineHistory,
-  useTimelinePlayheadTime,
+  useTimeline,
 } from '@techsquidtv/canvas-timeline-react';
 import { ClipboardPaste, Copy, Redo2, Trash2, Undo2, Unlink2 } from 'lucide-react';
 import { Button } from '#full-editor/components/ui/button';
@@ -62,15 +62,15 @@ function CopySelectionButton() {
 }
 
 function PasteAtPlayheadButton() {
+  const { engine } = useTimeline();
   const clipboard = useTimelineClipboard();
-  const playheadTime = useTimelinePlayheadTime();
 
   return (
     <Button
       aria-label="Paste at playhead"
       disabled={!clipboard.canPaste}
       iconOnly
-      onClick={() => clipboard.pasteSelection(playheadTime)}
+      onClick={() => clipboard.pasteSelection(engine.getTime())}
       title="Paste at playhead"
       variant="ghost"
     >

--- a/apps/full-editor-demo/src/components/timeline/TransportBar.tsx
+++ b/apps/full-editor-demo/src/components/timeline/TransportBar.tsx
@@ -1,5 +1,6 @@
 import {
   TimecodeField,
+  useTimeline,
   useTimelineClips,
   useTimelineEditCommands,
   useTimelineMarkers,
@@ -8,13 +9,24 @@ import {
   useTimelinePlayheadTime,
   useTimelineSnapping,
 } from '@techsquidtv/canvas-timeline-react';
-import { compareRational } from '@techsquidtv/canvas-timeline-utils';
+import { compareRational, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { Magnet, MapPin, Pause, Play, Scissors, StepBack, StepForward, X } from 'lucide-react';
 import { useEditorMediaSync } from '#full-editor/editor/shell/media-sync-context';
 import { Button } from '#full-editor/components/ui/button';
 import { Separator } from '#full-editor/components/ui/separator';
 import { useEditorProject } from '#full-editor/editor/project/project-context';
 import type { EditorTrackKind } from '#full-editor/data/demo-project';
+
+interface TimelineBoundedClip {
+  timelineEnd: RationalTime;
+  timelineStart: RationalTime;
+}
+
+function containsTimelineTime(clip: TimelineBoundedClip, time: RationalTime) {
+  return (
+    compareRational(time, clip.timelineStart) > 0 && compareRational(time, clip.timelineEnd) < 0
+  );
+}
 
 function PlayheadTimecodeControl() {
   const playheadControl = useTimelinePlayheadControl();
@@ -33,13 +45,12 @@ function PlayheadTimecodeControl() {
 }
 
 function CutSelectedClipButton() {
-  const playheadTime = useTimelinePlayheadTime();
+  const { engine } = useTimeline();
   const { selectedClip } = useTimelineClips<EditorTrackKind>();
   const { splitClip } = useTimelineEditCommands();
+  const playheadTime = engine.getTime();
   const canCutSelectedClip =
-    selectedClip !== null &&
-    compareRational(playheadTime, selectedClip.timelineStart) > 0 &&
-    compareRational(playheadTime, selectedClip.timelineEnd) < 0;
+    selectedClip !== null && containsTimelineTime(selectedClip, playheadTime);
 
   return (
     <Button
@@ -47,8 +58,11 @@ function CutSelectedClipButton() {
       disabled={!canCutSelectedClip}
       iconOnly
       onClick={() => {
+        const currentPlayheadTime = engine.getTime();
         if (selectedClip !== null) {
-          splitClip(selectedClip.id, playheadTime);
+          if (containsTimelineTime(selectedClip, currentPlayheadTime)) {
+            splitClip(selectedClip.id, currentPlayheadTime);
+          }
         }
       }}
       title={

--- a/apps/full-editor-demo/src/editor/autosave/usePersistableTimelineSnapshot.ts
+++ b/apps/full-editor-demo/src/editor/autosave/usePersistableTimelineSnapshot.ts
@@ -1,8 +1,6 @@
 import {
   useTimelineClipGroups,
   useTimelineMarkers,
-  useTimelinePlayback,
-  useTimelinePlayheadTime,
   useTimelineScrollLeft,
   useTimelineScrollTop,
   useTimelineSnapping,
@@ -29,8 +27,6 @@ export function usePersistableTimelineSnapshot(): PersistableTimelineSnapshot {
   const state = useTimelineState();
   const clipGroups = useTimelineClipGroups();
   const markers = useTimelineMarkers();
-  const playback = useTimelinePlayback();
-  const playheadTime = useTimelinePlayheadTime();
   const scrollLeft = useTimelineScrollLeft();
   const scrollTop = useTimelineScrollTop();
   const snapping = useTimelineSnapping();
@@ -41,9 +37,9 @@ export function usePersistableTimelineSnapshot(): PersistableTimelineSnapshot {
     const sanitizedState = sanitizePersistedTimelineState({
       clipGroups: clipGroups.groups,
       duration: state.duration,
-      inPoint: playback.inPoint,
+      inPoint: state.inPoint,
       markers: markers.markers,
-      outPoint: playback.outPoint,
+      outPoint: state.outPoint,
       playheadTime: { v: 0, r: 60000 },
       scrollLeft: 0,
       scrollTop: 0,
@@ -65,8 +61,8 @@ export function usePersistableTimelineSnapshot(): PersistableTimelineSnapshot {
   }, [
     clipGroups.groups,
     markers.markers,
-    playback.inPoint,
-    playback.outPoint,
+    state.inPoint,
+    state.outPoint,
     snapping.enabled,
     snapping.thresholdPixels,
     state.duration,
@@ -76,12 +72,12 @@ export function usePersistableTimelineSnapshot(): PersistableTimelineSnapshot {
   const timelineState = useMemo(
     () => ({
       ...contentState,
-      playheadTime: { ...playheadTime },
+      playheadTime: { ...state.playheadTime },
       scrollLeft,
       scrollTop,
       zoomScale,
     }),
-    [contentState, playheadTime, scrollLeft, scrollTop, zoomScale]
+    [contentState, scrollLeft, scrollTop, state.playheadTime, zoomScale]
   );
 
   const contentFingerprint = useMemo(() => JSON.stringify(contentState), [contentState]);

--- a/apps/full-editor-demo/src/editor/shell/MediaSyncProvider.tsx
+++ b/apps/full-editor-demo/src/editor/shell/MediaSyncProvider.tsx
@@ -39,52 +39,53 @@ function ActiveMediaSyncProvider({
   sources: readonly MediabunnySource[];
 }) {
   const [playbackError, setPlaybackError] = useState<string | null>(null);
-  const media = useMediabunnyTimelineMedia<PreviewLayerName>({
-    canvasRef,
-    sources,
-    layers: previewLayerSelectors,
-    onError: setPlaybackError,
-  });
+  const { durationBySourceId, pause, play, playing, ready, status } =
+    useMediabunnyTimelineMedia<PreviewLayerName>({
+      canvasRef,
+      sources,
+      layers: previewLayerSelectors,
+      onError: setPlaybackError,
+    });
 
   const clearPlaybackError = useCallback(() => {
     setPlaybackError(null);
   }, []);
 
   const togglePlay = useCallback(async () => {
-    if (media.playing) {
-      media.pause();
+    if (playing) {
+      pause();
       clearPlaybackError();
       return;
     }
 
-    const result = await media.play();
+    const result = await play();
     setPlaybackError(result.ok ? null : result.message);
-  }, [clearPlaybackError, media]);
+  }, [clearPlaybackError, pause, play, playing]);
 
   const value = useMemo<EditorMediaSyncContextValue>(
     () => ({
       canvasRef,
       clearPlaybackError,
-      durationBySourceId: media.durationBySourceId,
+      durationBySourceId,
       hasMediaSources: true,
-      pause: media.pause,
-      play: media.play,
+      pause,
+      play,
       playbackError,
-      playing: media.playing,
-      ready: media.ready,
-      status: media.status,
+      playing,
+      ready,
+      status,
       togglePlay,
     }),
     [
       canvasRef,
       clearPlaybackError,
-      media.durationBySourceId,
-      media.pause,
-      media.play,
-      media.playing,
-      media.ready,
-      media.status,
+      durationBySourceId,
+      pause,
+      play,
+      playing,
       playbackError,
+      ready,
+      status,
       togglePlay,
     ]
   );

--- a/apps/full-editor-demo/src/editor/shell/MediaSyncProvider.tsx
+++ b/apps/full-editor-demo/src/editor/shell/MediaSyncProvider.tsx
@@ -1,6 +1,5 @@
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 import type { MediabunnySource } from '@techsquidtv/canvas-timeline-mediabunny-adapter';
-import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { useSourceBinMedia } from '#full-editor/components/source-bin/source-bin-context';
 import {
@@ -64,12 +63,10 @@ function ActiveMediaSyncProvider({
 
   const value = useMemo<EditorMediaSyncContextValue>(
     () => ({
-      activeLayers: media.activeLayers,
       canvasRef,
       clearPlaybackError,
       durationBySourceId: media.durationBySourceId,
       hasMediaSources: true,
-      lastFrameTime: media.lastFrameTime,
       pause: media.pause,
       play: media.play,
       playbackError,
@@ -81,9 +78,7 @@ function ActiveMediaSyncProvider({
     [
       canvasRef,
       clearPlaybackError,
-      media.activeLayers,
       media.durationBySourceId,
-      media.lastFrameTime,
       media.pause,
       media.play,
       media.playing,
@@ -123,22 +118,10 @@ function IdleMediaSyncProvider({
   const togglePlay = useCallback(() => play().then(() => undefined), [play]);
   const value = useMemo<EditorMediaSyncContextValue>(
     () => ({
-      activeLayers: {
-        all: [],
-        byTrack: new Map(),
-        hasActiveClips: false,
-        layers: {
-          audio: [],
-          visuals: [],
-        },
-        primary: {},
-        time: fromSeconds(0),
-      },
       canvasRef,
       clearPlaybackError,
       durationBySourceId: new Map(),
       hasMediaSources: false,
-      lastFrameTime: null,
       pause,
       play,
       playbackError: null,

--- a/apps/full-editor-demo/src/editor/shell/media-sync-context.ts
+++ b/apps/full-editor-demo/src/editor/shell/media-sync-context.ts
@@ -6,14 +6,7 @@ type MediaSyncState = UseMediabunnyTimelineMediaResult<PreviewLayerName>;
 
 export interface EditorMediaSyncContextValue extends Pick<
   MediaSyncState,
-  | 'activeLayers'
-  | 'durationBySourceId'
-  | 'lastFrameTime'
-  | 'pause'
-  | 'play'
-  | 'playing'
-  | 'ready'
-  | 'status'
+  'durationBySourceId' | 'pause' | 'play' | 'playing' | 'ready' | 'status'
 > {
   canvasRef: RefObject<HTMLCanvasElement | null>;
   clearPlaybackError: () => void;


### PR DESCRIPTION
## Summary

- Reduce full editor demo React churn during media playback by removing live playhead subscriptions from autosave and click-only edit commands.
- Keep unused media sync fields out of the full editor context so per-frame adapter updates do not propagate through the editor shell.
- Add an empty changeset for the required PR gate.

## Release Impact

- Packages/API: None. Published package APIs and package output are unchanged.
- Docs/demos: Full editor demo playback path only.
- Breaking changes: None for public APIs. Internal full-editor media context fields `activeLayers` and `lastFrameTime` were removed because they were unused.
- Checklist areas reviewed: 0, 3, 4, 8, 10.

## Validation

- `vp run --filter @techsquidtv/canvas-timeline-full-editor-demo typecheck`
- `vp run --filter @techsquidtv/canvas-timeline-full-editor-demo build`
- `vp exec changeset status --since=origin/main`
- `printf '%s\n' 'perf(demo): reduce full editor playback churn' | vp exec commitlint --verbose`
- Pre-push hook completed successfully, including quality checks, tests, docs build, package build, and package validation.
