### PR TITLE
fix!: enforce ranges for external clocks

### DIFF
--- a/.changeset/external-clock-ranges.md
+++ b/.changeset/external-clock-ranges.md
@@ -1,0 +1,6 @@
+---
+'@techsquidtv/canvas-timeline-core': minor
+'@techsquidtv/canvas-timeline-react': minor
+---
+
+Enforce playback in/out points consistently for internal and external clocks, and replace blocking clock resumption with non-blocking activation requests.

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -576,6 +576,36 @@ describe('TimelineEngine', () => {
 
       rafSpy.mockRestore();
     });
+
+    it('applies in/out boundaries to externally clocked playback', () => {
+      engine.setInPoint(fromSeconds(2), false);
+      engine.setOutPoint(fromSeconds(4), false);
+      engine.setTime(fromSeconds(3));
+
+      expect(engine.play({ clock: 'external', respectInOut: true })).toBe(true);
+      expect(engine.updateExternalPlaybackTime(fromSeconds(4.5))).toMatchObject({
+        action: 'pause',
+        reason: 'in-out',
+      });
+      expect(toSeconds(engine.getTime())).toBe(4);
+      expect(engine.getState().playing).toBe(false);
+    });
+
+    it('loops external playback and resets playback started at the out point', () => {
+      engine.setInPoint(fromSeconds(2), false);
+      engine.setOutPoint(fromSeconds(4), false);
+      engine.setTime(fromSeconds(4));
+
+      expect(engine.getPlaybackStartTime({ respectInOut: true })).toEqual(fromSeconds(2));
+      expect(engine.play({ clock: 'external', respectInOut: true, loop: true })).toBe(true);
+      expect(toSeconds(engine.getTime())).toBe(2);
+      expect(engine.updateExternalPlaybackTime(fromSeconds(4.25))).toMatchObject({
+        action: 'loop',
+        reason: 'in-out',
+      });
+      expect(toSeconds(engine.getTime())).toBe(2);
+      expect(engine.getState().playing).toBe(true);
+    });
   });
 
   describe('Snapping', () => {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -3,6 +3,7 @@ import type {
   TimelineClipDropFeedback,
   Marker,
   PlaybackOptions,
+  ExternalPlaybackUpdate,
   TimelineClipMoveOptions,
   TimelineClipMoveResult,
   TimelineSnapFeedback,
@@ -705,7 +706,25 @@ export class TimelineEngine extends TimelineEngineState {
    * Plays the timeline.
    */
   play(options: PlaybackOptions = {}): boolean {
+    if (this.state.playing) {
+      return false;
+    }
+    const startTime = this.playbackManager.prepareStart(options);
+    if (compareRational(startTime, this.state.playheadTime) !== 0) {
+      this.updatePlayhead(startTime);
+    }
     return this.playbackManager.play(options);
+  }
+
+  /** Resolves playback start time from a reached Out point to the In point (or zero) when enabled. */
+  getPlaybackStartTime(options: PlaybackOptions = {}): RationalTime {
+    return this.playbackManager.prepareStart(options);
+  }
+
+  /** Advances externally clocked playback through the shared range policy. */
+  updateExternalPlaybackTime(time: RationalTime): ExternalPlaybackUpdate {
+    assertValidRationalTime(time, 'time');
+    return this.playbackManager.updateExternalTime(time);
   }
 
   /**

--- a/packages/core/src/playback.ts
+++ b/packages/core/src/playback.ts
@@ -1,5 +1,5 @@
 import type { TimelineEngine } from '#core/engine';
-import type { PlaybackClockSource, PlaybackOptions } from '#core/types';
+import type { ExternalPlaybackUpdate, PlaybackClockSource, PlaybackOptions } from '#core/types';
 import {
   addRational,
   compareRational,
@@ -14,6 +14,8 @@ export class PlaybackManager {
   private playbackClockSource: PlaybackClockSource = 'internal';
   private playbackTargetTime: RationalTime | undefined;
   private playbackAutoEnd = false;
+  private respectInOut = true;
+  private loopRange = false;
 
   constructor(engine: TimelineEngine) {
     this.engine = engine;
@@ -29,10 +31,9 @@ export class PlaybackManager {
     this.playbackAutoEnd = options.autoEnd ?? options.toTime !== undefined;
     this.playbackTargetTime =
       options.toTime ?? (options.autoEnd ? this.engine.maxContentTime : undefined);
+    this.respectInOut = options.respectInOut ?? true;
+    this.loopRange = options.loop ?? false;
     state.playing = true;
-
-    const respectInOut = options.respectInOut ?? true;
-    const loopRange = options.loop ?? false;
 
     if (this.playbackClockSource === 'external') {
       if (this.playbackInterval !== null) {
@@ -55,50 +56,10 @@ export class PlaybackManager {
 
       const deltaSec = (deltaMs / 1000) * (currentState.playbackRate ?? 1.0);
       const deltaRt = fromSeconds(deltaSec, currentState.playheadTime.r);
-      let nextTime = addRational(currentState.playheadTime, deltaRt);
-
-      // 1. Check respectInOut boundaries (In/Out points)
-      if (respectInOut) {
-        const inLimit = currentState.inPoint ?? fromSeconds(0, currentState.playheadTime.r);
-        const outLimit = currentState.outPoint;
-
-        if (outLimit !== undefined && compareRational(nextTime, outLimit) >= 0) {
-          if (loopRange) {
-            nextTime = inLimit;
-          } else {
-            this.engine.updatePlayhead(outLimit);
-            this.pause();
-            return;
-          }
-        }
-      }
-
-      // 2. Check total duration boundaries
-      if (
-        currentState.duration !== undefined &&
-        compareRational(nextTime, currentState.duration) >= 0
-      ) {
-        if (loopRange) {
-          nextTime = currentState.inPoint ?? fromSeconds(0, currentState.playheadTime.r);
-        } else {
-          this.engine.updatePlayhead(currentState.duration);
-          this.pause();
-          return;
-        }
-      }
-
-      // 3. Check target time (from options)
-      if (
-        this.playbackTargetTime !== undefined &&
-        compareRational(nextTime, this.playbackTargetTime) >= 0
-      ) {
-        this.engine.updatePlayhead(this.playbackTargetTime);
-        if (this.playbackAutoEnd) {
-          this.pause();
-          return;
-        }
-      } else {
-        this.engine.updatePlayhead(nextTime);
+      const nextTime = addRational(currentState.playheadTime, deltaRt);
+      const update = this.advanceTo(nextTime);
+      if (update.action === 'pause') {
+        return;
       }
 
       this.playbackInterval = requestAnimationFrame(loop);
@@ -107,6 +68,71 @@ export class PlaybackManager {
     this.playbackInterval = requestAnimationFrame(loop);
     this.engine.emit('playback:state', true);
     return true;
+  }
+
+  prepareStart(options: PlaybackOptions = {}): RationalTime {
+    const state = this.engine.getState();
+    if ((options.respectInOut ?? true) && state.outPoint !== undefined) {
+      if (compareRational(state.playheadTime, state.outPoint) >= 0) {
+        return state.inPoint ?? fromSeconds(0, state.playheadTime.r);
+      }
+    }
+    return state.playheadTime;
+  }
+
+  updateExternalTime(time: RationalTime): ExternalPlaybackUpdate {
+    if (this.playbackClockSource !== 'external' || !this.engine.getState().playing) {
+      this.engine.updatePlayhead(time);
+      return { time: this.engine.getTime(), action: 'continue' };
+    }
+    return this.advanceTo(time);
+  }
+
+  private advanceTo(nextTime: RationalTime): ExternalPlaybackUpdate {
+    const state = this.engine.getState();
+    const inLimit = state.inPoint ?? fromSeconds(0, nextTime.r);
+
+    if (
+      this.respectInOut &&
+      state.outPoint !== undefined &&
+      compareRational(nextTime, state.outPoint) >= 0
+    ) {
+      if (this.loopRange) {
+        this.engine.updatePlayhead(inLimit);
+        return { time: this.engine.getTime(), action: 'loop', reason: 'in-out' };
+      }
+      this.engine.updatePlayhead(state.outPoint);
+      const time = this.engine.getTime();
+      this.pause();
+      return { time, action: 'pause', reason: 'in-out' };
+    }
+
+    if (state.duration !== undefined && compareRational(nextTime, state.duration) >= 0) {
+      if (this.loopRange) {
+        this.engine.updatePlayhead(inLimit);
+        return { time: this.engine.getTime(), action: 'loop', reason: 'duration' };
+      }
+      this.engine.updatePlayhead(state.duration);
+      const time = this.engine.getTime();
+      this.pause();
+      return { time, action: 'pause', reason: 'duration' };
+    }
+
+    if (
+      this.playbackTargetTime !== undefined &&
+      compareRational(nextTime, this.playbackTargetTime) >= 0
+    ) {
+      this.engine.updatePlayhead(this.playbackTargetTime);
+      const time = this.engine.getTime();
+      if (this.playbackAutoEnd) {
+        this.pause();
+        return { time, action: 'pause', reason: 'target' };
+      }
+      return { time, action: 'continue' };
+    }
+
+    this.engine.updatePlayhead(nextTime);
+    return { time: this.engine.getTime(), action: 'continue' };
   }
 
   pause() {
@@ -122,6 +148,8 @@ export class PlaybackManager {
     this.playbackClockSource = 'internal';
     this.playbackTargetTime = undefined;
     this.playbackAutoEnd = false;
+    this.respectInOut = true;
+    this.loopRange = false;
     this.engine.emit('playback:state', false);
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,16 @@ export interface PlaybackOptions {
   respectInOut?: boolean;
 }
 
+/** Result of advancing playback from an externally owned media clock. */
+export interface ExternalPlaybackUpdate {
+  /** Effective timeline time after boundary handling. */
+  time: RationalTime;
+  /** Whether playback continues, loops, or pauses at a boundary. */
+  action: 'continue' | 'loop' | 'pause';
+  /** Boundary responsible for a loop or pause. */
+  reason?: 'in-out' | 'duration' | 'target';
+}
+
 /**
  * Source-media interval covered by a timeline clip.
  */

--- a/packages/react/src/hooks/integration/media.test.tsx
+++ b/packages/react/src/hooks/integration/media.test.tsx
@@ -56,6 +56,62 @@ test('useTimelineMediaPlayback starts external playback and advances from clock 
   cancelSpy.mockRestore();
 });
 
+test('useTimelineMediaPlayback invokes one loop transition until the clock re-enters range', () => {
+  const engine = createMediaSyncEngine();
+  engine.setInPoint(fromSeconds(1), false);
+  engine.setOutPoint(fromSeconds(4), false);
+  let clockTime = 1;
+  let tick: FrameRequestCallback | undefined;
+  const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    tick = callback;
+    return 1;
+  });
+  const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  const onLoop = vi.fn();
+
+  const { result } = renderHook(
+    () =>
+      useTimelineMediaPlayback({
+        getClockTime: () => clockTime,
+        layers: mediaSyncLayers,
+        playbackOptions: { loop: true, respectInOut: true },
+        onLoop,
+      }),
+    {
+      wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+    }
+  );
+
+  act(() => {
+    expect(result.current.play()).toEqual({ ok: true });
+  });
+
+  clockTime = 4.25;
+  act(() => {
+    tick?.(16);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(1);
+  expect(engine.getTime()).toEqual(fromSeconds(1));
+
+  act(() => {
+    tick?.(32);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(1);
+
+  clockTime = 1.25;
+  act(() => {
+    tick?.(48);
+  });
+  clockTime = 4.25;
+  act(() => {
+    tick?.(64);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(2);
+
+  rafSpy.mockRestore();
+  cancelSpy.mockRestore();
+});
+
 test('useTimelineMediaPlayback synchronizes at most once per project frame and skips missed ticks', () => {
   const engine = createMediaSyncEngine();
   engine.setTime(fromSeconds(1.02));
@@ -383,7 +439,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
     clockTime = toSeconds(timelineTime);
     return true;
   });
-  const resumeClock = vi.fn();
+  const requestClockActivation = vi.fn();
   const seek = vi.fn();
   const syncLayers = vi.fn();
 
@@ -397,7 +453,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
         adapter: {
           getClockTime: () => clockTime,
           startClock,
-          resumeClock,
+          requestClockActivation,
           seek,
           syncLayers,
         },
@@ -417,7 +473,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
     expect.objectContaining({ hasActiveClips: true })
   );
   expect(startClock).toHaveBeenCalledWith(fromSeconds(0), 1);
-  expect(resumeClock).toHaveBeenCalledWith(1);
+  expect(requestClockActivation).toHaveBeenCalledWith(1);
   expect(syncLayers).toHaveBeenCalledWith(
     expect.objectContaining({
       reason: 'play',
@@ -585,7 +641,7 @@ test('useTimelineMediaSync reports not-ready adapters without starting playback'
 test('useTimelineMediaSync awaits async clock startup failures', async () => {
   const engine = createMediaSyncEngine();
   const startClock = vi.fn(async () => false);
-  const resumeClock = vi.fn(async () => {});
+  const requestClockActivation = vi.fn();
   const onError = vi.fn();
 
   const { result } = renderHook(
@@ -597,7 +653,7 @@ test('useTimelineMediaSync awaits async clock startup failures', async () => {
         adapter: {
           getClockTime: () => 0,
           startClock,
-          resumeClock,
+          requestClockActivation,
         },
         onError,
       }),
@@ -614,7 +670,7 @@ test('useTimelineMediaSync awaits async clock startup failures', async () => {
     });
   });
 
-  expect(resumeClock).toHaveBeenCalledWith(1);
+  expect(requestClockActivation).toHaveBeenCalledWith(1);
   expect(startClock).toHaveBeenCalledWith(fromSeconds(1), 1);
   expect(engine.getState().playing).toBe(false);
   expect(onError).toHaveBeenCalledWith('Media clock could not start.');

--- a/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
@@ -2,6 +2,7 @@ import type {
   ActiveLayerResult,
   ActiveLayerSelector,
   MaybePromise,
+  PlaybackOptions,
 } from '@techsquidtv/canvas-timeline-core';
 import {
   fromSeconds,
@@ -80,12 +81,19 @@ export interface UseTimelineMediaPlaybackOptions<LayerName extends string = stri
   getClockTime: () => number;
   /** Optional sequence frame rate used to quantize playback updates to project frames. */
   frameRate?: TimecodeFrameRate;
+  /** Core playback range and looping policy applied to the external clock. */
+  playbackOptions?: Omit<PlaybackOptions, 'clock'>;
   /** Stops the external media clock when timeline playback pauses or leaves active content. */
   stopClock?: () => void;
   /** Named active layer selectors used by the external media surface. */
   layers: Record<LayerName, ActiveLayerSelector>;
   /** Synchronizes external rendering, audio, text, or effects for the active layers. */
   syncLayers?: (details: TimelineLayerSyncDetails<LayerName>) => MaybePromise<void>;
+  /** Realigns the external clock after core loops playback to a range start. */
+  onLoop?: (
+    timelineTime: RationalTime,
+    activeLayers: ActiveLayerResult<LayerName>
+  ) => MaybePromise<void>;
   /** Receives high-level playback status changes. */
   onStatus?: (status: TimelineContentPlaybackStatus) => void;
 }
@@ -204,6 +212,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
   const animationFrameRef = useRef<number | null>(null);
   const pausingRef = useRef(false);
   const playbackFrameCursorRef = useRef<PlaybackFrameCursor | null>(null);
+  const loopTransitionRef = useRef<object | null>(null);
 
   useEffect(() => {
     optionsRef.current = options;
@@ -263,6 +272,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
       pausingRef.current = true;
       cancelTick();
       playbackFrameCursorRef.current = null;
+      loopTransitionRef.current = null;
       try {
         const timelineTime = engine.getTime();
         const currentOptions = optionsRef.current;
@@ -290,8 +300,10 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
 
   const play = useCallback(() => {
     const currentOptions = optionsRef.current;
+    loopTransitionRef.current = null;
     const currentTime = engine.getTime();
-    const startTime = quantizeTimelineTimeToFrame(currentTime, currentOptions.frameRate);
+    const resolvedStartTime = engine.getPlaybackStartTime(currentOptions.playbackOptions);
+    const startTime = quantizeTimelineTimeToFrame(resolvedStartTime, currentOptions.frameRate);
     if (!rationalEquals(currentTime, startTime)) {
       engine.setTime(startTime);
     }
@@ -305,7 +317,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
       return timelineCommandFail('content-gap');
     }
 
-    const started = engine.play({ clock: 'external' });
+    const started = engine.play({ ...currentOptions.playbackOptions, clock: 'external' });
     if (!started) {
       return timelineCommandFail('unsupported');
     }
@@ -344,9 +356,33 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
         );
       }
 
-      engine.setTime(timelineTime);
-
-      const nextActiveLayers = synchronizeLayers(timelineTime, 'tick');
+      const update = engine.updateExternalPlaybackTime(timelineTime);
+      const nextActiveLayers = synchronizeLayers(update.time, 'tick');
+      if (update.action !== 'loop') {
+        loopTransitionRef.current = null;
+      } else if (loopTransitionRef.current === null) {
+        const transition = {};
+        loopTransitionRef.current = transition;
+        try {
+          const loopResult = currentOptions.onLoop?.(update.time, nextActiveLayers);
+          if (isPromiseLike(loopResult)) {
+            void Promise.resolve(loopResult).catch(() => {
+              if (loopTransitionRef.current === transition) {
+                pause('paused');
+              }
+            });
+          }
+        } catch {
+          if (loopTransitionRef.current === transition) {
+            pause('paused');
+          }
+          return;
+        }
+      }
+      if (update.action === 'pause') {
+        pause('paused');
+        return;
+      }
       if (!nextActiveLayers.hasActiveClips) {
         pause('content-gap');
         return;

--- a/packages/react/src/hooks/playback/useTimelineMediaSync.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaSync.ts
@@ -2,6 +2,7 @@ import type {
   ActiveLayerSelector,
   ActiveLayerResult,
   MaybePromise,
+  PlaybackOptions,
 } from '@techsquidtv/canvas-timeline-core';
 import { rationalEquals, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -35,8 +36,8 @@ export interface TimelineMediaSyncAdapter<LayerName extends string = string> {
   startClock: (timelineTime: RationalTime, playbackRate: number) => MaybePromise<boolean>;
   /** Stops the external media clock if timeline playback cannot start. */
   stopClock?: () => void;
-  /** Resumes browser-gated clocks, such as AudioContext, from a user gesture. */
-  resumeClock?: (playbackRate: number) => MaybePromise<void>;
+  /** Requests browser-gated clock activation without blocking visual transport. */
+  requestClockActivation?: (playbackRate: number) => void;
   /** Updates the external clock rate before timeline playback rate changes. */
   setClockRate?: (playbackRate: number) => void;
   /** Refreshes external media after paused playhead or timeline edits. */
@@ -68,6 +69,8 @@ export interface UseTimelineMediaSyncOptions<LayerName extends string = string> 
   ready?: boolean;
   /** Optional sequence frame rate used to lock media playback to project frames. */
   frameRate?: UseTimelineMediaPlaybackOptions<LayerName>['frameRate'];
+  /** Core playback range and looping policy applied to the external media clock. */
+  playbackOptions?: Omit<PlaybackOptions, 'clock'>;
   /** Named active layer selectors used by the external media surface. */
   layers: Record<LayerName, ActiveLayerSelector>;
   /** External media adapter callbacks. */
@@ -239,7 +242,7 @@ function createPlayFailure(
 export function useTimelineMediaSync<LayerName extends string = string>(
   options: UseTimelineMediaSyncOptions<LayerName>
 ): UseTimelineMediaSyncResult<LayerName> {
-  const { adapter, frameRate, layers, onError, ready = true } = options;
+  const { adapter, frameRate, layers, onError, playbackOptions, ready = true } = options;
   const adapterSeek = adapter.seek;
   const { engine } = useTimeline();
   const activeLayers = useActiveLayers<LayerName>({ layers });
@@ -252,11 +255,18 @@ export function useTimelineMediaSync<LayerName extends string = string>(
 
   const syncPlayback = useTimelineMediaPlayback<LayerName>({
     frameRate,
+    playbackOptions,
     getClockTime: adapter.getClockTime,
     stopClock: adapter.stopClock,
     layers,
     syncLayers: adapter.syncLayers,
     onStatus: adapter.onStatus,
+    onLoop: async (timelineTime, loopLayers) => {
+      await adapter.seek?.(timelineTime, loopLayers);
+      if (!(await adapter.startClock(timelineTime, engine.getPlaybackRate()))) {
+        throw new Error('Media clock could not restart after looping.');
+      }
+    },
   });
   const playingRef = useRef(syncPlayback.playing);
 
@@ -346,7 +356,8 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     const currentTime = engine.getTime();
-    let timelineTime = quantizeTimelineTimeToFrame(currentTime, frameRate);
+    const resolvedStartTime = engine.getPlaybackStartTime(playbackOptions);
+    let timelineTime = quantizeTimelineTimeToFrame(resolvedStartTime, frameRate);
     if (!rationalEquals(currentTime, timelineTime)) {
       engine.setTime(timelineTime);
     }
@@ -378,7 +389,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     try {
-      await adapter.resumeClock?.(syncPlayback.playbackRate);
+      adapter.requestClockActivation?.(syncPlayback.playbackRate);
       await adapter.seek?.(timelineTime, timelineLayers);
       if (!(await adapter.startClock(timelineTime, syncPlayback.playbackRate))) {
         adapter.stopClock?.();
@@ -413,7 +424,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     return { ok: true, time: timelineTime };
-  }, [adapter, engine, frameRate, layers, onError, ready, syncPlayback]);
+  }, [adapter, engine, frameRate, layers, onError, playbackOptions, ready, syncPlayback]);
 
   const setPlaybackRate = useCallback(
     (playbackRate: number) => {


### PR DESCRIPTION
## Summary\n\n- centralize internal and external playback boundary evaluation\n- enforce in/out points and looping for external media clocks\n- replace blocking clock resumption with non-blocking activation requests\n\n## Release Impact\n\n- Packages/API: core and React media synchronization\n- Docs/demos: none in this PR\n- Breaking changes: removes the blocking resumeClock adapter contract without an alias\n- Release risk: external-clock transport behavior\n\n## Stack\n\n1 of 5. Base: main.\n\n## Validation\n\n- vp run ci\n- full stack: 37/37 tasks, 53 test files, 524 tests