### PR TITLE
feat!: add media source representations

### DIFF
--- a/.changeset/mediabunny-source-runtime.md
+++ b/.changeset/mediabunny-source-runtime.md
@@ -1,0 +1,5 @@
+---
+'@techsquidtv/canvas-timeline-mediabunny-adapter': minor
+---
+
+Redesign Mediabunny sources around concise original inputs, selectable timestamp-mapped editing proxies, per-representation fallbacks, source metadata and track selection, runtime recovery, lazy owned audio graphs, and non-blocking audio activation diagnostics.

--- a/apps/full-editor-demo/src/features/media/MediaSyncProvider.tsx
+++ b/apps/full-editor-demo/src/features/media/MediaSyncProvider.tsx
@@ -43,14 +43,13 @@ function ActiveMediaSyncProvider({
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const { metadata } = useEditorProject();
   const { timecodeFrameRate } = getProjectFrameRatePreset(metadata.frameRate);
-  const { durationBySourceId, pause, play, playing, ready, status } =
-    useMediabunnyTimelineMedia<PreviewLayerName>({
-      canvasRef,
-      frameRate: timecodeFrameRate,
-      sources,
-      layers: previewLayerSelectors,
-      onError: setPlaybackError,
-    });
+  const { pause, play, playing, ready, status } = useMediabunnyTimelineMedia<PreviewLayerName>({
+    canvasRef,
+    frameRate: timecodeFrameRate,
+    sources,
+    layers: previewLayerSelectors,
+    onError: setPlaybackError,
+  });
 
   const clearPlaybackError = useCallback(() => {
     setPlaybackError(null);
@@ -71,7 +70,6 @@ function ActiveMediaSyncProvider({
     () => ({
       canvasRef,
       clearPlaybackError,
-      durationBySourceId,
       hasMediaSources: true,
       pause,
       play,
@@ -81,18 +79,7 @@ function ActiveMediaSyncProvider({
       status,
       togglePlay,
     }),
-    [
-      canvasRef,
-      clearPlaybackError,
-      durationBySourceId,
-      pause,
-      play,
-      playing,
-      playbackError,
-      ready,
-      status,
-      togglePlay,
-    ]
+    [canvasRef, clearPlaybackError, pause, play, playing, playbackError, ready, status, togglePlay]
   );
 
   return (
@@ -126,7 +113,6 @@ function IdleMediaSyncProvider({
     () => ({
       canvasRef,
       clearPlaybackError,
-      durationBySourceId: new Map(),
       hasMediaSources: false,
       pause,
       play,

--- a/apps/full-editor-demo/src/features/media/library/media-library-runtime.ts
+++ b/apps/full-editor-demo/src/features/media/library/media-library-runtime.ts
@@ -14,8 +14,8 @@ export function createPlayableSources(
         source.status === 'ready' && source.file !== null && source.kind !== 'image'
     )
     .map((source) => ({
-      id: source.id,
-      blob: source.file,
+      sourceId: source.id,
+      input: { kind: 'blob', blob: source.file },
     }));
 }
 

--- a/apps/full-editor-demo/src/features/media/media-sync-context.ts
+++ b/apps/full-editor-demo/src/features/media/media-sync-context.ts
@@ -6,7 +6,7 @@ type MediaSyncState = UseMediabunnyTimelineMediaResult<PreviewLayerName>;
 
 export interface EditorMediaSyncContextValue extends Pick<
   MediaSyncState,
-  'durationBySourceId' | 'pause' | 'play' | 'playing' | 'ready' | 'status'
+  'pause' | 'play' | 'playing' | 'ready' | 'status'
 > {
   canvasRef: RefObject<HTMLCanvasElement | null>;
   clearPlaybackError: () => void;

--- a/apps/www/src/demos/media-preview-sync/MediaTimelineSync.tsx
+++ b/apps/www/src/demos/media-preview-sync/MediaTimelineSync.tsx
@@ -76,7 +76,7 @@ function MediaSyncSurface({ metrics }: { metrics?: DemoMetrics }) {
     },
   });
   const lastFrameTime = useMediabunnyFrameTime(media.adapter);
-  const { ready, status, durationBySourceId, playing, playbackRate, play, pause, setPlaybackRate } =
+  const { ready, status, sourceStateById, playing, playbackRate, play, pause, setPlaybackRate } =
     media;
 
   useEffect(() => {
@@ -112,7 +112,7 @@ function MediaSyncSurface({ metrics }: { metrics?: DemoMetrics }) {
       }
     }
   }, [metrics, pause, play, playing]);
-  const mediaDuration = durationBySourceId.get(sampleSourceId) ?? null;
+  const mediaDuration = sourceStateById.get(sampleSourceId)?.metadata?.durationSeconds ?? null;
 
   return (
     <div className="media-sync-demo">

--- a/apps/www/src/demos/media-preview-sync/timeline-demo-data.ts
+++ b/apps/www/src/demos/media-preview-sync/timeline-demo-data.ts
@@ -5,7 +5,10 @@ import { getDemoClipColor } from '#www/demos/demo-clip-colors';
 export const sampleSourceId = 'big-buck-bunny-preview';
 
 const sampleMediaUrl = '/demo-media/big-buck-bunny-preview.webm';
-export const sampleMediaSource = { id: sampleSourceId, url: sampleMediaUrl } as const;
+export const sampleMediaSource = {
+  sourceId: sampleSourceId,
+  input: { kind: 'url', url: sampleMediaUrl },
+} as const;
 export const sampleDurationSeconds = 66.06;
 
 export const demoTracks: Track<'visual' | 'audio'>[] = [

--- a/packages/mediabunny-adapter/src/index.test.ts
+++ b/packages/mediabunny-adapter/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   createMediabunnyAdapter,
   formatMediabunnyTime,
   type MediabunnyModule,
+  type MediabunnySource,
 } from '#mediabunny-adapter/index';
 
 const originalAudioContext = window.AudioContext;
@@ -34,6 +35,10 @@ type MockVideoTrack = {
   getCodec: ReturnType<typeof vi.fn<() => Promise<string | null>>>;
   canDecode: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
   canBeTransparent: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+  getDisplayWidth: ReturnType<typeof vi.fn<() => Promise<number>>>;
+  getDisplayHeight: ReturnType<typeof vi.fn<() => Promise<number>>>;
+  getRotation: ReturnType<typeof vi.fn<() => Promise<0>>>;
+  computePacketStats: ReturnType<typeof vi.fn<() => Promise<{ averagePacketRate: number }>>>;
 };
 
 type MockAudioTrack = {
@@ -45,6 +50,8 @@ type MockAudioTrack = {
 type MockInput = {
   getPrimaryVideoTrack: ReturnType<typeof vi.fn<() => Promise<MockVideoTrack | null>>>;
   getPrimaryAudioTrack: ReturnType<typeof vi.fn<() => Promise<MockAudioTrack | null>>>;
+  getVideoTracks: ReturnType<typeof vi.fn<() => Promise<MockVideoTrack[]>>>;
+  getAudioTracks: ReturnType<typeof vi.fn<() => Promise<MockAudioTrack[]>>>;
   getFirstTimestamp: ReturnType<typeof vi.fn<() => Promise<number>>>;
   getDurationFromMetadata: ReturnType<typeof vi.fn<() => Promise<number | null>>>;
   computeDuration: ReturnType<typeof vi.fn<() => Promise<number>>>;
@@ -110,6 +117,10 @@ function createMockVideoTrack(): MockVideoTrack {
     getCodec: vi.fn(async () => 'vp09'),
     canDecode: vi.fn(async () => true),
     canBeTransparent: vi.fn(async () => false),
+    getDisplayWidth: vi.fn(async () => 1920),
+    getDisplayHeight: vi.fn(async () => 1080),
+    getRotation: vi.fn(async () => 0 as const),
+    computePacketStats: vi.fn(async () => ({ averagePacketRate: 30 })),
   };
 }
 
@@ -141,6 +152,12 @@ function createMockInput(
   return {
     getPrimaryVideoTrack: vi.fn(async () => videoTrack ?? null),
     getPrimaryAudioTrack: vi.fn(async () => audioTrack ?? null),
+    getVideoTracks: vi.fn(async () =>
+      videoTrack === null || videoTrack === undefined ? [] : [videoTrack]
+    ),
+    getAudioTracks: vi.fn(async () =>
+      audioTrack === null || audioTrack === undefined ? [] : [audioTrack]
+    ),
     getFirstTimestamp: vi.fn(async () => options.firstTimestamp ?? 0),
     getDurationFromMetadata: vi.fn(async () => metadataDuration ?? null),
     computeDuration: vi.fn(async () => options.computedDuration ?? 6),
@@ -152,6 +169,7 @@ function createMockAudioContext(): MockAudioContext {
   const gainNode = {
     gain: { value: 1 },
     connect: vi.fn(),
+    disconnect: vi.fn(),
   } as unknown as GainNode;
   const context: MockAudioContext = {
     currentTime: 10,
@@ -176,6 +194,10 @@ function createMockAudioContext(): MockAudioContext {
     }),
   };
   return context;
+}
+
+function urlSource(sourceId: string, url: string): MediabunnySource {
+  return { sourceId, input: { kind: 'url', url } };
 }
 
 function createActiveLayerResult(activeClips: ActiveClip[], time = 1): ActiveLayerResult<string> {
@@ -356,14 +378,23 @@ test('createMediabunnyAdapter loads url, blob, input, and createInput sources', 
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: mockMediabunny.module,
     sources: [
-      { id: 'url-source', url: 'https://media.example/video.mp4' },
-      { id: 'blob-source', blob },
-      { id: 'input-source', input: providedInput as unknown as RealMediabunny.Input },
+      urlSource('url-source', 'https://media.example/video.mp4'),
+      { sourceId: 'blob-source', input: { kind: 'blob', blob } },
       {
-        id: 'created-source',
-        createInput: (mediabunny) => {
-          expect(mediabunny).toBe(mockMediabunny.module);
-          return createdInput as unknown as RealMediabunny.Input;
+        sourceId: 'input-source',
+        input: {
+          kind: 'input',
+          input: providedInput as unknown as RealMediabunny.Input,
+        },
+      },
+      {
+        sourceId: 'created-source',
+        input: {
+          kind: 'input-factory',
+          createInput: (mediabunny) => {
+            expect(mediabunny).toBe(mockMediabunny.module);
+            return createdInput as unknown as RealMediabunny.Input;
+          },
         },
       },
     ],
@@ -373,10 +404,10 @@ test('createMediabunnyAdapter loads url, blob, input, and createInput sources', 
 
   expect(adapter.ready).toBe(true);
   expect(adapter.status).toBe('Ready. Mediabunny can drive timeline video and audio.');
-  expect(adapter.durationBySourceId.get('url-source')).toBe(4);
-  expect(adapter.durationBySourceId.get('blob-source')).toBe(5);
-  expect(adapter.durationBySourceId.get('input-source')).toBe(6);
-  expect(adapter.durationBySourceId.get('created-source')).toBe(7);
+  expect(adapter.sourceStateById.get('url-source')?.metadata?.durationSeconds).toBe(4);
+  expect(adapter.sourceStateById.get('blob-source')?.metadata?.durationSeconds).toBe(5);
+  expect(adapter.sourceStateById.get('input-source')?.metadata?.durationSeconds).toBe(6);
+  expect(adapter.sourceStateById.get('created-source')?.metadata?.durationSeconds).toBe(7);
   expect(mockMediabunny.createdUrlSources).toEqual(['https://media.example/video.mp4']);
   expect(mockMediabunny.createdBlobSources).toEqual([blob]);
 
@@ -387,7 +418,7 @@ test('createMediabunnyAdapter loads url, blob, input, and createInput sources', 
   expect(createdInput.dispose).toHaveBeenCalled();
 });
 
-test('createMediabunnyAdapter ignores duplicate source ids and surfaces load failures', async () => {
+test('createMediabunnyAdapter selects input fallbacks and surfaces load failures', async () => {
   const firstInput = createMockInput({ metadataDuration: 4 });
   const duplicateInput = createMockInput({ metadataDuration: 9 });
   const mockMediabunny = createMockMediabunny([firstInput, duplicateInput]);
@@ -395,14 +426,18 @@ test('createMediabunnyAdapter ignores duplicate source ids and surfaces load fai
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: mockMediabunny.module,
     sources: [
-      { id: 'same-source', url: 'https://media.example/first.mp4' },
-      { id: 'same-source', url: 'https://media.example/second.mp4' },
+      {
+        sourceId: 'same-source',
+        input: { kind: 'url', url: 'https://media.example/first.mp4' },
+        fallbacks: [{ kind: 'url', url: 'https://media.example/second.mp4' }],
+      },
     ],
   });
 
   await waitForAdapterLoad(adapter);
 
-  expect(adapter.durationBySourceId.get('same-source')).toBe(4);
+  expect(adapter.sourceStateById.get('same-source')?.metadata?.durationSeconds).toBe(4);
+  expect(adapter.sourceStateById.get('same-source')?.selectedInputIndex).toBe(0);
   expect(mockMediabunny.createdUrlSources).toEqual(['https://media.example/first.mp4']);
   expect(duplicateInput.getPrimaryVideoTrack).not.toHaveBeenCalled();
 
@@ -410,7 +445,7 @@ test('createMediabunnyAdapter ignores duplicate source ids and surfaces load fai
   const failingAdapter = createMediabunnyAdapter({
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: createMockMediabunny([failedInput]).module,
-    sources: [{ id: 'empty-source', url: 'https://media.example/empty.mp4' }],
+    sources: [urlSource('empty-source', 'https://media.example/empty.mp4')],
   });
 
   await waitForAdapterLoad(failingAdapter);
@@ -432,6 +467,49 @@ test('createMediabunnyAdapter ignores duplicate source ids and surfaces load fai
   expect(emptyAdapter.status).toBe('No Mediabunny source could be loaded.');
 });
 
+test('createMediabunnyAdapter selects proxies independently and maps their timestamps', async () => {
+  const originalInput = createMockInput({ metadataDuration: 20 });
+  const proxyInput = createMockInput({ firstTimestamp: 0, metadataDuration: 10 });
+  const mockMediabunny = createMockMediabunny([originalInput, proxyInput]);
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mockMediabunny.module,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: { kind: 'url', url: 'https://media.example/original.mp4' },
+        proxies: [
+          {
+            proxyId: 'edit-540p',
+            input: { kind: 'url', url: 'https://media.example/proxy.mp4' },
+            timing: { sourceTimeSeconds: 10, mediaTimeSeconds: 0 },
+          },
+        ],
+      },
+    ],
+  });
+
+  await waitForAdapterLoad(adapter);
+  await expect(
+    adapter.setRepresentation('source-1', { kind: 'proxy', proxyId: 'edit-540p' })
+  ).resolves.toMatchObject({
+    ok: true,
+    representation: { kind: 'proxy', proxyId: 'edit-540p' },
+    inputIndex: 0,
+  });
+
+  const frame = await adapter.getFrame(createActiveClip('visual', 'source-1', 1));
+  expect(mockMediabunny.canvasSink.getCanvas).toHaveBeenCalledWith(1);
+  expect(frame?.timestamp).toBe(11);
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    selectedRepresentation: { kind: 'proxy', proxyId: 'edit-540p' },
+    selectedInputIndex: 0,
+    metadata: {
+      sourceFirstTimestampSeconds: 10,
+      sourceEndTimestampSeconds: 20,
+    },
+  });
+});
+
 test('createMediabunnyAdapter ignores async load completion after disposal', async () => {
   let resolveInput: (input: RealMediabunny.Input) => void = () => {};
   const inputPromise = new Promise<RealMediabunny.Input>((resolve) => {
@@ -440,7 +518,12 @@ test('createMediabunnyAdapter ignores async load completion after disposal', asy
   const adapter = createMediabunnyAdapter({
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: createMockMediabunny([]).module,
-    sources: [{ id: 'slow-source', createInput: () => inputPromise }],
+    sources: [
+      {
+        sourceId: 'slow-source',
+        input: { kind: 'input-factory', createInput: () => inputPromise },
+      },
+    ],
   });
 
   adapter.dispose();
@@ -449,7 +532,7 @@ test('createMediabunnyAdapter ignores async load completion after disposal', asy
 
   expect(adapter.ready).toBe(false);
   expect(adapter.status).toBe('Loading Mediabunny sources...');
-  expect(adapter.durationBySourceId.size).toBe(0);
+  expect(adapter.sourceStateById.size).toBe(0);
 });
 
 test('createMediabunnyAdapter maps active layers to video frames and audio ranges', async () => {
@@ -488,7 +571,7 @@ test('createMediabunnyAdapter maps active layers to video frames and audio range
     audio: { context: audioContext as unknown as AudioContext },
     canvas: targetCanvas,
     mediabunny: mockMediabunny.module,
-    sources: [{ id: 'source-1', url: 'https://media.example/video.mp4' }],
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
   });
   const visualClip = createActiveClip('visual', 'source-1', 1.5);
   const audioClip = createActiveClip('audio', 'source-1', 1.5);
@@ -557,7 +640,7 @@ test('createMediabunnyAdapter samples sequential 24 fps frames on 30 fps playbac
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     canvas: targetCanvas,
     mediabunny: createMockMediabunny([input], { canvasSink }).module,
-    sources: [{ id: 'source-1', url: 'https://media.example/video.mp4' }],
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
   });
   const renderedTimestamps: number[] = [];
   const unsubscribe = adapter.subscribeFrame(() => {
@@ -611,7 +694,7 @@ test('createMediabunnyAdapter handles audio-only content and missing render surf
   const adapter = createMediabunnyAdapter({
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: createMockMediabunny([input], { audioSink }).module,
-    sources: [{ id: 'audio-source', url: 'https://media.example/audio.webm' }],
+    sources: [urlSource('audio-source', 'https://media.example/audio.webm')],
   });
   const audioClip = createActiveClip('audio', 'audio-source', 2);
 
@@ -639,7 +722,7 @@ test('createMediabunnyAdapter exposes frame, clock, resume, and status contracts
   const adapter = createMediabunnyAdapter({
     audio: { context: audioContext as unknown as AudioContext },
     mediabunny: createMockMediabunny([input], { canvasSink }).module,
-    sources: [{ id: 'source-1', url: 'https://media.example/video.mp4' }],
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
   });
   const visualClip = createActiveClip('visual', 'source-1', 2);
 
@@ -647,7 +730,8 @@ test('createMediabunnyAdapter exposes frame, clock, resume, and status contracts
 
   expect(adapter.startClock(fromSeconds(2), 2)).toBe(true);
   expect(adapter.getClockTime()).toBeCloseTo(2, 1);
-  await adapter.resumeClock(2);
+  adapter.requestClockActivation(2);
+  await Promise.resolve();
   expect(audioContext.resume).toHaveBeenCalled();
   adapter.setClockRate(0.5);
   adapter.stopClock();
@@ -701,7 +785,7 @@ test('createMediabunnyAdapter handles null decoded frames and late audio schedul
   const adapter = createMediabunnyAdapter({
     audio: { context: audioContext as unknown as AudioContext },
     mediabunny: createMockMediabunny([input], { audioSink, canvasSink }).module,
-    sources: [{ id: 'source-1', url: 'https://media.example/video.mp4' }],
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
   });
   const visualClip = createActiveClip('visual', 'source-1', 1);
   const audioClip = createActiveClip('audio', 'source-1', 1);
@@ -718,7 +802,7 @@ test('createMediabunnyAdapter handles null decoded frames and late audio schedul
   expect(startedNodeStartMocks[0]).toHaveBeenCalledWith(30, 20);
 });
 
-test('createMediabunnyAdapter rejects undecodable video and missing AudioContext', async () => {
+test('createMediabunnyAdapter rejects undecodable video and permits video without AudioContext', async () => {
   const undecodableInput = createMockInput({
     videoTrack: {
       ...createMockVideoTrack(),
@@ -728,7 +812,7 @@ test('createMediabunnyAdapter rejects undecodable video and missing AudioContext
   const undecodableAdapter = createMediabunnyAdapter({
     audio: { context: createMockAudioContext() as unknown as AudioContext },
     mediabunny: createMockMediabunny([undecodableInput]).module,
-    sources: [{ id: 'bad-video', url: 'https://media.example/bad.mp4' }],
+    sources: [urlSource('bad-video', 'https://media.example/bad.mp4')],
   });
 
   await waitForAdapterLoad(undecodableAdapter);
@@ -744,12 +828,15 @@ test('createMediabunnyAdapter rejects undecodable video and missing AudioContext
   (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext =
     undefined;
   const noAudioContextAdapter = createMediabunnyAdapter({
-    mediabunny: createMockMediabunny([createMockInput()]).module,
-    sources: [{ id: 'no-audio-context', url: 'https://media.example/video.mp4' }],
+    mediabunny: createMockMediabunny([createMockInput({ audioTrack: createMockAudioTrack() })])
+      .module,
+    sources: [urlSource('no-audio-context', 'https://media.example/video.mp4')],
   });
 
   await waitForAdapterLoad(noAudioContextAdapter);
-  expect(noAudioContextAdapter.error?.message).toBe('This browser does not expose AudioContext.');
+  expect(noAudioContextAdapter.ready).toBe(true);
+  expect(noAudioContextAdapter.error).toBeNull();
+  expect(noAudioContextAdapter.audioStatus).toMatchObject({ state: 'degraded' });
   window.AudioContext = previousAudioContext;
   (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext =
     previousWebkitAudioContext;
@@ -760,11 +847,151 @@ test('createMediabunnyAdapter rejects undecodable video and missing AudioContext
   } as unknown as MediabunnyModule;
   const missingBlobSourceAdapter = createMediabunnyAdapter({
     mediabunny: moduleWithoutBlobSource,
-    sources: [{ id: 'local-file', blob: new Blob(['sample']) }],
+    sources: [
+      {
+        sourceId: 'local-file',
+        input: { kind: 'blob', blob: new Blob(['sample']) },
+      },
+    ],
   });
 
   await waitForAdapterLoad(missingBlobSourceAdapter);
   expect(missingBlobSourceAdapter.error?.message).toBe(
     'This Mediabunny version does not expose BlobSource for local files.'
   );
+});
+
+test('createMediabunnyAdapter exposes selected-track metadata and runtime audio controls', async () => {
+  const videoTrack = createMockVideoTrack();
+  const audioTrack = createMockAudioTrack();
+  const input = createMockInput({
+    videoTrack,
+    audioTrack,
+    firstTimestamp: 12,
+    metadataDuration: 20,
+  });
+  const audioContext = createMockAudioContext();
+  const adapter = createMediabunnyAdapter({
+    audio: { context: audioContext as unknown as AudioContext, volume: 0.5 },
+    mediabunny: createMockMediabunny([input]).module,
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
+    selectTracks: ({ videoTracks, audioTracks }) => ({
+      videoTrack: videoTracks[0] ?? null,
+      audioTrack: audioTracks[0] ?? null,
+    }),
+  });
+
+  await waitForAdapterLoad(adapter);
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    selectedRepresentation: { kind: 'original' },
+    selectedInputIndex: 0,
+    metadata: {
+      firstTimestampSeconds: 12,
+      presentationStartTimestampSeconds: 12,
+      endTimestampSeconds: 20,
+      durationSeconds: 8,
+      video: { displayWidth: 1920, displayHeight: 1080, detectedFrameRate: 30 },
+      audio: { sampleRate: 48_000 },
+    },
+  });
+
+  const gainNode = audioContext.createGain.mock.results[0]?.value;
+  expect(gainNode?.gain.value).toBe(0.5);
+  adapter.setMuted(true);
+  expect(gainNode?.gain.value).toBe(0);
+  adapter.setVolume(0.25);
+  adapter.setMuted(false);
+  expect(gainNode?.gain.value).toBe(0.25);
+  adapter.dispose();
+  expect(audioContext.close).not.toHaveBeenCalled();
+});
+
+test('createMediabunnyAdapter reports pending audio activation without blocking playback', async () => {
+  vi.useFakeTimers();
+  const input = createMockInput({ audioTrack: createMockAudioTrack() });
+  const audioContext = createMockAudioContext();
+  audioContext.state = 'suspended';
+  audioContext.resume = vi.fn(() => new Promise<void>(() => {}));
+  const adapter = createMediabunnyAdapter({
+    audio: {
+      context: audioContext as unknown as AudioContext,
+      activationTimeoutMs: 25,
+    },
+    mediabunny: createMockMediabunny([input]).module,
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
+  });
+
+  await waitForAdapterLoad(adapter);
+  adapter.requestClockActivation(1);
+  expect(adapter.startClock(fromSeconds(0), 1)).toBe(true);
+  await vi.advanceTimersByTimeAsync(25);
+  expect(adapter.audioStatus).toEqual({ state: 'degraded', error: null });
+  adapter.dispose();
+  vi.useRealTimers();
+});
+
+test('createMediabunnyAdapter closes only an adapter-owned audio context', async () => {
+  const ownedContext = createMockAudioContext();
+  class OwnedAudioContextConstructor {
+    constructor() {
+      return ownedContext;
+    }
+  }
+  window.AudioContext = OwnedAudioContextConstructor as unknown as typeof AudioContext;
+  const adapter = createMediabunnyAdapter({
+    mediabunny: createMockMediabunny([createMockInput({ audioTrack: createMockAudioTrack() })])
+      .module,
+    sources: [urlSource('source-1', 'https://media.example/video.mp4')],
+  });
+
+  await waitForAdapterLoad(adapter);
+  adapter.dispose();
+  expect(ownedContext.close).toHaveBeenCalledTimes(1);
+});
+
+test('createMediabunnyAdapter falls back after a runtime video iterator failure', async () => {
+  const firstInput = createMockInput();
+  const fallbackInput = createMockInput();
+  let iteratorCount = 0;
+  const canvasSink: MockCanvasSink = {
+    getCanvas: vi.fn(async (timestamp) => ({
+      canvas: document.createElement('canvas'),
+      timestamp,
+      duration: 1 / 30,
+    })),
+    canvases: vi.fn(async function* () {
+      iteratorCount += 1;
+      if (iteratorCount === 1) {
+        throw new Error('decoder failed');
+      }
+      yield {
+        canvas: document.createElement('canvas'),
+        timestamp: 1,
+        duration: 1 / 30,
+      };
+    }),
+  };
+  const adapter = createMediabunnyAdapter({
+    canvas: document.createElement('canvas'),
+    mediabunny: createMockMediabunny([firstInput, fallbackInput], { canvasSink }).module,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: { kind: 'url', url: 'https://media.example/primary.mp4' },
+        fallbacks: [{ kind: 'url', url: 'https://media.example/fallback.mp4' }],
+      },
+    ],
+  });
+  const visualClip = createActiveClip('visual', 'source-1', 1);
+
+  await waitForAdapterLoad(adapter);
+  adapter.startClock(fromSeconds(1), 1);
+  await adapter.syncLayers({
+    timelineTime: fromSeconds(1),
+    reason: 'play',
+    activeLayers: createActiveLayers([visualClip], 1),
+  });
+  await vi.waitFor(() => {
+    expect(adapter.sourceStateById.get('source-1')?.selectedInputIndex).toBe(1);
+  });
 });

--- a/packages/mediabunny-adapter/src/index.ts
+++ b/packages/mediabunny-adapter/src/index.ts
@@ -21,11 +21,128 @@ export type MediabunnyModule = typeof Mediabunny;
 /**
  * Media asset descriptor that tells the adapter how to open a timeline source.
  */
-export type MediabunnySource =
-  | { id: string; url: string }
-  | { id: string; blob: Blob | File }
-  | { id: string; input: Mediabunny.Input }
-  | { id: string; createInput: (mediabunny: MediabunnyModule) => MaybePromise<Mediabunny.Input> };
+export type MediabunnySourceInput =
+  | {
+      kind: 'url';
+      url: string | URL | Request;
+      formats?: readonly Mediabunny.InputFormat[];
+      urlSourceOptions?: Mediabunny.UrlSourceOptions;
+    }
+  | { kind: 'blob'; blob: Blob | File }
+  | { kind: 'input'; input: Mediabunny.Input }
+  | {
+      kind: 'input-factory';
+      createInput: (mediabunny: MediabunnyModule) => MaybePromise<Mediabunny.Input>;
+    };
+
+/** Maps a logical source timestamp to the corresponding representation timestamp. */
+export interface MediabunnyRepresentationTiming {
+  sourceTimeSeconds: number;
+  mediaTimeSeconds: number;
+}
+
+/** A deliberately selectable editing proxy for one logical source. */
+export interface MediabunnyProxy {
+  proxyId: string;
+  input: MediabunnySourceInput;
+  fallbacks?: readonly MediabunnySourceInput[];
+  timing?: MediabunnyRepresentationTiming;
+}
+
+/** Original or proxy representation selected for a logical source. */
+export type MediabunnyRepresentationSelection =
+  | { kind: 'original' }
+  | { kind: 'proxy'; proxyId: string };
+
+/** One logical source with an original input and optional editing proxies. */
+export interface MediabunnySource {
+  sourceId: string;
+  input: MediabunnySourceInput;
+  fallbacks?: readonly MediabunnySourceInput[];
+  proxies?: readonly MediabunnyProxy[];
+  timing?: MediabunnyRepresentationTiming;
+}
+
+/** Tracks selected from a loaded source representation input. */
+export interface MediabunnyTrackSelection {
+  videoTrack: Mediabunny.InputVideoTrack | null;
+  audioTrack: Mediabunny.InputAudioTrack | null;
+}
+
+/** Context passed to custom media-track selection. */
+export interface MediabunnyTrackSelectionContext {
+  source: MediabunnySource;
+  representation: MediabunnyRepresentationSelection;
+  sourceInput: MediabunnySourceInput;
+  input: Mediabunny.Input;
+  videoTracks: readonly Mediabunny.InputVideoTrack[];
+  audioTracks: readonly Mediabunny.InputAudioTrack[];
+}
+
+/** Video metadata for the selected source track. */
+export interface MediabunnyVideoMetadata {
+  displayWidth: number;
+  displayHeight: number;
+  rotation: Mediabunny.Rotation;
+  detectedFrameRate: number | null;
+}
+
+/** Audio metadata for the selected source track. */
+export interface MediabunnyAudioMetadata {
+  sampleRate: number;
+}
+
+/** Timing and selected-track metadata for a loaded source. */
+export interface MediabunnySourceMetadata {
+  /** First timestamp in the selected representation's media time domain. */
+  firstTimestampSeconds: number;
+  /** First timestamp mapped into the logical source time domain. */
+  sourceFirstTimestampSeconds: number;
+  presentationStartTimestampSeconds: number;
+  /** End timestamp mapped into the logical source time domain. */
+  sourceEndTimestampSeconds: number;
+  endTimestampSeconds: number;
+  durationSeconds: number;
+  video: MediabunnyVideoMetadata | null;
+  audio: MediabunnyAudioMetadata | null;
+}
+
+/** One input attempt within the selected source representation. */
+export interface MediabunnySourceAttempt {
+  representation: MediabunnyRepresentationSelection;
+  inputIndex: number;
+  status: 'ready' | 'failed';
+  error: Error | null;
+}
+
+/** Observable loading and recovery state for a logical source. */
+export interface MediabunnySourceState {
+  sourceId: string;
+  status: 'loading' | 'ready' | 'recovering' | 'failed';
+  selectedRepresentation: MediabunnyRepresentationSelection;
+  selectedInputIndex: number | null;
+  attempts: readonly MediabunnySourceAttempt[];
+  metadata: MediabunnySourceMetadata | null;
+  error: Error | null;
+}
+
+/** Result of explicitly loading or replacing one logical source. */
+export type MediabunnySourceLoadResult =
+  | {
+      ok: true;
+      sourceId: string;
+      representation: MediabunnyRepresentationSelection;
+      inputIndex: number;
+      metadata: MediabunnySourceMetadata;
+    }
+  | { ok: false; sourceId: string; error: Error };
+
+/** Current availability of the adapter's optional Web Audio graph. */
+export type MediabunnyAudioStatus =
+  | { state: 'unavailable' }
+  | { state: 'suspended' }
+  | { state: 'running' }
+  | { state: 'degraded'; error: Error | null };
 
 /**
  * Web Audio options used when Mediabunny drives timeline audio playback.
@@ -37,6 +154,10 @@ export interface MediabunnyTimelineAudioOptions {
   destination?: AudioNode;
   /** Gain applied to scheduled audio, from 0 to 1. */
   volume?: number;
+  /** Initial mute state. */
+  muted?: boolean;
+  /** Delay before a pending browser activation is reported as degraded. */
+  activationTimeoutMs?: number;
 }
 
 /**
@@ -55,6 +176,12 @@ export interface CreateMediabunnyAdapterOptions {
   visualTrackKinds?: readonly string[];
   /** Track kinds the adapter should treat as audio scheduling sources. Defaults to `["audio"]`. */
   audioTrackKinds?: readonly string[];
+  /** Select the initial representation for each source. Defaults to original. */
+  selectRepresentation?: (source: MediabunnySource) => MediabunnyRepresentationSelection;
+  /** Selects the video/audio tracks used by each source input. */
+  selectTracks?: (
+    context: MediabunnyTrackSelectionContext
+  ) => MaybePromise<MediabunnyTrackSelection>;
   /** Callback fired when adapter status, readiness, or frame state changes. */
   onChange?: () => void;
 }
@@ -81,8 +208,11 @@ export interface MediabunnyAdapter {
   readonly error: Error | null;
   /** Timestamp of the last rendered video frame, in seconds. */
   readonly lastFrameTime: number | null;
-  /** Loaded media duration by source id, in seconds. */
-  readonly durationBySourceId: ReadonlyMap<string, number>;
+  /** Loading, selected representation, input attempts, metadata, and recovery by source id. */
+  readonly sourceStateById: ReadonlyMap<string, MediabunnySourceState>;
+  readonly volume: number;
+  readonly muted: boolean;
+  readonly audioStatus: MediabunnyAudioStatus;
   /** React timeline media sync adapter backed by Mediabunny clocks and sinks. */
   readonly syncAdapter: TimelineMediaSyncAdapter<string>;
   /** Subscribe to decoded preview frame timestamp changes. */
@@ -95,8 +225,21 @@ export interface MediabunnyAdapter {
   startClock: (timelineTime: RationalTime, playbackRate: number) => boolean;
   /** Stop Mediabunny-driven playback without disposing loaded sources. */
   stopClock: () => void;
-  /** Resume a suspended audio context and keep the current clock aligned. */
-  resumeClock: (playbackRate: number) => Promise<void>;
+  /** Request browser audio activation without blocking visual transport. */
+  requestClockActivation: (playbackRate: number) => void;
+  /** Update master output volume without reloading sources. */
+  setVolume: (volume: number) => void;
+  /** Update master mute state without reloading sources. */
+  setMuted: (muted: boolean) => void;
+  /** Select and load an original or proxy representation. */
+  setRepresentation: (
+    sourceId: string,
+    representation: MediabunnyRepresentationSelection
+  ) => Promise<MediabunnySourceLoadResult>;
+  /** Retry the configured inputs for the selected representation of one source. */
+  retrySource: (sourceId: string) => Promise<MediabunnySourceLoadResult>;
+  /** Replace one logical source and load its selected representation. */
+  replaceSource: (source: MediabunnySource) => Promise<MediabunnySourceLoadResult>;
   /** Update the active playback rate while preserving timeline position. */
   setClockRate: (playbackRate: number) => void;
   /** Seek decoded media to the active clips for a timeline time. */
@@ -123,6 +266,9 @@ interface MediabunnySourceController {
   sourceId: string;
   input: Mediabunny.Input | null;
   ownsInput: boolean;
+  representation: MediabunnyRepresentationSelection;
+  inputIndex: number;
+  mediaTimeOffsetSeconds: number;
   videoSink: Mediabunny.CanvasSink | null;
   audioSink: Mediabunny.AudioBufferSink | null;
   audioContext: AudioContext | null;
@@ -160,7 +306,13 @@ interface PendingFrameRequest {
 }
 
 interface LoadedMediaInfo {
-  duration: number;
+  metadata: MediabunnySourceMetadata;
+}
+
+interface MediabunnyResolvedRepresentation {
+  selection: MediabunnyRepresentationSelection;
+  inputs: readonly MediabunnySourceInput[];
+  timing: MediabunnyRepresentationTiming | undefined;
 }
 
 /**
@@ -176,6 +328,80 @@ export function formatMediabunnyTime(seconds: number): string {
   return `${seconds.toFixed(2)}s`;
 }
 
+function validateSources(sources: readonly MediabunnySource[]) {
+  const sourceIds = new Set<string>();
+  for (const source of sources) {
+    if (source.sourceId.length === 0) {
+      throw new Error('Mediabunny sourceId cannot be empty.');
+    }
+    if (sourceIds.has(source.sourceId)) {
+      throw new Error(`Duplicate Mediabunny sourceId "${source.sourceId}".`);
+    }
+    sourceIds.add(source.sourceId);
+    validateMediabunnyTiming(source.sourceId, 'original', source.timing);
+    const proxyIds = new Set<string>();
+    for (const proxy of source.proxies ?? []) {
+      if (proxy.proxyId.length === 0) {
+        throw new Error(`Source "${source.sourceId}" has an empty proxyId.`);
+      }
+      if (proxyIds.has(proxy.proxyId)) {
+        throw new Error(`Source "${source.sourceId}" has duplicate proxyId "${proxy.proxyId}".`);
+      }
+      proxyIds.add(proxy.proxyId);
+      validateMediabunnyTiming(source.sourceId, `proxy "${proxy.proxyId}"`, proxy.timing);
+    }
+  }
+}
+
+function validateMediabunnyTiming(
+  sourceId: string,
+  representation: string,
+  timing: MediabunnyRepresentationTiming | undefined
+) {
+  if (
+    timing !== undefined &&
+    (!Number.isFinite(timing.sourceTimeSeconds) || !Number.isFinite(timing.mediaTimeSeconds))
+  ) {
+    throw new Error(`Source "${sourceId}" ${representation} timing values must be finite.`);
+  }
+}
+
+function resolveMediabunnyRepresentation(
+  source: MediabunnySource,
+  selection: MediabunnyRepresentationSelection
+): MediabunnyResolvedRepresentation | undefined {
+  if (selection.kind === 'original') {
+    return {
+      selection,
+      inputs: [source.input, ...(source.fallbacks ?? [])],
+      timing: source.timing,
+    };
+  }
+
+  const proxy = source.proxies?.find((candidate) => candidate.proxyId === selection.proxyId);
+  if (proxy === undefined) {
+    return undefined;
+  }
+
+  return {
+    selection,
+    inputs: [proxy.input, ...(proxy.fallbacks ?? [])],
+    timing: proxy.timing,
+  };
+}
+
+function assertMediabunnyRepresentation(
+  source: MediabunnySource,
+  selection: MediabunnyRepresentationSelection
+) {
+  if (resolveMediabunnyRepresentation(source, selection) === undefined) {
+    const representationId = selection.kind === 'proxy' ? selection.proxyId : 'original';
+    throw new Error(
+      `Source "${source.sourceId}" does not define representation "${representationId}".`
+    );
+  }
+}
+
 /**
  * Create a Mediabunny adapter that drives Canvas Timeline media playback.
  *
@@ -184,6 +410,10 @@ export function formatMediabunnyTime(seconds: number): string {
 export function createMediabunnyAdapter(
   options: CreateMediabunnyAdapterOptions
 ): MediabunnyAdapter {
+  validateSources(options.sources);
+  if (options.audio?.destination !== undefined && options.audio.context === undefined) {
+    throw new Error('An audio context is required when an audio destination is provided.');
+  }
   let ready = false;
   let status = 'Loading Mediabunny sources...';
   let error: Error | null = null;
@@ -194,9 +424,30 @@ export function createMediabunnyAdapter(
   let lastFrameTime: number | null = null;
   const frameListeners = new Set<() => void>();
   const controllers = new Map<string, MediabunnySourceController>();
-  const durationBySourceId = new Map<string, number>();
+  const sourceDefinitions = new Map(options.sources.map((source) => [source.sourceId, source]));
+  const selectedRepresentationBySourceId = new Map<string, MediabunnyRepresentationSelection>();
+  const sourceStateById = new Map<string, MediabunnySourceState>();
+  const loadGenerations = new Map<string, number>();
+  const recoveringSources = new Set<string>();
   const visualTrackKinds = new Set(options.visualTrackKinds ?? ['visual']);
   const audioTrackKinds = new Set(options.audioTrackKinds ?? ['audio']);
+  const mediabunnyPromise = Promise.resolve(
+    typeof options.mediabunny === 'function' ? options.mediabunny() : options.mediabunny
+  );
+  let audioContext: AudioContext | null = options.audio?.context ?? null;
+  let ownsAudioContext = false;
+  let masterGainNode: GainNode | null = null;
+  let volume = options.audio?.volume ?? 0.7;
+  let muted = options.audio?.muted ?? false;
+  let audioStatus: MediabunnyAudioStatus = { state: 'unavailable' };
+  let activationGeneration = 0;
+  let activationTimer: number | null = null;
+
+  for (const source of options.sources) {
+    const selection = options.selectRepresentation?.(source) ?? { kind: 'original' };
+    assertMediabunnyRepresentation(source, selection);
+    selectedRepresentationBySourceId.set(source.sourceId, selection);
+  }
 
   const notify = () => {
     options.onChange?.();
@@ -222,6 +473,44 @@ export function createMediabunnyAdapter(
     error = nextError instanceof Error ? nextError : new Error(String(nextError));
     status = error.message;
     notify();
+  };
+
+  const setSourceState = (state: MediabunnySourceState) => {
+    sourceStateById.set(state.sourceId, state);
+    notify();
+  };
+
+  const updateMasterGain = () => {
+    if (masterGainNode !== null) {
+      masterGainNode.gain.value = muted ? 0 : volume;
+    }
+  };
+
+  const ensureAudioRuntime = () => {
+    if (masterGainNode !== null && audioContext !== null) {
+      return { context: audioContext, gainNode: masterGainNode };
+    }
+    const AudioContextCtor =
+      window.AudioContext ??
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (AudioContextCtor === undefined) {
+      audioStatus = {
+        state: 'degraded',
+        error: new Error('This browser does not expose AudioContext.'),
+      };
+      notify();
+      return null;
+    }
+    if (audioContext === null) {
+      audioContext = new AudioContextCtor();
+      ownsAudioContext = true;
+    }
+    masterGainNode = audioContext.createGain();
+    updateMasterGain();
+    masterGainNode.connect(options.audio?.destination ?? audioContext.destination);
+    audioStatus = { state: audioContext.state === 'running' ? 'running' : 'suspended' };
+    notify();
+    return { context: audioContext, gainNode: masterGainNode };
   };
 
   const getController = (activeClip: ActiveClip | undefined) => {
@@ -259,10 +548,16 @@ export function createMediabunnyAdapter(
     }
 
     clockController = controller;
-    await renderActiveVideoFrame(controller, canvas, activeVideo, (timestamp) => {
-      controller.lastRenderedVideoTimestamp = timestamp;
-      setLastFrameTime(timestamp);
-    });
+    try {
+      await renderActiveVideoFrame(controller, canvas, activeVideo, (timestamp) => {
+        controller.lastRenderedVideoTimestamp = timestamp;
+        setLastFrameTime(toLogicalSourceSeconds(controller, timestamp));
+      });
+    } catch (renderError) {
+      const error = renderError instanceof Error ? renderError : new Error(String(renderError));
+      void recoverSource(controller.sourceId, controller, error);
+      throw error;
+    }
   };
 
   const syncAudio = (activeAudio: ActiveClip | undefined) => {
@@ -275,7 +570,9 @@ export function createMediabunnyAdapter(
     }
 
     clockController = controller;
-    syncAudioClip(controller, activeAudio);
+    syncAudioClip(controller, activeAudio, (audioError) => {
+      void recoverSource(controller.sourceId, controller, audioError);
+    });
   };
 
   const findActiveClipForKinds = (
@@ -301,6 +598,179 @@ export function createMediabunnyAdapter(
     return controller?.activeAudioSyncKey !== activeAudio.syncKey;
   };
 
+  const loadSource = async (
+    source: MediabunnySource,
+    selection: MediabunnyRepresentationSelection,
+    loadStatus: 'loading' | 'recovering',
+    startIndex = 0,
+    previousAttempts: readonly MediabunnySourceAttempt[] = []
+  ): Promise<MediabunnySourceLoadResult> => {
+    const representation = resolveMediabunnyRepresentation(source, selection);
+    if (representation === undefined) {
+      return {
+        ok: false,
+        sourceId: source.sourceId,
+        error: new Error(
+          `Source "${source.sourceId}" does not define the selected representation.`
+        ),
+      };
+    }
+    const generation = (loadGenerations.get(source.sourceId) ?? 0) + 1;
+    loadGenerations.set(source.sourceId, generation);
+    setSourceState({
+      sourceId: source.sourceId,
+      status: loadStatus,
+      selectedRepresentation: selection,
+      selectedInputIndex: null,
+      attempts: previousAttempts,
+      metadata: null,
+      error: null,
+    });
+
+    const mediabunny = await mediabunnyPromise;
+    const attempts = [...previousAttempts];
+    let finalError = new Error(
+      `No remaining inputs are available for source "${source.sourceId}".`
+    );
+
+    for (let inputIndex = startIndex; inputIndex < representation.inputs.length; inputIndex += 1) {
+      const sourceInput = representation.inputs[inputIndex];
+      if (sourceInput === undefined) {
+        continue;
+      }
+      const candidate = createController(
+        source.sourceId,
+        selection,
+        inputIndex,
+        representation.timing
+      );
+      try {
+        const loaded = await loadMediabunnySourceController(
+          candidate,
+          mediabunny,
+          source,
+          selection,
+          sourceInput,
+          options.selectTracks,
+          ensureAudioRuntime
+        );
+        if (disposed || loadGenerations.get(source.sourceId) !== generation) {
+          disposeController(candidate);
+          return {
+            ok: false,
+            sourceId: source.sourceId,
+            error: new Error(`Loading source "${source.sourceId}" was superseded.`),
+          };
+        }
+
+        attempts.push({ representation: selection, inputIndex, status: 'ready', error: null });
+        const previous = controllers.get(source.sourceId);
+        const wasPlaying = previous?.playing ?? false;
+        const timelineSeconds = previous === undefined ? 0 : getTimelinePlaybackSeconds(previous);
+        if (previous !== undefined) {
+          if (clockController === previous) {
+            clockController = candidate;
+          }
+          disposeController(previous);
+        }
+        controllers.set(source.sourceId, candidate);
+        selectedRepresentationBySourceId.set(source.sourceId, selection);
+        if (wasPlaying) {
+          setTimelineClock(candidate, timelineSeconds, currentPlaybackRate);
+        }
+        candidate.playing = wasPlaying;
+        ready = controllers.size > 0;
+        error = null;
+        status = 'Ready. Mediabunny can drive timeline video and audio.';
+        setSourceState({
+          sourceId: source.sourceId,
+          status: 'ready',
+          selectedRepresentation: selection,
+          selectedInputIndex: inputIndex,
+          attempts,
+          metadata: loaded.metadata,
+          error: null,
+        });
+        return {
+          ok: true,
+          sourceId: source.sourceId,
+          representation: selection,
+          inputIndex,
+          metadata: loaded.metadata,
+        };
+      } catch (sourceError) {
+        disposeController(candidate);
+        finalError = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
+        attempts.push({
+          representation: selection,
+          inputIndex,
+          status: 'failed',
+          error: finalError,
+        });
+      }
+    }
+
+    const previous = controllers.get(source.sourceId);
+    if (loadStatus === 'recovering' && previous !== undefined) {
+      disposeController(previous);
+      controllers.delete(source.sourceId);
+    }
+    ready = controllers.size > 0;
+    setSourceState({
+      sourceId: source.sourceId,
+      status: 'failed',
+      selectedRepresentation: selection,
+      selectedInputIndex: null,
+      attempts,
+      metadata: null,
+      error: finalError,
+    });
+    return { ok: false, sourceId: source.sourceId, error: finalError };
+  };
+
+  const recoverSource = async (
+    sourceId: string,
+    expectedController: MediabunnySourceController,
+    recoveryError: Error
+  ) => {
+    const source = sourceDefinitions.get(sourceId);
+    const controller = controllers.get(sourceId);
+    if (
+      source === undefined ||
+      controller !== expectedController ||
+      recoveringSources.has(sourceId) ||
+      disposed
+    ) {
+      return;
+    }
+    recoveringSources.add(sourceId);
+    stopMediaClock(controller);
+    const previousState = sourceStateById.get(sourceId);
+    const attempts = [
+      ...(previousState?.attempts ?? []),
+      {
+        representation: controller.representation,
+        inputIndex: controller.inputIndex,
+        status: 'failed',
+        error: recoveryError,
+      } as const,
+    ];
+    try {
+      const result = await loadSource(
+        source,
+        controller.representation,
+        'recovering',
+        controller.inputIndex + 1,
+        attempts
+      );
+      if (!result.ok) {
+        setError(result.error);
+      }
+    } finally {
+      recoveringSources.delete(sourceId);
+    }
+  };
+
   const syncLayers = async ({
     activeLayers,
     reason,
@@ -308,6 +778,16 @@ export function createMediabunnyAdapter(
   }: TimelineLayerSyncDetails<string>) => {
     const activeVisual = findActiveClipForKinds(activeLayers, visualTrackKinds);
     const activeAudio = findActiveClipForKinds(activeLayers, audioTrackKinds);
+
+    for (const activeClip of [activeVisual, activeAudio]) {
+      if (activeClip === undefined) {
+        continue;
+      }
+      const sourceState = sourceStateById.get(activeClip.clip.sourceId);
+      if (sourceState?.status === 'failed' && sourceState.error !== null) {
+        throw sourceState.error;
+      }
+    }
 
     if (activeVisual !== undefined) {
       const controller = getController(activeVisual);
@@ -322,11 +802,10 @@ export function createMediabunnyAdapter(
           canvas,
           activeVisual,
           (timestamp) => {
-            setLastFrameTime(timestamp);
+            setLastFrameTime(toLogicalSourceSeconds(controller, timestamp));
           },
           (playbackError) => {
-            stopMediaClock(controller);
-            setError(playbackError);
+            void recoverSource(controller.sourceId, controller, playbackError);
           }
         );
       } else {
@@ -357,15 +836,24 @@ export function createMediabunnyAdapter(
     get lastFrameTime() {
       return lastFrameTime;
     },
-    get durationBySourceId() {
-      return durationBySourceId;
+    get sourceStateById() {
+      return sourceStateById;
+    },
+    get volume() {
+      return volume;
+    },
+    get muted() {
+      return muted;
+    },
+    get audioStatus() {
+      return audioStatus;
     },
     get syncAdapter() {
       return {
         getClockTime: adapter.getClockTime,
         startClock: adapter.startClock,
         stopClock: adapter.stopClock,
-        resumeClock: adapter.resumeClock,
+        requestClockActivation: adapter.requestClockActivation,
         setClockRate: adapter.setClockRate,
         seek: adapter.seek,
         syncLayers: adapter.syncLayers,
@@ -413,16 +901,119 @@ export function createMediabunnyAdapter(
         void cancelVideoPlayback(controller);
       }
     },
-    resumeClock: async (playbackRate) => {
-      const controller = clockController ?? [...controllers.values()][0];
-      if (controller?.audioContext?.state !== 'suspended') {
+    requestClockActivation: (playbackRate) => {
+      if (audioContext?.state !== 'suspended') {
         return;
       }
-
-      await controller.audioContext.resume();
-      if (controller.playing) {
-        setTimelineClock(controller, getTimelinePlaybackSeconds(controller), playbackRate);
+      const generation = ++activationGeneration;
+      if (activationTimer !== null) {
+        window.clearTimeout(activationTimer);
       }
+      activationTimer = window.setTimeout(() => {
+        if (generation !== activationGeneration || audioContext?.state === 'running') {
+          return;
+        }
+        audioStatus = { state: 'degraded', error: null };
+        notify();
+      }, options.audio?.activationTimeoutMs ?? 1000);
+      void audioContext.resume().then(
+        () => {
+          if (generation !== activationGeneration || disposed) {
+            return;
+          }
+          if (activationTimer !== null) {
+            window.clearTimeout(activationTimer);
+          }
+          activationTimer = null;
+          audioStatus = { state: 'running' };
+          const timelineSeconds = adapter.getClockTime();
+          const playing = [...controllers.values()].some((controller) => controller.playing);
+          setAllClocks(timelineSeconds, playbackRate, playing);
+          notify();
+        },
+        (activationError: unknown) => {
+          if (generation !== activationGeneration || disposed) {
+            return;
+          }
+          if (activationTimer !== null) {
+            window.clearTimeout(activationTimer);
+          }
+          activationTimer = null;
+          audioStatus = {
+            state: 'degraded',
+            error:
+              activationError instanceof Error
+                ? activationError
+                : new Error(String(activationError)),
+          };
+          notify();
+        }
+      );
+    },
+    setVolume: (nextVolume) => {
+      if (!Number.isFinite(nextVolume) || nextVolume < 0 || nextVolume > 1) {
+        throw new RangeError('volume must be a finite number from 0 to 1.');
+      }
+      volume = nextVolume;
+      updateMasterGain();
+      notify();
+    },
+    setMuted: (nextMuted) => {
+      muted = nextMuted;
+      updateMasterGain();
+      notify();
+    },
+    setRepresentation: async (sourceId, representation) => {
+      const source = sourceDefinitions.get(sourceId);
+      if (source === undefined) {
+        return { ok: false, sourceId, error: new Error(`Unknown source "${sourceId}".`) };
+      }
+      const resolved = resolveMediabunnyRepresentation(source, representation);
+      if (resolved === undefined) {
+        return {
+          ok: false,
+          sourceId,
+          error: new Error(`Source "${sourceId}" does not define the selected representation.`),
+        };
+      }
+      const previousState = sourceStateById.get(sourceId);
+      const result = await loadSource(source, representation, 'loading');
+      if (!result.ok && controllers.has(sourceId) && previousState !== undefined) {
+        setSourceState(previousState);
+      }
+      return result;
+    },
+    retrySource: async (sourceId) => {
+      const source = sourceDefinitions.get(sourceId);
+      if (source === undefined) {
+        return { ok: false, sourceId, error: new Error(`Unknown source "${sourceId}".`) };
+      }
+      const previousState = sourceStateById.get(sourceId);
+      const representation =
+        selectedRepresentationBySourceId.get(sourceId) ?? ({ kind: 'original' } as const);
+      const result = await loadSource(source, representation, 'loading');
+      if (!result.ok && controllers.has(sourceId) && previousState !== undefined) {
+        setSourceState(previousState);
+      }
+      return result;
+    },
+    replaceSource: async (source) => {
+      validateSources([source]);
+      const previousState = sourceStateById.get(source.sourceId);
+      const previousSelection =
+        selectedRepresentationBySourceId.get(source.sourceId) ?? ({ kind: 'original' } as const);
+      const representation =
+        resolveMediabunnyRepresentation(source, previousSelection) === undefined
+          ? (options.selectRepresentation?.(source) ?? ({ kind: 'original' } as const))
+          : previousSelection;
+      assertMediabunnyRepresentation(source, representation);
+      const result = await loadSource(source, representation, 'loading');
+      if (result.ok) {
+        sourceDefinitions.set(source.sourceId, source);
+      } else if (controllers.has(source.sourceId) && previousState !== undefined) {
+        setSourceState(previousState);
+      }
+      return result;
     },
     setClockRate: (playbackRate) => {
       const timelineSeconds = adapter.getClockTime();
@@ -468,40 +1059,71 @@ export function createMediabunnyAdapter(
         return null;
       }
 
-      const wrappedCanvas = await controller.videoSink.getCanvas(toSeconds(activeVideo.sourceTime));
+      let wrappedCanvas: Awaited<ReturnType<Mediabunny.CanvasSink['getCanvas']>>;
+      try {
+        wrappedCanvas = await controller.videoSink.getCanvas(
+          toRepresentationSeconds(controller, toSeconds(activeVideo.sourceTime))
+        );
+      } catch (frameError) {
+        const error = frameError instanceof Error ? frameError : new Error(String(frameError));
+        void recoverSource(controller.sourceId, controller, error);
+        return null;
+      }
       if (wrappedCanvas === null) {
         return null;
       }
 
       return {
         canvas: wrappedCanvas.canvas,
-        timestamp: wrappedCanvas.timestamp,
+        timestamp: toLogicalSourceSeconds(controller, wrappedCanvas.timestamp),
       };
     },
     dispose: () => {
       disposed = true;
+      activationGeneration += 1;
+      if (activationTimer !== null) {
+        window.clearTimeout(activationTimer);
+      }
       for (const controller of controllers.values()) {
         disposeController(controller);
       }
       controllers.clear();
-      durationBySourceId.clear();
+      sourceStateById.clear();
       frameListeners.clear();
+      masterGainNode?.disconnect();
+      if (ownsAudioContext) {
+        void audioContext?.close();
+      }
     },
   };
 
-  void loadSources(options, controllers, durationBySourceId)
-    .then((loadedCount) => {
+  void Promise.all(
+    options.sources.map((source) =>
+      loadSource(
+        source,
+        selectedRepresentationBySourceId.get(source.sourceId) ?? { kind: 'original' },
+        'loading'
+      )
+    )
+  )
+    .then((results) => {
       if (disposed) {
         controllers.clear();
-        durationBySourceId.clear();
+        sourceStateById.clear();
         return;
       }
 
+      const loadedCount = results.filter((result) => result.ok).length;
       ready = loadedCount > 0;
-      status =
-        loadedCount > 0
-          ? 'Ready. Mediabunny can drive timeline video and audio.'
-          : 'No Mediabunny source could be loaded.';
+      const failedResult = results.find((result) => !result.ok);
+      if (loadedCount > 0) {
+        status = 'Ready. Mediabunny can drive timeline video and audio.';
+      } else if (failedResult !== undefined && !failedResult.ok) {
+        error = failedResult.error;
+        status = failedResult.error.message;
+      } else {
+        status = 'No Mediabunny source could be loaded.';
+      }
       notify();
     })
     .catch((loadError: unknown) => {
@@ -513,49 +1135,18 @@ export function createMediabunnyAdapter(
   return adapter;
 }
 
-async function loadSources(
-  options: CreateMediabunnyAdapterOptions,
-  controllers: Map<string, MediabunnySourceController>,
-  durationBySourceId: Map<string, number>
-) {
-  const mediabunny =
-    typeof options.mediabunny === 'function' ? await options.mediabunny() : options.mediabunny;
-
-  let loadedCount = 0;
-  let lastError: unknown;
-
-  for (const source of options.sources) {
-    if (controllers.has(source.id)) {
-      continue;
-    }
-
-    const controller = createController(source.id);
-    try {
-      const mediaInfo = await loadMediabunnySourceController(
-        controller,
-        mediabunny,
-        source,
-        options.audio
-      );
-      controllers.set(source.id, controller);
-      durationBySourceId.set(source.id, mediaInfo.duration);
-      loadedCount += 1;
-    } catch (sourceError) {
-      lastError = sourceError;
-      disposeController(controller);
-    }
-  }
-
-  if (loadedCount === 0 && lastError !== undefined) {
-    throw lastError;
-  }
-
-  return loadedCount;
-}
-
-function createController(sourceId: string): MediabunnySourceController {
+function createController(
+  sourceId: string,
+  representation: MediabunnyRepresentationSelection,
+  inputIndex: number,
+  timing: MediabunnyRepresentationTiming | undefined
+): MediabunnySourceController {
   return {
     sourceId,
+    representation,
+    inputIndex,
+    mediaTimeOffsetSeconds:
+      timing === undefined ? 0 : timing.mediaTimeSeconds - timing.sourceTimeSeconds,
     input: null,
     ownsInput: true,
     videoSink: null,
@@ -593,29 +1184,52 @@ async function loadMediabunnySourceController(
   controller: MediabunnySourceController,
   mediabunny: MediabunnyModule,
   source: MediabunnySource,
-  audioOptions: MediabunnyTimelineAudioOptions | undefined
+  representation: MediabunnyRepresentationSelection,
+  sourceInput: MediabunnySourceInput,
+  selectTracks: CreateMediabunnyAdapterOptions['selectTracks'],
+  ensureAudioRuntime: () => { context: AudioContext; gainNode: GainNode } | null
 ): Promise<LoadedMediaInfo> {
-  const input = await createInput(mediabunny, source);
+  const input = await createInput(mediabunny, sourceInput);
   controller.input = input;
-  controller.ownsInput = !('input' in source);
+  controller.ownsInput = sourceInput.kind !== 'input';
 
-  const videoTrack = await input.getPrimaryVideoTrack();
-  const audioTrack = await input.getPrimaryAudioTrack();
+  let videoTrack: Mediabunny.InputVideoTrack | null;
+  let audioTrack: Mediabunny.InputAudioTrack | null;
+  if (selectTracks === undefined) {
+    [videoTrack, audioTrack] = await Promise.all([
+      input.getPrimaryVideoTrack(),
+      input.getPrimaryAudioTrack(),
+    ]);
+  } else {
+    const [videoTracks, audioTracks] = await Promise.all([
+      input.getVideoTracks(),
+      input.getAudioTracks(),
+    ]);
+    ({ videoTrack, audioTrack } = await selectTracks({
+      source,
+      representation,
+      sourceInput,
+      input,
+      videoTracks,
+      audioTracks,
+    }));
+  }
   type InputTrack = NonNullable<typeof videoTrack> | NonNullable<typeof audioTrack>;
   const tracks = [videoTrack, audioTrack].filter((track): track is InputTrack => track !== null);
 
   if (tracks.length === 0) {
-    throw new Error(`No audio or video track found for source "${source.id}".`);
+    throw new Error(`No audio or video track found for source "${source.sourceId}".`);
   }
 
-  const firstTimestamp = Math.max(await input.getFirstTimestamp(tracks), 0);
+  const firstTimestamp = await input.getFirstTimestamp(tracks);
+  const presentationStartTimestamp = Math.max(firstTimestamp, 0);
   const endTimestamp =
     (await input.getDurationFromMetadata(tracks, { skipLiveWait: true })) ??
     (await input.computeDuration(tracks, { skipLiveWait: true }));
 
   if (videoTrack !== null) {
     if ((await videoTrack.getCodec()) === null || !(await videoTrack.canDecode())) {
-      throw new Error(`The browser cannot decode the video track for source "${source.id}".`);
+      throw new Error(`The browser cannot decode the video track for source "${source.sourceId}".`);
     }
 
     const alpha = await videoTrack.canBeTransparent();
@@ -626,53 +1240,64 @@ async function loadMediabunnySourceController(
     });
   }
 
-  const AudioContextCtor =
-    window.AudioContext ??
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-  if (AudioContextCtor === undefined) {
-    throw new Error('This browser does not expose AudioContext.');
-  }
-
-  const audioContext =
-    audioOptions?.context ??
-    (audioTrack !== null
-      ? new AudioContextCtor({ sampleRate: await audioTrack.getSampleRate() })
-      : new AudioContextCtor());
-  const gainNode = audioContext.createGain();
-  gainNode.gain.value = audioOptions?.volume ?? 0.7;
-  gainNode.connect(audioOptions?.destination ?? audioContext.destination);
-  controller.audioContext = audioContext;
-  controller.gainNode = gainNode;
-
   if (
     audioTrack !== null &&
     (await audioTrack.getCodec()) !== null &&
     (await audioTrack.canDecode())
   ) {
-    controller.audioSink = new mediabunny.AudioBufferSink(audioTrack);
+    const audioRuntime = ensureAudioRuntime();
+    if (audioRuntime !== null) {
+      controller.audioContext = audioRuntime.context;
+      controller.gainNode = audioRuntime.gainNode;
+      controller.audioSink = new mediabunny.AudioBufferSink(audioTrack);
+    }
   }
 
+  const [videoMetadata, audioMetadata] = await Promise.all([
+    videoTrack === null
+      ? null
+      : Promise.all([
+          videoTrack.getDisplayWidth(),
+          videoTrack.getDisplayHeight(),
+          videoTrack.getRotation(),
+          videoTrack.computePacketStats(100, { skipLiveWait: true }).catch(() => null),
+        ]).then(([displayWidth, displayHeight, rotation, packetStats]) => ({
+          displayWidth,
+          displayHeight,
+          rotation,
+          detectedFrameRate: packetStats?.averagePacketRate || null,
+        })),
+    audioTrack === null ? null : audioTrack.getSampleRate().then((sampleRate) => ({ sampleRate })),
+  ]);
+
   return {
-    duration: endTimestamp - firstTimestamp,
+    metadata: {
+      firstTimestampSeconds: firstTimestamp,
+      sourceFirstTimestampSeconds: toLogicalSourceSeconds(controller, firstTimestamp),
+      presentationStartTimestampSeconds: presentationStartTimestamp,
+      endTimestampSeconds: endTimestamp,
+      sourceEndTimestampSeconds: toLogicalSourceSeconds(controller, endTimestamp),
+      durationSeconds: Math.max(0, endTimestamp - presentationStartTimestamp),
+      video: videoMetadata,
+      audio: audioMetadata,
+    },
   };
 }
 
 async function createInput(
   mediabunny: MediabunnyModule,
-  source: MediabunnySource
+  sourceInput: MediabunnySourceInput
 ): Promise<Mediabunny.Input> {
-  if ('input' in source) {
-    return source.input;
+  if (sourceInput.kind === 'input') {
+    return sourceInput.input;
   }
-
-  if ('createInput' in source) {
-    return source.createInput(mediabunny);
+  if (sourceInput.kind === 'input-factory') {
+    return sourceInput.createInput(mediabunny);
   }
-
-  if ('url' in source) {
+  if (sourceInput.kind === 'url') {
     return new mediabunny.Input({
-      source: new mediabunny.UrlSource(source.url),
-      formats: mediabunny.ALL_FORMATS,
+      source: new mediabunny.UrlSource(sourceInput.url, sourceInput.urlSourceOptions),
+      formats: [...(sourceInput.formats ?? mediabunny.ALL_FORMATS)],
     });
   }
 
@@ -687,7 +1312,7 @@ async function createInput(
   }
 
   return new mediabunny.Input({
-    source: new mediabunnyWithBlobSource.BlobSource(source.blob),
+    source: new mediabunnyWithBlobSource.BlobSource(sourceInput.blob),
     formats: mediabunny.ALL_FORMATS,
   });
 }
@@ -702,6 +1327,14 @@ function setTimelineClock(
   controller.audioClockReady = controller.audioContext?.state === 'running';
   controller.wallClockStartTime = performance.now() / 1000;
   controller.playbackRate = playbackRate;
+}
+
+function toRepresentationSeconds(controller: MediabunnySourceController, sourceSeconds: number) {
+  return sourceSeconds + controller.mediaTimeOffsetSeconds;
+}
+
+function toLogicalSourceSeconds(controller: MediabunnySourceController, mediaSeconds: number) {
+  return mediaSeconds - controller.mediaTimeOffsetSeconds;
 }
 
 function getTimelinePlaybackSeconds(controller: MediabunnySourceController) {
@@ -735,7 +1368,12 @@ async function renderActiveVideoFrame(
   video: ActiveClip,
   onFrame?: (timestamp: number) => void
 ) {
-  await renderFrameAt(controller, canvas, toSeconds(video.sourceTime), onFrame);
+  await renderFrameAt(
+    controller,
+    canvas,
+    toRepresentationSeconds(controller, toSeconds(video.sourceTime)),
+    onFrame
+  );
 }
 
 const VIDEO_TIMESTAMP_EPSILON = 1e-9;
@@ -866,10 +1504,10 @@ async function startVideoPlayback(
     return;
   }
 
-  const sourceSeconds = toSeconds(activeVideo.sourceTime);
+  const sourceSeconds = toRepresentationSeconds(controller, toSeconds(activeVideo.sourceTime));
   controller.videoPlaybackIterator = controller.videoSink.canvases(
     sourceSeconds,
-    toSeconds(activeVideo.sourceRange.end)
+    toRepresentationSeconds(controller, toSeconds(activeVideo.sourceRange.end))
   );
   controller.videoPlaybackSyncKey = activeVideo.syncKey;
   controller.videoPlaybackSourceSeconds = sourceSeconds;
@@ -887,7 +1525,7 @@ function syncActiveVideoPlaybackFrame(
   onFrame?: (timestamp: number) => void,
   onFailure?: (error: Error) => void
 ) {
-  const sourceSeconds = toSeconds(activeVideo.sourceTime);
+  const sourceSeconds = toRepresentationSeconds(controller, toSeconds(activeVideo.sourceTime));
   if (
     controller.videoPlaybackIterator === null ||
     controller.videoPlaybackSyncKey !== activeVideo.syncKey ||
@@ -917,7 +1555,11 @@ function clearPreviewCanvas(controller: MediabunnySourceController, canvas: HTML
   }
 }
 
-function syncAudioClip(controller: MediabunnySourceController, audio: ActiveClip | undefined) {
+function syncAudioClip(
+  controller: MediabunnySourceController,
+  audio: ActiveClip | undefined,
+  onFailure?: (error: Error) => void
+) {
   stopAudioIterator(controller);
   stopQueuedAudio(controller);
   controller.activeAudioSyncKey = audio?.syncKey;
@@ -926,15 +1568,17 @@ function syncAudioClip(controller: MediabunnySourceController, audio: ActiveClip
     return;
   }
 
-  const sourceStart = toSeconds(audio.sourceTime);
-  const sourceEnd = toSeconds(audio.sourceRange.end);
+  const sourceStart = toRepresentationSeconds(controller, toSeconds(audio.sourceTime));
+  const sourceEnd = toRepresentationSeconds(controller, toSeconds(audio.sourceRange.end));
 
   if (sourceEnd <= sourceStart) {
     return;
   }
 
   controller.audioBufferIterator = controller.audioSink.buffers(sourceStart, sourceEnd);
-  void runAudioIterator(controller, audio.clip, audio.syncKey);
+  void runAudioIterator(controller, audio.clip, audio.syncKey).catch((iteratorError: unknown) => {
+    onFailure?.(iteratorError instanceof Error ? iteratorError : new Error(String(iteratorError)));
+  });
 }
 
 function stopMediaClock(controller: MediabunnySourceController) {
@@ -956,7 +1600,6 @@ function disposeController(controller: MediabunnySourceController) {
   if (controller.ownsInput) {
     controller.input?.dispose();
   }
-  void controller.audioContext?.close();
 }
 
 function stopQueuedAudio(controller: MediabunnySourceController) {
@@ -989,7 +1632,7 @@ async function runAudioIterator(
   }
 
   const clipTimelineStart = toSeconds(audioClip.timelineStart);
-  const clipSourceStart = toSeconds(audioClip.sourceStart);
+  const clipSourceStart = toRepresentationSeconds(controller, toSeconds(audioClip.sourceStart));
 
   for await (const { buffer, timestamp } of controller.audioBufferIterator) {
     if (

--- a/packages/mediabunny-adapter/src/react.test.tsx
+++ b/packages/mediabunny-adapter/src/react.test.tsx
@@ -59,13 +59,45 @@ function createMediaSyncEngine() {
   });
 }
 
-function createTestAdapter(overrides: Partial<MediabunnyAdapter> = {}) {
+function createTestAdapter(overrides: Partial<MediabunnyAdapter> = {}): MediabunnyAdapter {
   return {
     ready: true,
     status: 'Ready.',
     error: null,
     lastFrameTime: null,
-    durationBySourceId: new Map([['source-1', 4]]),
+    sourceStateById: new Map([
+      [
+        'source-1',
+        {
+          sourceId: 'source-1',
+          status: 'ready',
+          selectedRepresentation: { kind: 'original' },
+          selectedInputIndex: 0,
+          attempts: [
+            {
+              representation: { kind: 'original' },
+              inputIndex: 0,
+              status: 'ready',
+              error: null,
+            },
+          ],
+          metadata: {
+            firstTimestampSeconds: 0,
+            sourceFirstTimestampSeconds: 0,
+            presentationStartTimestampSeconds: 0,
+            endTimestampSeconds: 4,
+            sourceEndTimestampSeconds: 4,
+            durationSeconds: 4,
+            video: null,
+            audio: null,
+          },
+          error: null,
+        },
+      ],
+    ]),
+    volume: 0.7,
+    muted: false,
+    audioStatus: { state: 'unavailable' },
     subscribeFrame: () => () => {},
     syncAdapter: {
       getClockTime: vi.fn(() => 0),
@@ -78,7 +110,15 @@ function createTestAdapter(overrides: Partial<MediabunnyAdapter> = {}) {
     getClockTime: () => 0,
     startClock: () => true,
     stopClock: () => {},
-    resumeClock: () => Promise.resolve(),
+    requestClockActivation: () => {},
+    setVolume: () => {},
+    setMuted: () => {},
+    setRepresentation: (sourceId) =>
+      Promise.resolve({ ok: false, sourceId, error: new Error('Unavailable in test.') }),
+    retrySource: (sourceId: string) =>
+      Promise.resolve({ ok: false, sourceId, error: new Error('unavailable') }),
+    replaceSource: (source) =>
+      Promise.resolve({ ok: false, sourceId: source.sourceId, error: new Error('unavailable') }),
     setClockRate: () => {},
     seek: () => Promise.resolve(),
     renderVideo: () => Promise.resolve(),
@@ -160,7 +200,7 @@ test('useMediabunnyAdapter returns noop behavior when window is unavailable', as
   expect(adapter.getClockTime()).toBe(0);
   expect(adapter.startClock(fromSeconds(0), 1)).toBe(false);
   adapter.stopClock();
-  await adapter.resumeClock(1);
+  adapter.requestClockActivation(1);
   adapter.setClockRate(1);
   await adapter.seek(fromSeconds(0), {
     time: fromSeconds(0),
@@ -216,7 +256,12 @@ test('useMediabunnyTimelineMedia creates an adapter and exposes sync state', asy
     () =>
       useMediabunnyTimelineMedia({
         canvasRef: { current: canvas },
-        sources: [{ id: 'source-1', url: '/sample.mp4' }],
+        sources: [
+          {
+            sourceId: 'source-1',
+            input: { kind: 'url', url: '/sample.mp4' },
+          },
+        ],
         layers,
       }),
     {
@@ -227,7 +272,12 @@ test('useMediabunnyTimelineMedia creates an adapter and exposes sync state', asy
   expect(createMediabunnyAdapter).toHaveBeenCalledWith(
     expect.objectContaining({
       mediabunny: expect.any(Function),
-      sources: [{ id: 'source-1', url: '/sample.mp4' }],
+      sources: [
+        {
+          sourceId: 'source-1',
+          input: { kind: 'url', url: '/sample.mp4' },
+        },
+      ],
       onChange: expect.any(Function),
     })
   );
@@ -235,7 +285,7 @@ test('useMediabunnyTimelineMedia creates an adapter and exposes sync state', asy
   expect(result.current.ready).toBe(true);
   expect(result.current.status).toBe('Ready. Mediabunny can drive timeline video and audio.');
   expect('lastFrameTime' in result.current).toBe(false);
-  expect(result.current.durationBySourceId.get('source-1')).toBe(4);
+  expect(result.current.sourceStateById.get('source-1')?.metadata?.durationSeconds).toBe(4);
 
   await act(async () => {
     await expect(result.current.play()).resolves.toEqual({ ok: true, time: fromSeconds(0) });

--- a/packages/mediabunny-adapter/src/react.ts
+++ b/packages/mediabunny-adapter/src/react.ts
@@ -47,7 +47,10 @@ export interface UseMediabunnyAdapterOptions extends Omit<
 export interface UseMediabunnyTimelineMediaOptions<LayerName extends string = string>
   extends
     Omit<UseMediabunnyAdapterOptions, 'mediabunny'>,
-    Pick<UseTimelineMediaSyncOptions<LayerName>, 'frameRate' | 'layers' | 'onError'> {
+    Pick<
+      UseTimelineMediaSyncOptions<LayerName>,
+      'frameRate' | 'layers' | 'onError' | 'playbackOptions'
+    > {
   /** Mediabunny module instance or lazy browser loader. Defaults to a browser import. */
   mediabunny?: CreateMediabunnyAdapterOptions['mediabunny'];
 }
@@ -67,8 +70,8 @@ export interface UseMediabunnyTimelineMediaResult<
   status: string;
   /** Last source loading error, when one is active. */
   error: Error | null;
-  /** Loaded media duration by source id, in seconds. */
-  durationBySourceId: ReadonlyMap<string, number>;
+  /** Loading, selected representation, input attempts, metadata, and recovery by source id. */
+  sourceStateById: MediabunnyAdapter['sourceStateById'];
   /** Underlying low-level Mediabunny adapter. */
   adapter: MediabunnyAdapter;
 }
@@ -78,7 +81,10 @@ const noopAdapter: MediabunnyAdapter = {
   status: 'Mediabunny is waiting for the browser.',
   error: null,
   lastFrameTime: null,
-  durationBySourceId: new Map(),
+  sourceStateById: new Map(),
+  volume: 0.7,
+  muted: false,
+  audioStatus: { state: 'unavailable' },
   subscribeFrame: () => () => {},
   syncAdapter: {
     getClockTime: () => 0,
@@ -88,7 +94,19 @@ const noopAdapter: MediabunnyAdapter = {
   getClockTime: () => 0,
   startClock: () => false,
   stopClock: () => {},
-  resumeClock: () => Promise.resolve(),
+  requestClockActivation: () => {},
+  setVolume: () => {},
+  setMuted: () => {},
+  setRepresentation: (sourceId) =>
+    Promise.resolve({ ok: false, sourceId, error: new Error('Mediabunny is unavailable.') }),
+  retrySource: (sourceId) =>
+    Promise.resolve({ ok: false, sourceId, error: new Error('Mediabunny is unavailable.') }),
+  replaceSource: (source) =>
+    Promise.resolve({
+      ok: false,
+      sourceId: source.sourceId,
+      error: new Error('Mediabunny is unavailable.'),
+    }),
   setClockRate: () => {},
   seek: () => Promise.resolve(),
   renderVideo: () => Promise.resolve(),
@@ -121,8 +139,15 @@ const loadMediabunny = () => import('mediabunny') as Promise<MediabunnyModule>;
  *
  * export function DecoderStatus() {
  *   const canvasRef = useRef<HTMLCanvasElement>(null);
- *   const sources = useMemo(() => [{ id: 'source-1', url: '/media/sample.mp4' }], []);
- *   const adapter = useMediabunnyAdapter({ canvasRef, sources });
+ *   const sources = useMemo(() => [{
+ *     sourceId: 'source-1',
+ *     input: { kind: 'url', url: '/media/sample.mp4' },
+ *   }], []);
+ *   const adapter = useMediabunnyAdapter({
+ *     canvasRef,
+ *     sources,
+ *     mediabunny: () => import('mediabunny'),
+ *   });
  *
  *   return (
  *     <>
@@ -137,7 +162,16 @@ const loadMediabunny = () => import('mediabunny') as Promise<MediabunnyModule>;
  * @see {@link useMediabunnyTimelineMedia}
  */
 export function useMediabunnyAdapter(options: UseMediabunnyAdapterOptions): MediabunnyAdapter {
-  const { audio, audioTrackKinds, canvasRef, mediabunny, sources, visualTrackKinds } = options;
+  const {
+    audio,
+    audioTrackKinds,
+    canvasRef,
+    mediabunny,
+    selectRepresentation,
+    selectTracks,
+    sources,
+    visualTrackKinds,
+  } = options;
   const [, forceUpdate] = useReducer((value: number) => value + 1, 0);
   const [adapter, setAdapter] = useState<MediabunnyAdapter>(noopAdapter);
 
@@ -150,6 +184,8 @@ export function useMediabunnyAdapter(options: UseMediabunnyAdapterOptions): Medi
       audio,
       audioTrackKinds,
       mediabunny,
+      selectRepresentation,
+      selectTracks,
       sources,
       visualTrackKinds,
       onChange: forceUpdate,
@@ -159,7 +195,15 @@ export function useMediabunnyAdapter(options: UseMediabunnyAdapterOptions): Medi
     return () => {
       nextAdapter.dispose();
     };
-  }, [audio, audioTrackKinds, mediabunny, sources, visualTrackKinds]);
+  }, [
+    audio,
+    audioTrackKinds,
+    mediabunny,
+    selectRepresentation,
+    selectTracks,
+    sources,
+    visualTrackKinds,
+  ]);
 
   useEffect(() => {
     adapter.setCanvas(canvasRef?.current ?? null);
@@ -212,7 +256,10 @@ export function useMediabunnyFrameTime(adapter: MediabunnyAdapter): number | nul
  *
  * export function DecodedPreview() {
  *   const canvasRef = useRef<HTMLCanvasElement>(null);
- *   const sources = useMemo(() => [{ id: 'source-1', url: '/media/interview.mp4' }], []);
+ *   const sources = useMemo(() => [{
+ *     sourceId: 'source-1',
+ *     input: { kind: 'url', url: '/media/interview.mp4' },
+ *   }], []);
  *   const media = useMediabunnyTimelineMedia<PreviewLayerName>({
  *     canvasRef,
  *     sources,
@@ -247,6 +294,8 @@ export function useMediabunnyTimelineMedia<LayerName extends string = string>(
     layers,
     mediabunny = loadMediabunny,
     onError,
+    playbackOptions,
+    selectTracks,
     sources,
     visualTrackKinds,
   } = options;
@@ -255,6 +304,7 @@ export function useMediabunnyTimelineMedia<LayerName extends string = string>(
     audioTrackKinds,
     canvasRef,
     mediabunny,
+    selectTracks,
     sources,
     visualTrackKinds,
   });
@@ -264,6 +314,7 @@ export function useMediabunnyTimelineMedia<LayerName extends string = string>(
     layers,
     adapter: adapter.syncAdapter,
     onError,
+    playbackOptions,
   });
 
   return {
@@ -271,7 +322,7 @@ export function useMediabunnyTimelineMedia<LayerName extends string = string>(
     ready: adapter.ready,
     status: adapter.status,
     error: adapter.error,
-    durationBySourceId: adapter.durationBySourceId,
+    sourceStateById: adapter.sourceStateById,
     adapter,
   };
 }


### PR DESCRIPTION
## Summary\n\n- use concise original inputs with per-representation fallbacks\n- add deliberately selectable, timestamp-mapped editing proxies\n- scope runtime decode recovery to the selected representation's inputs\n- expose selected representation, selected input, attempts, timing, tracks, dimensions, and frame rate\n- retain lazy owned audio graphs, caller-owned context safety, runtime gain controls, and non-blocking activation\n- migrate the full editor and Mediabunny demo consumers\n\n## Release Impact\n\n- Packages/API: Mediabunny adapter and React helper\n- Docs/demos: full editor and decoded preview demo\n- Breaking changes: removes flat descriptors, duplicate-ID fallback, variants, durationBySourceId, and resumeClock without aliases\n- Release risk: proxy timestamp translation, runtime source recovery, and audio lifecycle\n\n## Stack\n\n3 of 5. Base: feat/html-media/source-variants.\n\n## Validation\n\n- 15 adapter tests and 5 React helper tests\n- proxy frame and metadata timestamp mapping covered\n- full stack: vp run ci