### PR TITLE
ci: tune Dependabot update policy

### DIFF
--- a/.changeset/tune-dependabot-updates.md
+++ b/.changeset/tune-dependabot-updates.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tune Dependabot grouping and cooldown policy without changing published package contents.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,40 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    versioning-strategy: increase-if-necessary
     groups:
-      production-dependencies:
-        dependency-type: 'production'
-      development-dependencies:
-        dependency-type: 'development'
+      astro-cloudflare:
+        patterns:
+          - 'astro'
+          - 'astro-*'
+          - '@astrojs/*'
+          - '@cloudflare/*'
+          - 'wrangler'
+          - 'workerd'
+        update-types:
+          - 'patch'
+          - 'minor'
+      sentry:
+        patterns:
+          - '@sentry/*'
+        update-types:
+          - 'patch'
+          - 'minor'
+      mediabunny:
+        patterns:
+          - 'mediabunny'
+          - '@mediabunny/*'
+        update-types:
+          - 'patch'
+          - 'minor'
+      vite-tooling:
+        patterns:
+          - 'vite-plus'
+          - '@voidzero-dev/*'
+          - 'vitest'
+          - '@vitest/*'
+        update-types:
+          - 'patch'
+          - 'minor'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,13 @@ jobs:
       - name: Enable pnpm
         run: corepack enable
 
+      - name: Resolve Wrangler version
+        id: wrangler-version
+        working-directory: apps/www
+        run: |
+          version="$(node -p "require('./package.json').devDependencies.wrangler.replace(/^[^0-9]*/, '')")"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy production docs to Cloudflare Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         id: deploy-production
@@ -187,7 +194,7 @@ jobs:
         with:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.107.0'
+          wranglerVersion: ${{ steps.wrangler-version.outputs.version }}
           packageManager: pnpm
           workingDirectory: apps/www
           command: pages deploy dist/client --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
@@ -199,7 +206,7 @@ jobs:
         with:
           apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.107.0'
+          wranglerVersion: ${{ steps.wrangler-version.outputs.version }}
           packageManager: pnpm
           workingDirectory: apps/www
           command: pages deploy dist/client --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,11 @@ jobs:
         id: wrangler-version
         working-directory: apps/www
         run: |
-          version="$(node -p "require('./package.json').devDependencies.wrangler.replace(/^[^0-9]*/, '')")"
+          version="$(node -p 'require("./package.json").devDependencies.wrangler.replace(/^[^0-9]*/, "")')"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve wrangler version from apps/www/package.json" >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy production docs to Cloudflare Pages


### PR DESCRIPTION
## Summary

- Replace broad npm production/development Dependabot groups with focused compatibility-family groups for Astro/Cloudflare, Sentry, Mediabunny, and Vite tooling.
- Add a 7-day npm cooldown and use `increase-if-necessary` so compatible updates avoid unnecessary manifest churn.
- Resolve the Cloudflare docs deploy Wrangler version from `apps/www/package.json` instead of hardcoding a second copy in CI.
- Add an empty changeset because this does not affect published package contents.

## Release Impact

- Packages/API: None.
- Docs/demos: None.
- Breaking changes: None.
- Release risk: Low; affects Dependabot PR shape and docs deploy dependency version alignment only.

## Validation

- `node -p "require('./package.json').devDependencies.wrangler.replace(/^[^0-9]*/, '')"` from `apps/www`
- `vp exec changeset status --since=origin/main`
- `printf %s\n "ci: tune Dependabot update policy" | vp exec commitlint --verbose`
- `printf %s\n "ci: align docs deploy Wrangler version" | vp exec commitlint --verbose`
- `vp run repo:check`
- Pre-push validation passed during `git push`.