### PR TITLE
fix(demo): harden full editor recovery and controls

### DIFF
--- a/apps/full-editor-demo/src/App.tsx
+++ b/apps/full-editor-demo/src/App.tsx
@@ -111,8 +111,14 @@ function LoadedEditor({
   bootstrapState: EditorBootstrapState;
   resetEditorProject: (metadataOverride?: ProjectMetadataOverride) => Promise<void>;
 }) {
+  const persistenceWritable =
+    bootstrapState.storageAvailable && bootstrapState.projectRestoreError === undefined;
   const [autosaveStatus, setAutosaveStatus] = useState<ProjectAutosaveStatus>(
-    bootstrapState.storageAvailable ? 'saved' : 'unavailable'
+    bootstrapState.projectRestoreError === undefined
+      ? bootstrapState.storageAvailable
+        ? 'saved'
+        : 'unavailable'
+      : 'error'
   );
   const [projectMetadata, setProjectMetadata] = useState<ProjectMetadata>(
     bootstrapState.projectMetadata
@@ -169,6 +175,7 @@ function LoadedEditor({
       <ProjectProvider
         autosaveStatus={autosaveStatus}
         metadata={projectMetadata}
+        projectRestoreError={bootstrapState.projectRestoreError}
         resetProject={resetEditorProject}
         rulerFormat={rulerFormat}
         setProjectFrameRatePreset={setProjectFrameRatePreset}
@@ -178,7 +185,10 @@ function LoadedEditor({
         storageAvailable={bootstrapState.storageAvailable}
       >
         <ProjectAutosave
-          enabled={bootstrapState.storageAvailable}
+          disabledStatus={
+            bootstrapState.projectRestoreError === undefined ? 'unavailable' : 'error'
+          }
+          enabled={persistenceWritable}
           metadata={projectMetadata}
           onStatusChange={setAutosaveStatus}
         />

--- a/apps/full-editor-demo/src/components/panels/ProjectPanel.test.tsx
+++ b/apps/full-editor-demo/src/components/panels/ProjectPanel.test.tsx
@@ -103,3 +103,12 @@ test('ProjectPanel cancels a ruler-format draft without applying it', () => {
   expect(rulerFormatSelect.value).toBe('seconds');
   expect(context.setRulerFormat).not.toHaveBeenCalled();
 });
+
+test('ProjectPanel reports when project recovery disables autosave', () => {
+  renderProjectPanel({ projectRestoreError: 'Snapshot is invalid.' });
+
+  const recoveryMessage = screen.getByText(/Saved project restore failed: Snapshot is invalid\./);
+  expect(recoveryMessage.textContent).toContain(
+    'Autosave is disabled until a new project is created.'
+  );
+});

--- a/apps/full-editor-demo/src/components/panels/ProjectPanel.tsx
+++ b/apps/full-editor-demo/src/components/panels/ProjectPanel.tsx
@@ -35,6 +35,7 @@ export function ProjectPanel() {
   const state = useTimelineState();
   const {
     metadata,
+    projectRestoreError,
     rulerFormat,
     setProjectFrameRatePreset,
     setProjectResolutionPreset,
@@ -121,6 +122,13 @@ export function ProjectPanel() {
           <dd>{clips.length}</dd>
         </div>
       </dl>
+
+      {projectRestoreError === undefined ? null : (
+        <p className="editor-menu-error">
+          Saved project restore failed: {projectRestoreError} Autosave is disabled until a new
+          project is created.
+        </p>
+      )}
 
       <section className="project-panel-settings">
         <h3 className="project-panel-heading">Project Settings</h3>

--- a/apps/full-editor-demo/src/components/timeline/CutSelectedClipButton.tsx
+++ b/apps/full-editor-demo/src/components/timeline/CutSelectedClipButton.tsx
@@ -1,0 +1,51 @@
+import {
+  useTimeline,
+  useTimelineClips,
+  useTimelineEditCommands,
+} from '@techsquidtv/canvas-timeline-react';
+import { toSeconds, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
+import { Scissors } from 'lucide-react';
+import { Button } from '#full-editor/components/ui/button';
+import type { EditorTrackKind } from '#full-editor/data/demo-project';
+
+interface TimelineBoundedClip {
+  timelineEnd: RationalTime;
+  timelineStart: RationalTime;
+}
+
+export function CutSelectedClipButton({ playheadSeconds }: { playheadSeconds: number }) {
+  const { engine } = useTimeline();
+  const { selectedClip } = useTimelineClips<EditorTrackKind>();
+  const { splitClip } = useTimelineEditCommands();
+  const canCutSelectedClip =
+    selectedClip !== null && containsTimelineSeconds(selectedClip, playheadSeconds);
+
+  return (
+    <Button
+      aria-label="Cut selected clip at playhead"
+      disabled={!canCutSelectedClip}
+      iconOnly
+      onClick={() => {
+        const currentPlayheadTime = engine.getTime();
+        if (
+          selectedClip !== null &&
+          containsTimelineSeconds(selectedClip, toSeconds(currentPlayheadTime))
+        ) {
+          splitClip(selectedClip.id, currentPlayheadTime);
+        }
+      }}
+      title={
+        canCutSelectedClip
+          ? 'Cut selected clip at playhead'
+          : 'Select a clip and place the playhead inside it'
+      }
+      variant="ghost"
+    >
+      <Scissors aria-hidden="true" />
+    </Button>
+  );
+}
+
+function containsTimelineSeconds(clip: TimelineBoundedClip, timeSeconds: number) {
+  return timeSeconds > toSeconds(clip.timelineStart) && timeSeconds < toSeconds(clip.timelineEnd);
+}

--- a/apps/full-editor-demo/src/components/timeline/TransportBar.test.tsx
+++ b/apps/full-editor-demo/src/components/timeline/TransportBar.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { TimelineProvider } from '@techsquidtv/canvas-timeline-react';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { expect, test } from 'vite-plus/test';
+import { CutSelectedClipButton } from '#full-editor/components/timeline/CutSelectedClipButton';
+
+test('CutSelectedClipButton reacts to the current playhead position', () => {
+  const engine = new TimelineEngine({
+    duration: fromSeconds(10),
+    playheadTime: fromSeconds(0),
+    tracks: [
+      {
+        clips: [
+          {
+            id: 'clip-selected',
+            selected: true,
+            sourceId: 'source-video',
+            sourceStart: fromSeconds(0),
+            timelineEnd: fromSeconds(6),
+            timelineStart: fromSeconds(2),
+          },
+        ],
+        id: 'track-v1',
+        kind: 'visual',
+        locked: false,
+        muted: false,
+        name: 'V1',
+        selected: false,
+        targeted: true,
+        visible: true,
+      },
+    ],
+  });
+  const renderButton = (playheadSeconds: number) => (
+    <TimelineProvider engine={engine}>
+      <CutSelectedClipButton playheadSeconds={playheadSeconds} />
+    </TimelineProvider>
+  );
+  const { rerender } = render(renderButton(0));
+  const button = screen.getByRole<HTMLButtonElement>('button', {
+    name: 'Cut selected clip at playhead',
+  });
+
+  expect(button.disabled).toBe(true);
+
+  rerender(renderButton(4));
+  expect(button.disabled).toBe(false);
+
+  rerender(renderButton(6));
+  expect(button.disabled).toBe(true);
+});

--- a/apps/full-editor-demo/src/components/timeline/TransportBar.tsx
+++ b/apps/full-editor-demo/src/components/timeline/TransportBar.tsx
@@ -1,33 +1,18 @@
 import {
   TimecodeField,
-  useTimeline,
-  useTimelineClips,
-  useTimelineEditCommands,
   useTimelineMarkers,
   useTimelinePlayback,
   useTimelinePlayheadControl,
   useTimelinePlayheadTime,
   useTimelineSnapping,
 } from '@techsquidtv/canvas-timeline-react';
-import { compareRational, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
-import { Magnet, MapPin, Pause, Play, Scissors, StepBack, StepForward, X } from 'lucide-react';
+import { Magnet, MapPin, Pause, Play, StepBack, StepForward, X } from 'lucide-react';
 import { useEditorMediaSync } from '#full-editor/editor/shell/media-sync-context';
 import { Button } from '#full-editor/components/ui/button';
 import { Separator } from '#full-editor/components/ui/separator';
 import { useEditorProject } from '#full-editor/editor/project/project-context';
-import type { EditorTrackKind } from '#full-editor/data/demo-project';
 import { getProjectFrameRatePreset } from '#full-editor/project/frame-rate';
-
-interface TimelineBoundedClip {
-  timelineEnd: RationalTime;
-  timelineStart: RationalTime;
-}
-
-function containsTimelineTime(clip: TimelineBoundedClip, time: RationalTime) {
-  return (
-    compareRational(time, clip.timelineStart) > 0 && compareRational(time, clip.timelineEnd) < 0
-  );
-}
+import { CutSelectedClipButton } from '#full-editor/components/timeline/CutSelectedClipButton';
 
 function PlayheadTimecodeControl() {
   const playheadControl = useTimelinePlayheadControl();
@@ -46,39 +31,6 @@ function PlayheadTimecodeControl() {
       <TimecodeField.Trigger className="timeline-timecode-control-button" />
       <TimecodeField.Input className="timeline-timecode-control-input" />
     </TimecodeField.Root>
-  );
-}
-
-function CutSelectedClipButton() {
-  const { engine } = useTimeline();
-  const { selectedClip } = useTimelineClips<EditorTrackKind>();
-  const { splitClip } = useTimelineEditCommands();
-  const playheadTime = engine.getTime();
-  const canCutSelectedClip =
-    selectedClip !== null && containsTimelineTime(selectedClip, playheadTime);
-
-  return (
-    <Button
-      aria-label="Cut selected clip at playhead"
-      disabled={!canCutSelectedClip}
-      iconOnly
-      onClick={() => {
-        const currentPlayheadTime = engine.getTime();
-        if (selectedClip !== null) {
-          if (containsTimelineTime(selectedClip, currentPlayheadTime)) {
-            splitClip(selectedClip.id, currentPlayheadTime);
-          }
-        }
-      }}
-      title={
-        canCutSelectedClip
-          ? 'Cut selected clip at playhead'
-          : 'Select a clip and place the playhead inside it'
-      }
-      variant="ghost"
-    >
-      <Scissors aria-hidden="true" />
-    </Button>
   );
 }
 
@@ -170,7 +122,7 @@ export function TransportBar() {
       >
         <MapPin aria-hidden="true" />
       </Button>
-      <CutSelectedClipButton />
+      <CutSelectedClipButton playheadSeconds={playheadControl.value} />
     </div>
   );
 }

--- a/apps/full-editor-demo/src/editor/autosave/ProjectAutosave.test.tsx
+++ b/apps/full-editor-demo/src/editor/autosave/ProjectAutosave.test.tsx
@@ -1,0 +1,45 @@
+import { render, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vite-plus/test';
+import { ProjectAutosave } from '#full-editor/editor/autosave/ProjectAutosave';
+import { getDefaultProjectMetadata } from '#full-editor/project/project-metadata';
+
+const { savePersistedProjectState } = vi.hoisted(() => ({
+  savePersistedProjectState: vi.fn(),
+}));
+
+vi.mock('#full-editor/persistence/project/project-store', () => ({
+  savePersistedProjectState,
+}));
+
+vi.mock('#full-editor/editor/autosave/usePersistableTimelineSnapshot', () => ({
+  usePersistableTimelineSnapshot: () => ({
+    fingerprint: 'seed-project',
+    timelineState: {
+      clipGroups: [],
+      markers: [],
+      playheadTime: { r: 60_000, v: 0 },
+      scrollLeft: 0,
+      scrollTop: 0,
+      snapEnabled: true,
+      snapThresholdPixels: 10,
+      tracks: [],
+      zoomScale: 38,
+    },
+  }),
+}));
+
+test('ProjectAutosave remains read-only after project restore failure', async () => {
+  const onStatusChange = vi.fn();
+
+  render(
+    <ProjectAutosave
+      disabledStatus="error"
+      enabled={false}
+      metadata={getDefaultProjectMetadata()}
+      onStatusChange={onStatusChange}
+    />
+  );
+
+  await waitFor(() => expect(onStatusChange).toHaveBeenCalledWith('error'));
+  expect(savePersistedProjectState).not.toHaveBeenCalled();
+});

--- a/apps/full-editor-demo/src/editor/autosave/ProjectAutosave.tsx
+++ b/apps/full-editor-demo/src/editor/autosave/ProjectAutosave.tsx
@@ -7,12 +7,18 @@ import { usePersistableTimelineSnapshot } from '#full-editor/editor/autosave/use
 const PROJECT_AUTOSAVE_DELAY_MS = 600;
 
 interface ProjectAutosaveProps {
+  disabledStatus: Extract<ProjectAutosaveStatus, 'error' | 'unavailable'>;
   enabled: boolean;
   metadata: ProjectMetadata;
   onStatusChange: (status: ProjectAutosaveStatus) => void;
 }
 
-export function ProjectAutosave({ enabled, metadata, onStatusChange }: ProjectAutosaveProps) {
+export function ProjectAutosave({
+  disabledStatus,
+  enabled,
+  metadata,
+  onStatusChange,
+}: ProjectAutosaveProps) {
   const snapshot = usePersistableTimelineSnapshot();
   const metadataRef = useRef(metadata);
   const persistedStateRef = useRef(snapshot.timelineState);
@@ -27,7 +33,7 @@ export function ProjectAutosave({ enabled, metadata, onStatusChange }: ProjectAu
 
   useEffect(() => {
     if (!enabled) {
-      onStatusChange('unavailable');
+      onStatusChange(disabledStatus);
       return;
     }
 
@@ -46,7 +52,7 @@ export function ProjectAutosave({ enabled, metadata, onStatusChange }: ProjectAu
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [enabled, metadata, onStatusChange, snapshot.fingerprint]);
+  }, [disabledStatus, enabled, metadata, onStatusChange, snapshot.fingerprint]);
 
   return null;
 }

--- a/apps/full-editor-demo/src/editor/bootstrap/loadEditorBootstrap.ts
+++ b/apps/full-editor-demo/src/editor/bootstrap/loadEditorBootstrap.ts
@@ -11,6 +11,7 @@ import {
 import type { PersistedTimelineState } from '#full-editor/persistence/project/types';
 
 export interface EditorBootstrapState {
+  projectRestoreError?: string;
   projectState: PersistedTimelineState;
   projectMetadata: ProjectMetadata;
   sourceRestoreError?: string;
@@ -33,6 +34,7 @@ export async function loadEditorBootstrap(): Promise<EditorBootstrapState> {
 
   let projectState = seedProjectState;
   let projectMetadata = getDefaultProjectMetadata();
+  let projectRestoreError: string | undefined;
   let sources: readonly MediaLibrarySource[] = [];
   let sourceRestoreError: string | undefined;
 
@@ -50,7 +52,8 @@ export async function loadEditorBootstrap(): Promise<EditorBootstrapState> {
             title: snapshot.title,
             width: snapshot.width,
           };
-  } catch {
+  } catch (error) {
+    projectRestoreError = errorMessage(error);
     projectState = seedProjectState;
   }
 
@@ -63,6 +66,7 @@ export async function loadEditorBootstrap(): Promise<EditorBootstrapState> {
   return {
     projectState,
     projectMetadata,
+    projectRestoreError,
     sourceRestoreError,
     sources,
     storageAvailable,

--- a/apps/full-editor-demo/src/editor/project/ProjectProvider.tsx
+++ b/apps/full-editor-demo/src/editor/project/ProjectProvider.tsx
@@ -8,6 +8,7 @@ export function ProjectProvider({
   autosaveStatus,
   children,
   metadata,
+  projectRestoreError,
   resetProject,
   rulerFormat,
   setProjectFrameRatePreset,
@@ -20,6 +21,7 @@ export function ProjectProvider({
     () => ({
       autosaveStatus,
       metadata,
+      projectRestoreError,
       resetProject,
       rulerFormat,
       setProjectFrameRatePreset,
@@ -31,6 +33,7 @@ export function ProjectProvider({
     [
       autosaveStatus,
       metadata,
+      projectRestoreError,
       resetProject,
       rulerFormat,
       setProjectFrameRatePreset,

--- a/apps/full-editor-demo/src/editor/project/project-context.ts
+++ b/apps/full-editor-demo/src/editor/project/project-context.ts
@@ -12,6 +12,7 @@ export type ProjectAutosaveStatus = 'idle' | 'saving' | 'saved' | 'error' | 'una
 export interface ProjectContextValue {
   autosaveStatus: ProjectAutosaveStatus;
   metadata: ProjectMetadata;
+  projectRestoreError?: string;
   resetProject: (metadataOverride?: ProjectMetadataOverride) => Promise<void>;
   rulerFormat: EditorRulerFormat;
   setProjectFrameRatePreset: (presetId: ProjectFrameRatePresetId) => void;

--- a/apps/full-editor-demo/src/media/library/media-library-manifest.test.ts
+++ b/apps/full-editor-demo/src/media/library/media-library-manifest.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { parseMediaLibraryManifest } from '#full-editor/media/library/media-library-manifest';
+
+describe('media library manifest', () => {
+  it('parses a fully valid manifest', () => {
+    const manifest = {
+      version: 1,
+      sources: [
+        {
+          id: 'source-video',
+          kind: 'video',
+          metadata: { durationSeconds: 10, hasVideo: true },
+          mimeType: 'video/mp4',
+          name: 'video.mp4',
+          originalPath: 'assets/source-video/original',
+          sizeBytes: 1024,
+          status: 'ready',
+        },
+      ],
+    };
+
+    expect(parseMediaLibraryManifest(JSON.stringify(manifest))).toEqual(manifest);
+  });
+
+  it('rejects unsupported manifest versions instead of treating them as empty', () => {
+    expect(() => parseMediaLibraryManifest(JSON.stringify({ version: 2, sources: [] }))).toThrow(
+      'Unsupported or invalid media library manifest.'
+    );
+  });
+
+  it('rejects the complete manifest when any source is invalid', () => {
+    const manifest = {
+      version: 1,
+      sources: [
+        {
+          id: 'source-valid',
+          kind: 'audio',
+          metadata: { hasAudio: true },
+          mimeType: 'audio/mp4',
+          name: 'audio.m4a',
+          originalPath: 'assets/source-valid/original',
+          sizeBytes: 512,
+          status: 'ready',
+        },
+        {
+          id: 'source-invalid',
+          kind: 'video',
+        },
+      ],
+    };
+
+    expect(() => parseMediaLibraryManifest(JSON.stringify(manifest))).toThrow(
+      'Media library manifest contains an invalid source.'
+    );
+  });
+});

--- a/apps/full-editor-demo/src/media/library/media-library-manifest.ts
+++ b/apps/full-editor-demo/src/media/library/media-library-manifest.ts
@@ -18,13 +18,14 @@ export function parseMediaLibraryManifest(text: string): MediaLibraryManifestFil
   const parsed: unknown = JSON.parse(text);
 
   if (!isJsonObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.sources)) {
-    return createEmptyMediaLibraryManifest();
+    throw new Error('Unsupported or invalid media library manifest.');
   }
 
-  return {
-    version: 1,
-    sources: parsed.sources.filter(isManifestSource),
-  };
+  if (!parsed.sources.every(isManifestSource)) {
+    throw new Error('Media library manifest contains an invalid source.');
+  }
+
+  return { version: 1, sources: parsed.sources };
 }
 
 export function createEmptyMediaLibraryManifest(): MediaLibraryManifestFile {

--- a/apps/full-editor-demo/src/media/library/media-library-manifest.ts
+++ b/apps/full-editor-demo/src/media/library/media-library-manifest.ts
@@ -21,11 +21,14 @@ export function parseMediaLibraryManifest(text: string): MediaLibraryManifestFil
     throw new Error('Unsupported or invalid media library manifest.');
   }
 
-  if (!parsed.sources.every(isManifestSource)) {
+  const rawSources: unknown[] = parsed.sources;
+  const sources = rawSources.filter(isManifestSource);
+
+  if (sources.length !== rawSources.length) {
     throw new Error('Media library manifest contains an invalid source.');
   }
 
-  return { version: 1, sources: parsed.sources };
+  return { version: 1, sources };
 }
 
 export function createEmptyMediaLibraryManifest(): MediaLibraryManifestFile {

--- a/apps/full-editor-demo/src/persistence/project/project-snapshot-schema.test.ts
+++ b/apps/full-editor-demo/src/persistence/project/project-snapshot-schema.test.ts
@@ -16,22 +16,35 @@ describe('project snapshot schema', () => {
 
   it('rejects older project snapshot versions', () => {
     const snapshot = createSnapshot();
-    const parsed = parseProjectSnapshot(
-      JSON.stringify({
-        ...snapshot,
-        version: 2,
-      })
-    );
+    expect(() =>
+      parseProjectSnapshot(
+        JSON.stringify({
+          ...snapshot,
+          version: 2,
+        })
+      )
+    ).toThrow('Unsupported or invalid project snapshot.');
+  });
 
-    expect(parsed).toBeNull();
+  it('rejects malformed timeline state instead of treating it as a missing project', () => {
+    expect(() =>
+      parseProjectSnapshot(
+        JSON.stringify({
+          ...createSnapshot(),
+          timelineState: { tracks: [] },
+        })
+      )
+    ).toThrow('Unsupported or invalid project snapshot.');
   });
 
   it('restores supported fractional rates and rejects unsupported project rates', () => {
     expect(
       parseProjectSnapshot(JSON.stringify({ ...createSnapshot(), frameRate: 30_000 / 1_001 }))
-        ?.frameRate
+        .frameRate
     ).toBe(30_000 / 1_001);
-    expect(parseProjectSnapshot(JSON.stringify({ ...createSnapshot(), frameRate: 48 }))).toBeNull();
+    expect(() =>
+      parseProjectSnapshot(JSON.stringify({ ...createSnapshot(), frameRate: 48 }))
+    ).toThrow('Unsupported or invalid project snapshot.');
   });
 
   it('defaults project metadata to a 1080p canvas', () => {

--- a/apps/full-editor-demo/src/persistence/project/project-snapshot-schema.ts
+++ b/apps/full-editor-demo/src/persistence/project/project-snapshot-schema.ts
@@ -11,9 +11,14 @@ interface JsonObject {
   readonly [key: string]: unknown;
 }
 
-export function parseProjectSnapshot(text: string): ProjectStorageSnapshot | null {
+export function parseProjectSnapshot(text: string): ProjectStorageSnapshot {
   const parsed: unknown = JSON.parse(text);
-  return isProjectSnapshot(parsed) ? parsed : null;
+
+  if (!isProjectSnapshot(parsed)) {
+    throw new Error('Unsupported or invalid project snapshot.');
+  }
+
+  return parsed;
 }
 
 function isProjectSnapshot(value: unknown): value is ProjectStorageSnapshot {

--- a/test-utils/browser-storage.ts
+++ b/test-utils/browser-storage.ts
@@ -1,0 +1,41 @@
+import { beforeEach } from 'vite-plus/test';
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length() {
+    return this.items.size;
+  }
+
+  clear() {
+    this.items.clear();
+  }
+
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    value: new MemoryStorage(),
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -634,8 +634,14 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost:3000/',
+      },
+    },
     globals: true,
     include: ['apps/**/*.{test,spec}.{ts,tsx}', 'packages/**/*.{test,spec}.{ts,tsx}'],
+    setupFiles: ['./test-utils/browser-storage.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

- Reject invalid media manifests instead of treating them as empty, so stored media is not orphan-cleaned after a bad manifest read.
- Surface invalid project snapshots as restore errors and disable autosave until the user creates a fresh project.
- Make cut-button eligibility react to the transport playhead value and add jsdom browser-storage setup for persistence tests.

## Release Impact

- Packages/API: None. Changes are limited to the full-editor demo app and test configuration.
- Docs/demos: Full-editor demo recovery, autosave status, and cut control behavior are affected.
- Breaking changes: Demo project snapshot parsing now throws for invalid snapshots instead of returning null. No compatibility fallback was added.
- Checklist areas reviewed: Public release checklist sections 0, 3, 4, 5, and 6 for demo behavior, test coverage, browser/test environment, and Changesets status.

## Validation

- `pnpm exec vp check apps/full-editor-demo/src`
- `pnpm --filter @techsquidtv/canvas-timeline-full-editor-demo typecheck`
- `pnpm exec vitest run apps/full-editor-demo/src`
- `pnpm --filter @techsquidtv/canvas-timeline-full-editor-demo build`
- `vp run repo:check`
- `vp exec changeset status --since=main`
- Pre-push hook: `vp run ci`-equivalent suite passed during `git push`, including 48 Vitest files / 509 tests, docs build, package checks, and consumer smoke.