### PR TITLE
feat(html-media)!: add source representations

### DIFF
--- a/.changeset/external-clock-ranges.md
+++ b/.changeset/external-clock-ranges.md
@@ -1,0 +1,6 @@
+---
+'@techsquidtv/canvas-timeline-core': minor
+'@techsquidtv/canvas-timeline-react': minor
+---
+
+Enforce playback in/out points consistently for internal and external clocks, and replace blocking clock resumption with non-blocking activation requests.

--- a/.changeset/html-source-variants.md
+++ b/.changeset/html-source-variants.md
@@ -1,0 +1,5 @@
+---
+'@techsquidtv/canvas-timeline-html-media-adapter': minor
+---
+
+Redesign HTML media sources around a concise original input, per-representation fallbacks, selectable editing proxies, timestamp mapping, runtime retry and replacement, and volume and mute controls.

--- a/apps/www/src/demos/html-media-sync/HTMLMediaTimelineSync.tsx
+++ b/apps/www/src/demos/html-media-sync/HTMLMediaTimelineSync.tsx
@@ -69,9 +69,12 @@ function HTMLMediaSyncSurface({ metrics }: { metrics?: DemoMetrics }) {
 
   // Adapter setup
   const sources = useMemo(
-    () => ({
-      [sampleSourceId]: sampleMediaUrl,
-    }),
+    () => [
+      {
+        sourceId: sampleSourceId,
+        input: sampleMediaUrl,
+      },
+    ],
     []
   );
   const { playing, playbackRate, play, pause, setPlaybackRate, ready } = useHTMLTimelineMedia({

--- a/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
+++ b/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
@@ -221,9 +221,12 @@ function KeyframeOpacitySurface({ metrics }: { metrics?: DemoMetrics }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const sources = useMemo(
-    () => ({
-      [sampleSourceId]: sampleMediaUrl,
-    }),
+    () => [
+      {
+        sourceId: sampleSourceId,
+        input: sampleMediaUrl,
+      },
+    ],
     []
   );
   const keyframes = useTimelineKeyframes({

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -576,6 +576,36 @@ describe('TimelineEngine', () => {
 
       rafSpy.mockRestore();
     });
+
+    it('applies in/out boundaries to externally clocked playback', () => {
+      engine.setInPoint(fromSeconds(2), false);
+      engine.setOutPoint(fromSeconds(4), false);
+      engine.setTime(fromSeconds(3));
+
+      expect(engine.play({ clock: 'external', respectInOut: true })).toBe(true);
+      expect(engine.updateExternalPlaybackTime(fromSeconds(4.5))).toMatchObject({
+        action: 'pause',
+        reason: 'in-out',
+      });
+      expect(toSeconds(engine.getTime())).toBe(4);
+      expect(engine.getState().playing).toBe(false);
+    });
+
+    it('loops external playback and resets playback started at the out point', () => {
+      engine.setInPoint(fromSeconds(2), false);
+      engine.setOutPoint(fromSeconds(4), false);
+      engine.setTime(fromSeconds(4));
+
+      expect(engine.getPlaybackStartTime({ respectInOut: true })).toEqual(fromSeconds(2));
+      expect(engine.play({ clock: 'external', respectInOut: true, loop: true })).toBe(true);
+      expect(toSeconds(engine.getTime())).toBe(2);
+      expect(engine.updateExternalPlaybackTime(fromSeconds(4.25))).toMatchObject({
+        action: 'loop',
+        reason: 'in-out',
+      });
+      expect(toSeconds(engine.getTime())).toBe(2);
+      expect(engine.getState().playing).toBe(true);
+    });
   });
 
   describe('Snapping', () => {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -3,6 +3,7 @@ import type {
   TimelineClipDropFeedback,
   Marker,
   PlaybackOptions,
+  ExternalPlaybackUpdate,
   TimelineClipMoveOptions,
   TimelineClipMoveResult,
   TimelineSnapFeedback,
@@ -705,7 +706,25 @@ export class TimelineEngine extends TimelineEngineState {
    * Plays the timeline.
    */
   play(options: PlaybackOptions = {}): boolean {
+    if (this.state.playing) {
+      return false;
+    }
+    const startTime = this.playbackManager.prepareStart(options);
+    if (compareRational(startTime, this.state.playheadTime) !== 0) {
+      this.updatePlayhead(startTime);
+    }
     return this.playbackManager.play(options);
+  }
+
+  /** Resolves playback start time from a reached Out point to the In point (or zero) when enabled. */
+  getPlaybackStartTime(options: PlaybackOptions = {}): RationalTime {
+    return this.playbackManager.prepareStart(options);
+  }
+
+  /** Advances externally clocked playback through the shared range policy. */
+  updateExternalPlaybackTime(time: RationalTime): ExternalPlaybackUpdate {
+    assertValidRationalTime(time, 'time');
+    return this.playbackManager.updateExternalTime(time);
   }
 
   /**

--- a/packages/core/src/playback.ts
+++ b/packages/core/src/playback.ts
@@ -1,5 +1,5 @@
 import type { TimelineEngine } from '#core/engine';
-import type { PlaybackClockSource, PlaybackOptions } from '#core/types';
+import type { ExternalPlaybackUpdate, PlaybackClockSource, PlaybackOptions } from '#core/types';
 import {
   addRational,
   compareRational,
@@ -14,6 +14,8 @@ export class PlaybackManager {
   private playbackClockSource: PlaybackClockSource = 'internal';
   private playbackTargetTime: RationalTime | undefined;
   private playbackAutoEnd = false;
+  private respectInOut = true;
+  private loopRange = false;
 
   constructor(engine: TimelineEngine) {
     this.engine = engine;
@@ -29,10 +31,9 @@ export class PlaybackManager {
     this.playbackAutoEnd = options.autoEnd ?? options.toTime !== undefined;
     this.playbackTargetTime =
       options.toTime ?? (options.autoEnd ? this.engine.maxContentTime : undefined);
+    this.respectInOut = options.respectInOut ?? true;
+    this.loopRange = options.loop ?? false;
     state.playing = true;
-
-    const respectInOut = options.respectInOut ?? true;
-    const loopRange = options.loop ?? false;
 
     if (this.playbackClockSource === 'external') {
       if (this.playbackInterval !== null) {
@@ -55,50 +56,10 @@ export class PlaybackManager {
 
       const deltaSec = (deltaMs / 1000) * (currentState.playbackRate ?? 1.0);
       const deltaRt = fromSeconds(deltaSec, currentState.playheadTime.r);
-      let nextTime = addRational(currentState.playheadTime, deltaRt);
-
-      // 1. Check respectInOut boundaries (In/Out points)
-      if (respectInOut) {
-        const inLimit = currentState.inPoint ?? fromSeconds(0, currentState.playheadTime.r);
-        const outLimit = currentState.outPoint;
-
-        if (outLimit !== undefined && compareRational(nextTime, outLimit) >= 0) {
-          if (loopRange) {
-            nextTime = inLimit;
-          } else {
-            this.engine.updatePlayhead(outLimit);
-            this.pause();
-            return;
-          }
-        }
-      }
-
-      // 2. Check total duration boundaries
-      if (
-        currentState.duration !== undefined &&
-        compareRational(nextTime, currentState.duration) >= 0
-      ) {
-        if (loopRange) {
-          nextTime = currentState.inPoint ?? fromSeconds(0, currentState.playheadTime.r);
-        } else {
-          this.engine.updatePlayhead(currentState.duration);
-          this.pause();
-          return;
-        }
-      }
-
-      // 3. Check target time (from options)
-      if (
-        this.playbackTargetTime !== undefined &&
-        compareRational(nextTime, this.playbackTargetTime) >= 0
-      ) {
-        this.engine.updatePlayhead(this.playbackTargetTime);
-        if (this.playbackAutoEnd) {
-          this.pause();
-          return;
-        }
-      } else {
-        this.engine.updatePlayhead(nextTime);
+      const nextTime = addRational(currentState.playheadTime, deltaRt);
+      const update = this.advanceTo(nextTime);
+      if (update.action === 'pause') {
+        return;
       }
 
       this.playbackInterval = requestAnimationFrame(loop);
@@ -107,6 +68,71 @@ export class PlaybackManager {
     this.playbackInterval = requestAnimationFrame(loop);
     this.engine.emit('playback:state', true);
     return true;
+  }
+
+  prepareStart(options: PlaybackOptions = {}): RationalTime {
+    const state = this.engine.getState();
+    if ((options.respectInOut ?? true) && state.outPoint !== undefined) {
+      if (compareRational(state.playheadTime, state.outPoint) >= 0) {
+        return state.inPoint ?? fromSeconds(0, state.playheadTime.r);
+      }
+    }
+    return state.playheadTime;
+  }
+
+  updateExternalTime(time: RationalTime): ExternalPlaybackUpdate {
+    if (this.playbackClockSource !== 'external' || !this.engine.getState().playing) {
+      this.engine.updatePlayhead(time);
+      return { time: this.engine.getTime(), action: 'continue' };
+    }
+    return this.advanceTo(time);
+  }
+
+  private advanceTo(nextTime: RationalTime): ExternalPlaybackUpdate {
+    const state = this.engine.getState();
+    const inLimit = state.inPoint ?? fromSeconds(0, nextTime.r);
+
+    if (
+      this.respectInOut &&
+      state.outPoint !== undefined &&
+      compareRational(nextTime, state.outPoint) >= 0
+    ) {
+      if (this.loopRange) {
+        this.engine.updatePlayhead(inLimit);
+        return { time: this.engine.getTime(), action: 'loop', reason: 'in-out' };
+      }
+      this.engine.updatePlayhead(state.outPoint);
+      const time = this.engine.getTime();
+      this.pause();
+      return { time, action: 'pause', reason: 'in-out' };
+    }
+
+    if (state.duration !== undefined && compareRational(nextTime, state.duration) >= 0) {
+      if (this.loopRange) {
+        this.engine.updatePlayhead(inLimit);
+        return { time: this.engine.getTime(), action: 'loop', reason: 'duration' };
+      }
+      this.engine.updatePlayhead(state.duration);
+      const time = this.engine.getTime();
+      this.pause();
+      return { time, action: 'pause', reason: 'duration' };
+    }
+
+    if (
+      this.playbackTargetTime !== undefined &&
+      compareRational(nextTime, this.playbackTargetTime) >= 0
+    ) {
+      this.engine.updatePlayhead(this.playbackTargetTime);
+      const time = this.engine.getTime();
+      if (this.playbackAutoEnd) {
+        this.pause();
+        return { time, action: 'pause', reason: 'target' };
+      }
+      return { time, action: 'continue' };
+    }
+
+    this.engine.updatePlayhead(nextTime);
+    return { time: this.engine.getTime(), action: 'continue' };
   }
 
   pause() {
@@ -122,6 +148,8 @@ export class PlaybackManager {
     this.playbackClockSource = 'internal';
     this.playbackTargetTime = undefined;
     this.playbackAutoEnd = false;
+    this.respectInOut = true;
+    this.loopRange = false;
     this.engine.emit('playback:state', false);
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,16 @@ export interface PlaybackOptions {
   respectInOut?: boolean;
 }
 
+/** Result of advancing playback from an externally owned media clock. */
+export interface ExternalPlaybackUpdate {
+  /** Effective timeline time after boundary handling. */
+  time: RationalTime;
+  /** Whether playback continues, loops, or pauses at a boundary. */
+  action: 'continue' | 'loop' | 'pause';
+  /** Boundary responsible for a loop or pause. */
+  reason?: 'in-out' | 'duration' | 'target';
+}
+
 /**
  * Source-media interval covered by a timeline clip.
  */

--- a/packages/html-media-adapter/src/index.test.ts
+++ b/packages/html-media-adapter/src/index.test.ts
@@ -10,6 +10,15 @@ import {
   useHTMLTimelineMedia,
 } from '#html-media-adapter/index';
 
+function htmlSources(source: string | Blob | File = '/sample.mp4') {
+  return [
+    {
+      sourceId: 'source-1',
+      input: source,
+    },
+  ] as const;
+}
+
 function createMediaSyncEngine() {
   return new TimelineEngine({
     duration: fromSeconds(12),
@@ -62,9 +71,7 @@ test('createHTMLMediaAdapter maps active clip source time to a media element', a
   const pause = vi.spyOn(element, 'pause').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': '/sample.mp4',
-    },
+    sources: htmlSources(),
   });
   const activeVideo = engine.getActiveClip({
     time: fromSeconds(1.25),
@@ -109,9 +116,7 @@ test('createHTMLMediaAdapter normalizes relative sources without reassigning mat
   });
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': 'sample.mp4',
-    },
+    sources: htmlSources('sample.mp4'),
   });
   const activeLayers = engine.getActiveLayers({
     time: fromSeconds(1),
@@ -135,9 +140,7 @@ test('createHTMLMediaAdapter disposes object URLs for blob sources', async () =>
   const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': new Blob(['sample']),
-    },
+    sources: htmlSources(new Blob(['sample'])),
   });
 
   await adapter.seek?.(
@@ -165,9 +168,7 @@ test('createHTMLMediaAdapter switches rates and stops playback', async () => {
   const pause = vi.spyOn(element, 'pause').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': '/sample.mp4',
-    },
+    sources: htmlSources(),
   });
 
   await adapter.seek?.(
@@ -194,9 +195,7 @@ test('createHTMLMediaAdapter reports rejected native playback', async () => {
   vi.spyOn(element, 'pause').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': '/sample.mp4',
-    },
+    sources: htmlSources(),
   });
 
   await adapter.seek?.(
@@ -219,7 +218,7 @@ test('createHTMLMediaAdapter clears the element for missing sources and content 
   const load = vi.spyOn(element, 'load').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {},
+    sources: [],
   });
 
   element.src = 'http://localhost:3000/previous.mp4';
@@ -261,9 +260,7 @@ test('createHTMLMediaAdapter replays synced clips only while play intent is acti
   vi.spyOn(element, 'pause').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': '/sample.mp4',
-    },
+    sources: htmlSources(),
   });
   const activeLayers = engine.getActiveLayers({
     time: fromSeconds(1),
@@ -301,9 +298,7 @@ test('createHTMLMediaAdapter pauses and clears play intent on non-playing status
   const pause = vi.spyOn(element, 'pause').mockImplementation(() => {});
   const adapter = createHTMLMediaAdapter({
     element,
-    sources: {
-      'source-1': '/sample.mp4',
-    },
+    sources: htmlSources(),
   });
   const activeLayers = engine.getActiveLayers({
     time: fromSeconds(1),
@@ -330,9 +325,7 @@ test('useHTMLMediaAdapter exposes a noop until the ref connects and disposes on 
   const initial = renderHook(() =>
     useHTMLMediaAdapter({
       ref,
-      sources: {
-        'source-1': '/sample.mp4',
-      },
+      sources: htmlSources(),
     })
   );
 
@@ -346,9 +339,7 @@ test('useHTMLMediaAdapter exposes a noop until the ref connects and disposes on 
   const connected = renderHook(() =>
     useHTMLMediaAdapter({
       ref,
-      sources: {
-        'source-1': '/sample.mp4',
-      },
+      sources: htmlSources(),
     })
   );
 
@@ -375,9 +366,7 @@ test('useHTMLTimelineMedia creates an adapter and exposes synchronized transport
     () =>
       useHTMLTimelineMedia({
         ref,
-        sources: {
-          'source-1': '/sample.mp4',
-        },
+        sources: htmlSources(),
         layers,
       }),
     {
@@ -406,4 +395,137 @@ test('useHTMLTimelineMedia creates an adapter and exposes synchronized transport
     expect(result.current.pause()).toEqual({ ok: true });
   });
   expect(pause).toHaveBeenCalled();
+});
+
+test('createHTMLMediaAdapter advances input fallbacks and exposes media controls', async () => {
+  const engine = createMediaSyncEngine();
+  const element = document.createElement('video');
+  vi.spyOn(element, 'pause').mockImplementation(() => {});
+  vi.spyOn(element, 'play').mockResolvedValue(undefined);
+  const adapter = createHTMLMediaAdapter({
+    element,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: '/primary.mp4',
+        fallbacks: ['/fallback.mp4'],
+      },
+    ],
+  });
+  const activeLayers = engine.getActiveLayers({
+    time: fromSeconds(1),
+    layers: { visuals: { trackKind: 'visual', sourceId: 'source-1' } },
+  });
+
+  await adapter.seek?.(fromSeconds(1), activeLayers);
+  expect(adapter.sourceStateById.get('source-1')?.selectedInputIndex).toBe(0);
+  element.dispatchEvent(new Event('error'));
+  expect(element.src).toBe('http://localhost:3000/fallback.mp4');
+  expect(adapter.sourceStateById.get('source-1')?.selectedInputIndex).toBe(1);
+
+  adapter.setVolume(0.4);
+  adapter.setMuted(true);
+  expect(adapter.volume).toBe(0.4);
+  expect(adapter.muted).toBe(true);
+});
+
+test('createHTMLMediaAdapter retries failed sources from their preferred input', async () => {
+  const engine = createMediaSyncEngine();
+  const element = document.createElement('video');
+  vi.spyOn(element, 'pause').mockImplementation(() => {});
+  const adapter = createHTMLMediaAdapter({
+    element,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: '/primary.mp4',
+        fallbacks: ['/fallback.mp4'],
+      },
+    ],
+  });
+  const activeLayers = engine.getActiveLayers({
+    time: fromSeconds(1),
+    layers: { visuals: { trackKind: 'visual', sourceId: 'source-1' } },
+  });
+
+  await adapter.seek?.(fromSeconds(1), activeLayers);
+  element.dispatchEvent(new Event('error'));
+  element.dispatchEvent(new Event('error'));
+
+  expect(adapter.sourceStateById.get('source-1')?.status).toBe('failed');
+  expect(adapter.retrySource('missing-source')).toBe(false);
+  expect(adapter.retrySource('source-1')).toBe(true);
+  expect(element.src).toBe('http://localhost:3000/primary.mp4');
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    status: 'ready',
+    selectedInputIndex: 0,
+  });
+});
+
+test('createHTMLMediaAdapter invalidates blob URLs when replacing a source', async () => {
+  const engine = createMediaSyncEngine();
+  const element = document.createElement('video');
+  vi.spyOn(element, 'pause').mockImplementation(() => {});
+  const createObjectURL = vi
+    .spyOn(URL, 'createObjectURL')
+    .mockReturnValueOnce('blob:first')
+    .mockReturnValueOnce('blob:second');
+  const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  const adapter = createHTMLMediaAdapter({
+    element,
+    sources: htmlSources(new Blob(['first'])),
+  });
+  const activeLayers = engine.getActiveLayers({
+    time: fromSeconds(1),
+    layers: { visuals: { trackKind: 'visual', sourceId: 'source-1' } },
+  });
+
+  await adapter.seek?.(fromSeconds(1), activeLayers);
+  expect(element.src).toBe('blob:first');
+
+  expect(adapter.replaceSource({ sourceId: 'source-1', input: new Blob(['second']) })).toBe(true);
+
+  expect(revokeObjectURL).toHaveBeenCalledWith('blob:first');
+  expect(createObjectURL).toHaveBeenCalledTimes(2);
+  expect(element.src).toBe('blob:second');
+
+  adapter.dispose();
+  expect(revokeObjectURL).toHaveBeenCalledWith('blob:second');
+});
+
+test('createHTMLMediaAdapter selects proxies independently from input fallback', async () => {
+  const engine = createMediaSyncEngine();
+  const element = document.createElement('video');
+  vi.spyOn(element, 'pause').mockImplementation(() => {});
+  const adapter = createHTMLMediaAdapter({
+    element,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: '/original.mp4',
+        proxies: [
+          {
+            proxyId: 'edit-540p',
+            input: '/proxy.mp4',
+            timing: { sourceTimeSeconds: 10, mediaTimeSeconds: 0 },
+          },
+        ],
+      },
+    ],
+  });
+  const activeLayers = engine.getActiveLayers({
+    time: fromSeconds(1),
+    layers: { visuals: { trackKind: 'visual', sourceId: 'source-1' } },
+  });
+
+  expect(adapter.setRepresentation('source-1', { kind: 'proxy', proxyId: 'edit-540p' })).toBe(true);
+  await adapter.seek?.(fromSeconds(1), activeLayers);
+
+  expect(element.src).toBe('http://localhost:3000/proxy.mp4');
+  expect(element.currentTime).toBe(1);
+  expect(adapter.getClockTime()).toBe(1);
+  expect(adapter.sourceStateById.get('source-1')?.selectedRepresentation).toEqual({
+    kind: 'proxy',
+    proxyId: 'edit-540p',
+  });
 });

--- a/packages/html-media-adapter/src/index.ts
+++ b/packages/html-media-adapter/src/index.ts
@@ -1,6 +1,6 @@
 import type { ActiveClip } from '@techsquidtv/canvas-timeline-core';
 import { toSeconds, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
-import { useEffect, useMemo, useState, type RefObject } from 'react';
+import { useEffect, useMemo, useReducer, useState, type RefObject } from 'react';
 import {
   useTimelineMediaSync,
   type TimelineMediaSyncAdapter,
@@ -12,6 +12,59 @@ import {
  * Source value that can be loaded into a native HTML media element.
  */
 export type HTMLMediaAdapterSource = string | Blob | File;
+
+/** Maps a logical source timestamp to the corresponding representation timestamp. */
+export interface HTMLMediaRepresentationTiming {
+  /** Timestamp in the logical source time domain. */
+  sourceTimeSeconds: number;
+  /** Equivalent timestamp in this representation's media time domain. */
+  mediaTimeSeconds: number;
+}
+
+/** A deliberately selectable editing proxy for one logical source. */
+export interface HTMLMediaProxy {
+  /** Stable proxy identifier used for selection and diagnostics. */
+  proxyId: string;
+  /** Preferred URL, blob, or file for this proxy. */
+  input: HTMLMediaAdapterSource;
+  /** Inputs attempted only when this proxy's preferred input fails. */
+  fallbacks?: readonly HTMLMediaAdapterSource[];
+  /** Optional mapping when proxy timestamps differ from logical source timestamps. */
+  timing?: HTMLMediaRepresentationTiming;
+}
+
+/** Original or proxy representation selected for a logical source. */
+export type HTMLMediaRepresentationSelection =
+  | { kind: 'original' }
+  | { kind: 'proxy'; proxyId: string };
+
+/** One logical timeline source with an original input and optional editing proxies. */
+export interface HTMLMediaSource {
+  /** Identifier matching timeline clip `sourceId` values. */
+  sourceId: string;
+  /** Preferred URL, blob, or file for the original representation. */
+  input: HTMLMediaAdapterSource;
+  /** Inputs attempted only when the original input fails. */
+  fallbacks?: readonly HTMLMediaAdapterSource[];
+  /** Deliberately selectable editing representations. */
+  proxies?: readonly HTMLMediaProxy[];
+  /** Optional mapping when original media timestamps differ from logical source timestamps. */
+  timing?: HTMLMediaRepresentationTiming;
+}
+
+/** Observable representation and input state for one HTML media source. */
+export interface HTMLMediaSourceState {
+  /** Logical source identifier. */
+  sourceId: string;
+  /** Current native source loading state. */
+  status: 'idle' | 'ready' | 'failed';
+  /** Original or proxy representation currently selected for this source. */
+  selectedRepresentation: HTMLMediaRepresentationSelection;
+  /** Selected preferred/fallback input index, or `null` after all inputs fail. */
+  selectedInputIndex: number | null;
+  /** Terminal source error when loading fails. */
+  error: Error | null;
+}
 
 /**
  * Timeline media sync adapter backed by one HTMLMediaElement.
@@ -28,6 +81,17 @@ export type HTMLMediaAdapterSource = string | Blob | File;
  * @see {@link useHTMLTimelineMedia}
  */
 export interface HTMLMediaAdapter extends TimelineMediaSyncAdapter {
+  readonly sourceStateById: ReadonlyMap<string, HTMLMediaSourceState>;
+  readonly volume: number;
+  readonly muted: boolean;
+  setVolume: (volume: number) => void;
+  setMuted: (muted: boolean) => void;
+  setRepresentation: (
+    sourceId: string,
+    representation: HTMLMediaRepresentationSelection
+  ) => boolean;
+  retrySource: (sourceId: string) => boolean;
+  replaceSource: (source: HTMLMediaSource) => boolean;
   /** Release object URLs and pause the media element. */
   dispose: () => void;
 }
@@ -37,15 +101,18 @@ export interface HTMLMediaAdapter extends TimelineMediaSyncAdapter {
  *
  * @remarks
  *
- * Sources are keyed by timeline clip `sourceId`. Values can be URLs, `Blob`s,
- * or `File`s, which makes this useful for both persisted project media and
- * user-selected local files.
+ * Logical sources match timeline clip `sourceId` values. Each source has one
+ * original input, optional per-representation fallbacks, and optional proxies.
  */
 export interface CreateHTMLMediaAdapterOptions {
   /** Native video or audio element to synchronize with the timeline. */
   element: HTMLMediaElement;
-  /** Media sources keyed by timeline clip `sourceId`. */
-  sources: Record<string, HTMLMediaAdapterSource>;
+  /** Logical media sources, original inputs, and optional proxies. */
+  sources: readonly HTMLMediaSource[];
+  /** Select the initial representation for each source. Defaults to original. */
+  selectRepresentation?: (source: HTMLMediaSource) => HTMLMediaRepresentationSelection;
+  /** Called when selected source state or runtime controls change. */
+  onChange?: () => void;
 }
 
 /**
@@ -59,8 +126,10 @@ export interface UseHTMLMediaAdapterOptions<
 > {
   /** Ref containing the media element once React has mounted it. */
   ref: RefObject<TMediaElement | null>;
-  /** Media sources keyed by timeline clip `sourceId`. */
-  sources: Record<string, HTMLMediaAdapterSource>;
+  /** Logical media sources, original inputs, and optional proxies. */
+  sources: readonly HTMLMediaSource[];
+  /** Select the initial representation for each source. Defaults to original. */
+  selectRepresentation?: CreateHTMLMediaAdapterOptions['selectRepresentation'];
 }
 
 /**
@@ -95,7 +164,7 @@ export interface UseHTMLTimelineMediaOptions<
 >
   extends
     UseHTMLMediaAdapterOptions<TMediaElement>,
-    Pick<UseTimelineMediaSyncOptions<LayerName>, 'layers' | 'onError'> {}
+    Pick<UseTimelineMediaSyncOptions<LayerName>, 'layers' | 'onError' | 'playbackOptions'> {}
 
 /**
  * Timeline transport state plus the underlying native media adapter.
@@ -108,13 +177,23 @@ export interface UseHTMLTimelineMediaResult<
 > extends UseTimelineMediaSyncResult<LayerName> {
   /** Whether the media element ref has been connected. */
   ready: boolean;
+  /** Selected representation and input load state by source id. */
+  sourceStateById: HTMLMediaAdapter['sourceStateById'];
   /** Low-level adapter used for custom synchronization flows. */
   adapter: HTMLMediaAdapter;
 }
 
 const noopAdapter: HTMLMediaAdapter = {
+  sourceStateById: new Map(),
+  volume: 1,
+  muted: false,
   getClockTime: () => 0,
   startClock: () => false,
+  setVolume: () => {},
+  setMuted: () => {},
+  setRepresentation: () => false,
+  retrySource: () => false,
+  replaceSource: () => false,
   dispose: () => {},
 };
 
@@ -140,9 +219,10 @@ const noopAdapter: HTMLMediaAdapter = {
  * if (video) {
  *   const adapter = createHTMLMediaAdapter({
  *     element: video,
- *     sources: {
- *       'source-1': '/media/interview.mp4',
- *     },
+ *     sources: [{
+ *       sourceId: 'source-1',
+ *       input: '/media/interview.mp4',
+ *     }],
  *   });
  *
  *   await adapter.seek?.(engine.getTime(), engine.getActiveLayers({
@@ -158,12 +238,36 @@ const noopAdapter: HTMLMediaAdapter = {
  */
 export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): HTMLMediaAdapter {
   const { element, sources } = options;
-  const objectUrls = new Map<string, string>();
+  validateHTMLMediaSources(sources);
+  const sourceDefinitions = new Map(sources.map((source) => [source.sourceId, source]));
+  const sourceStateById = new Map<string, HTMLMediaSourceState>();
+  const selectedRepresentationBySourceId = new Map<string, HTMLMediaRepresentationSelection>();
+  const selectedInputIndexBySourceId = new Map<string, number>();
+  const objectUrlsBySourceId = new Map<string, Map<string, string>>();
   let activeClip: ActiveClip | undefined;
   let timelineTimeAtStart = 0;
   let playbackRate = 1;
   let shouldPlay = false;
   let lastError: Error | null = null;
+  const notify = () => options.onChange?.();
+
+  const revokeSourceObjectUrls = (sourceId: string) => {
+    const sourceObjectUrls = objectUrlsBySourceId.get(sourceId);
+    if (sourceObjectUrls === undefined) {
+      return;
+    }
+
+    for (const url of sourceObjectUrls.values()) {
+      URL.revokeObjectURL(url);
+    }
+    objectUrlsBySourceId.delete(sourceId);
+  };
+
+  for (const source of sources) {
+    const selection = options.selectRepresentation?.(source) ?? { kind: 'original' };
+    assertHTMLMediaRepresentation(source, selection);
+    selectedRepresentationBySourceId.set(source.sourceId, selection);
+  }
 
   const clearElement = () => {
     activeClip = undefined;
@@ -172,23 +276,62 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     element.load();
   };
 
-  const getSourceUrl = (sourceId: string) => {
-    const source = sources[sourceId];
+  const getRepresentation = (sourceId: string) => {
+    const source = sourceDefinitions.get(sourceId);
     if (source === undefined) {
       return undefined;
     }
 
-    if (typeof source === 'string') {
-      return new URL(source, element.ownerDocument.baseURI).href;
+    const selection = selectedRepresentationBySourceId.get(sourceId) ?? { kind: 'original' };
+    if (selection.kind === 'original') {
+      return {
+        selection,
+        inputs: [source.input, ...(source.fallbacks ?? [])],
+        timing: source.timing,
+      };
     }
 
-    const existingUrl = objectUrls.get(sourceId);
+    const proxy = source.proxies?.find((candidate) => candidate.proxyId === selection.proxyId);
+    if (proxy === undefined) {
+      return undefined;
+    }
+
+    return {
+      selection,
+      inputs: [proxy.input, ...(proxy.fallbacks ?? [])],
+      timing: proxy.timing,
+    };
+  };
+
+  const getSourceUrl = (sourceId: string) => {
+    const representation = getRepresentation(sourceId);
+    const inputIndex = selectedInputIndexBySourceId.get(sourceId) ?? 0;
+    const input = representation?.inputs[inputIndex];
+    if (representation === undefined || input === undefined) {
+      return undefined;
+    }
+
+    if (typeof input === 'string') {
+      return new URL(input, element.ownerDocument.baseURI).href;
+    }
+
+    const representationKey =
+      representation.selection.kind === 'original'
+        ? 'original'
+        : `proxy:${representation.selection.proxyId}`;
+    const objectUrlKey = `${representationKey}:${inputIndex}`;
+    const sourceObjectUrls = objectUrlsBySourceId.get(sourceId);
+    const existingUrl = sourceObjectUrls?.get(objectUrlKey);
     if (existingUrl !== undefined) {
       return existingUrl;
     }
 
-    const url = URL.createObjectURL(source);
-    objectUrls.set(sourceId, url);
+    const url = URL.createObjectURL(input);
+    if (sourceObjectUrls === undefined) {
+      objectUrlsBySourceId.set(sourceId, new Map([[objectUrlKey, url]]));
+    } else {
+      sourceObjectUrls.set(objectUrlKey, url);
+    }
     return url;
   };
 
@@ -201,6 +344,18 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     }
 
     lastError = null;
+    const representation = getRepresentation(clip.clip.sourceId);
+    const inputIndex = selectedInputIndexBySourceId.get(clip.clip.sourceId) ?? 0;
+    if (representation !== undefined) {
+      sourceStateById.set(clip.clip.sourceId, {
+        sourceId: clip.clip.sourceId,
+        status: 'ready',
+        selectedRepresentation: representation.selection,
+        selectedInputIndex: inputIndex,
+        error: null,
+      });
+      notify();
+    }
     activeClip = clip;
     timelineTimeAtStart = toSeconds(timelineTime);
     element.playbackRate = playbackRate;
@@ -209,7 +364,10 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
       element.src = nextUrl;
     }
 
-    const nextCurrentTime = toSeconds(clip.sourceTime);
+    const timing = representation?.timing;
+    const nextCurrentTime =
+      toSeconds(clip.sourceTime) +
+      (timing === undefined ? 0 : timing.mediaTimeSeconds - timing.sourceTimeSeconds);
     if (Math.abs(element.currentTime - nextCurrentTime) > 0.03) {
       element.currentTime = nextCurrentTime;
     }
@@ -235,14 +393,63 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     }
   };
 
+  const handleElementError = () => {
+    if (activeClip === undefined) {
+      return;
+    }
+    const sourceId = activeClip.clip.sourceId;
+    const representation = getRepresentation(sourceId);
+    const nextIndex = (selectedInputIndexBySourceId.get(sourceId) ?? 0) + 1;
+    if (representation?.inputs[nextIndex] === undefined) {
+      const sourceError = new Error(
+        `All HTML media inputs failed for the selected representation of source "${sourceId}".`
+      );
+      lastError = sourceError;
+      sourceStateById.set(sourceId, {
+        sourceId,
+        status: 'failed',
+        selectedRepresentation: selectedRepresentationBySourceId.get(sourceId) ?? {
+          kind: 'original',
+        },
+        selectedInputIndex: null,
+        error: sourceError,
+      });
+      notify();
+      shouldPlay = false;
+      element.pause();
+      return;
+    }
+    selectedInputIndexBySourceId.set(sourceId, nextIndex);
+    const clip = activeClip;
+    loadClip(clip, { v: timelineTimeAtStart, r: 1 });
+    if (shouldPlay) {
+      void playElement().catch(() => undefined);
+    }
+  };
+  element.addEventListener('error', handleElementError);
+
   return {
+    get sourceStateById() {
+      return sourceStateById;
+    },
+    get volume() {
+      return element.volume;
+    },
+    get muted() {
+      return element.muted;
+    },
     getClockTime: () => {
       if (activeClip === undefined) {
         return timelineTimeAtStart;
       }
 
+      const representation = getRepresentation(activeClip.clip.sourceId);
+      const timing = representation?.timing;
+      const logicalSourceTime =
+        element.currentTime -
+        (timing === undefined ? 0 : timing.mediaTimeSeconds - timing.sourceTimeSeconds);
       return (
-        element.currentTime +
+        logicalSourceTime +
         toSeconds(activeClip.clip.timelineStart) -
         toSeconds(activeClip.clip.sourceStart)
       );
@@ -262,6 +469,60 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     setClockRate: (rate) => {
       playbackRate = rate;
       element.playbackRate = rate;
+    },
+    setVolume: (volume) => {
+      if (!Number.isFinite(volume) || volume < 0 || volume > 1) {
+        throw new RangeError('volume must be a finite number from 0 to 1.');
+      }
+      element.volume = volume;
+      notify();
+    },
+    setMuted: (muted) => {
+      element.muted = muted;
+      notify();
+    },
+    setRepresentation: (sourceId, representation) => {
+      const source = sourceDefinitions.get(sourceId);
+      if (source === undefined) {
+        return false;
+      }
+      assertHTMLMediaRepresentation(source, representation);
+      selectedRepresentationBySourceId.set(sourceId, representation);
+      selectedInputIndexBySourceId.set(sourceId, 0);
+      if (activeClip?.clip.sourceId === sourceId) {
+        return loadClip(activeClip, { v: timelineTimeAtStart, r: 1 });
+      }
+      notify();
+      return true;
+    },
+    retrySource: (sourceId) => {
+      if (!sourceDefinitions.has(sourceId)) {
+        return false;
+      }
+      selectedInputIndexBySourceId.set(sourceId, 0);
+      if (activeClip?.clip.sourceId === sourceId) {
+        return loadClip(activeClip, { v: timelineTimeAtStart, r: 1 });
+      }
+      notify();
+      return true;
+    },
+    replaceSource: (source) => {
+      validateHTMLMediaSources([source]);
+      revokeSourceObjectUrls(source.sourceId);
+      sourceDefinitions.set(source.sourceId, source);
+      const previousSelection = selectedRepresentationBySourceId.get(source.sourceId) ?? {
+        kind: 'original',
+      };
+      const nextSelection = hasHTMLMediaRepresentation(source, previousSelection)
+        ? previousSelection
+        : ({ kind: 'original' } as const);
+      selectedRepresentationBySourceId.set(source.sourceId, nextSelection);
+      selectedInputIndexBySourceId.set(source.sourceId, 0);
+      if (activeClip?.clip.sourceId === source.sourceId) {
+        return loadClip(activeClip, { v: timelineTimeAtStart, r: 1 });
+      }
+      notify();
+      return true;
     },
     seek: (_timelineTime, activeLayers) => {
       const clip = activeLayers.all[0];
@@ -300,12 +561,73 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     dispose: () => {
       shouldPlay = false;
       element.pause();
-      for (const url of objectUrls.values()) {
-        URL.revokeObjectURL(url);
+      element.removeEventListener('error', handleElementError);
+      for (const sourceId of objectUrlsBySourceId.keys()) {
+        revokeSourceObjectUrls(sourceId);
       }
-      objectUrls.clear();
     },
   };
+}
+
+function validateHTMLMediaSources(sources: readonly HTMLMediaSource[]) {
+  const sourceIds = new Set<string>();
+  for (const source of sources) {
+    if (sourceIds.has(source.sourceId)) {
+      throw new Error(`Duplicate HTML media sourceId "${source.sourceId}".`);
+    }
+    sourceIds.add(source.sourceId);
+    validateHTMLMediaTiming(source.sourceId, 'original', source.timing);
+    const proxyIds = new Set<string>();
+    for (const proxy of source.proxies ?? []) {
+      if (proxy.proxyId.length === 0) {
+        throw new Error(`HTML media source "${source.sourceId}" has an empty proxyId.`);
+      }
+      if (proxyIds.has(proxy.proxyId)) {
+        throw new Error(
+          `HTML media source "${source.sourceId}" has duplicate proxyId "${proxy.proxyId}".`
+        );
+      }
+      proxyIds.add(proxy.proxyId);
+      validateHTMLMediaTiming(source.sourceId, `proxy "${proxy.proxyId}"`, proxy.timing);
+    }
+  }
+}
+
+function validateHTMLMediaTiming(
+  sourceId: string,
+  representation: string,
+  timing: HTMLMediaRepresentationTiming | undefined
+) {
+  if (
+    timing !== undefined &&
+    (!Number.isFinite(timing.sourceTimeSeconds) || !Number.isFinite(timing.mediaTimeSeconds))
+  ) {
+    throw new Error(
+      `HTML media source "${sourceId}" ${representation} timing values must be finite.`
+    );
+  }
+}
+
+function hasHTMLMediaRepresentation(
+  source: HTMLMediaSource,
+  representation: HTMLMediaRepresentationSelection
+) {
+  return (
+    representation.kind === 'original' ||
+    source.proxies?.some((proxy) => proxy.proxyId === representation.proxyId) === true
+  );
+}
+
+function assertHTMLMediaRepresentation(
+  source: HTMLMediaSource,
+  representation: HTMLMediaRepresentationSelection
+) {
+  if (!hasHTMLMediaRepresentation(source, representation)) {
+    const proxyId = representation.kind === 'proxy' ? representation.proxyId : 'original';
+    throw new Error(
+      `HTML media source "${source.sourceId}" does not define representation "${proxyId}".`
+    );
+  }
 }
 
 /**
@@ -325,7 +647,8 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
 export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTMLMediaElement>(
   options: UseHTMLMediaAdapterOptions<TMediaElement>
 ): UseHTMLMediaAdapterResult {
-  const { ref, sources } = options;
+  const { ref, selectRepresentation, sources } = options;
+  const [, forceUpdate] = useReducer((value: number) => value + 1, 0);
   const [element, setElement] = useState<HTMLMediaElement | null>(null);
 
   useEffect(() => {
@@ -337,8 +660,13 @@ export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTM
       return noopAdapter;
     }
 
-    return createHTMLMediaAdapter({ element, sources });
-  }, [element, sources]);
+    return createHTMLMediaAdapter({
+      element,
+      sources,
+      selectRepresentation,
+      onChange: forceUpdate,
+    });
+  }, [element, selectRepresentation, sources]);
 
   useEffect(() => adapter.dispose, [adapter]);
 
@@ -357,7 +685,7 @@ export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTM
  * @remarks
  *
  * This hook is the simplest route for browser-native video or audio previews:
- * create a stable `sources` map, name the active layers you want to sync, and
+ * create a stable `sources` array, name the active layers you want to sync, and
  * render standard transport buttons from the returned commands. It is best for
  * straightforward media previews; use the Mediabunny adapter when you need
  * decoded canvas frames, audio scheduling, or richer source inspection.
@@ -378,7 +706,10 @@ export function useHTMLMediaAdapter<TMediaElement extends HTMLMediaElement = HTM
  *
  * export function NativeVideoPreview() {
  *   const ref = useRef<HTMLVideoElement>(null);
- *   const sources = useMemo(() => ({ 'sample-video': '/media/sample.mp4' }), []);
+ *   const sources = useMemo(() => [{
+ *     sourceId: 'sample-video',
+ *     input: '/media/sample.mp4',
+ *   }], []);
  *   const media = useHTMLTimelineMedia({
  *     ref,
  *     sources,
@@ -406,11 +737,12 @@ export function useHTMLTimelineMedia<
 >(
   options: UseHTMLTimelineMediaOptions<LayerName, TMediaElement>
 ): UseHTMLTimelineMediaResult<LayerName> {
-  const { layers, onError, ref, sources } = options;
-  const htmlMedia = useHTMLMediaAdapter({ ref, sources });
+  const { layers, onError, playbackOptions, ref, selectRepresentation, sources } = options;
+  const htmlMedia = useHTMLMediaAdapter({ ref, selectRepresentation, sources });
   const mediaSync = useTimelineMediaSync<LayerName>({
     ready: htmlMedia.ready,
     layers,
+    playbackOptions,
     adapter: htmlMedia.adapter,
     onError,
   });
@@ -419,6 +751,7 @@ export function useHTMLTimelineMedia<
     () => ({
       ...mediaSync,
       ready: htmlMedia.ready,
+      sourceStateById: htmlMedia.adapter.sourceStateById,
       adapter: htmlMedia.adapter,
     }),
     [htmlMedia.adapter, htmlMedia.ready, mediaSync]

--- a/packages/react/src/hooks/integration/media.test.tsx
+++ b/packages/react/src/hooks/integration/media.test.tsx
@@ -56,6 +56,62 @@ test('useTimelineMediaPlayback starts external playback and advances from clock 
   cancelSpy.mockRestore();
 });
 
+test('useTimelineMediaPlayback invokes one loop transition until the clock re-enters range', () => {
+  const engine = createMediaSyncEngine();
+  engine.setInPoint(fromSeconds(1), false);
+  engine.setOutPoint(fromSeconds(4), false);
+  let clockTime = 1;
+  let tick: FrameRequestCallback | undefined;
+  const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    tick = callback;
+    return 1;
+  });
+  const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  const onLoop = vi.fn();
+
+  const { result } = renderHook(
+    () =>
+      useTimelineMediaPlayback({
+        getClockTime: () => clockTime,
+        layers: mediaSyncLayers,
+        playbackOptions: { loop: true, respectInOut: true },
+        onLoop,
+      }),
+    {
+      wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+    }
+  );
+
+  act(() => {
+    expect(result.current.play()).toEqual({ ok: true });
+  });
+
+  clockTime = 4.25;
+  act(() => {
+    tick?.(16);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(1);
+  expect(engine.getTime()).toEqual(fromSeconds(1));
+
+  act(() => {
+    tick?.(32);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(1);
+
+  clockTime = 1.25;
+  act(() => {
+    tick?.(48);
+  });
+  clockTime = 4.25;
+  act(() => {
+    tick?.(64);
+  });
+  expect(onLoop).toHaveBeenCalledTimes(2);
+
+  rafSpy.mockRestore();
+  cancelSpy.mockRestore();
+});
+
 test('useTimelineMediaPlayback synchronizes at most once per project frame and skips missed ticks', () => {
   const engine = createMediaSyncEngine();
   engine.setTime(fromSeconds(1.02));
@@ -383,7 +439,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
     clockTime = toSeconds(timelineTime);
     return true;
   });
-  const resumeClock = vi.fn();
+  const requestClockActivation = vi.fn();
   const seek = vi.fn();
   const syncLayers = vi.fn();
 
@@ -397,7 +453,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
         adapter: {
           getClockTime: () => clockTime,
           startClock,
-          resumeClock,
+          requestClockActivation,
           seek,
           syncLayers,
         },
@@ -417,7 +473,7 @@ test('useTimelineMediaSync seeks to first media and starts an external adapter c
     expect.objectContaining({ hasActiveClips: true })
   );
   expect(startClock).toHaveBeenCalledWith(fromSeconds(0), 1);
-  expect(resumeClock).toHaveBeenCalledWith(1);
+  expect(requestClockActivation).toHaveBeenCalledWith(1);
   expect(syncLayers).toHaveBeenCalledWith(
     expect.objectContaining({
       reason: 'play',
@@ -585,7 +641,7 @@ test('useTimelineMediaSync reports not-ready adapters without starting playback'
 test('useTimelineMediaSync awaits async clock startup failures', async () => {
   const engine = createMediaSyncEngine();
   const startClock = vi.fn(async () => false);
-  const resumeClock = vi.fn(async () => {});
+  const requestClockActivation = vi.fn();
   const onError = vi.fn();
 
   const { result } = renderHook(
@@ -597,7 +653,7 @@ test('useTimelineMediaSync awaits async clock startup failures', async () => {
         adapter: {
           getClockTime: () => 0,
           startClock,
-          resumeClock,
+          requestClockActivation,
         },
         onError,
       }),
@@ -614,7 +670,7 @@ test('useTimelineMediaSync awaits async clock startup failures', async () => {
     });
   });
 
-  expect(resumeClock).toHaveBeenCalledWith(1);
+  expect(requestClockActivation).toHaveBeenCalledWith(1);
   expect(startClock).toHaveBeenCalledWith(fromSeconds(1), 1);
   expect(engine.getState().playing).toBe(false);
   expect(onError).toHaveBeenCalledWith('Media clock could not start.');

--- a/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaPlayback.ts
@@ -2,6 +2,7 @@ import type {
   ActiveLayerResult,
   ActiveLayerSelector,
   MaybePromise,
+  PlaybackOptions,
 } from '@techsquidtv/canvas-timeline-core';
 import {
   fromSeconds,
@@ -80,12 +81,19 @@ export interface UseTimelineMediaPlaybackOptions<LayerName extends string = stri
   getClockTime: () => number;
   /** Optional sequence frame rate used to quantize playback updates to project frames. */
   frameRate?: TimecodeFrameRate;
+  /** Core playback range and looping policy applied to the external clock. */
+  playbackOptions?: Omit<PlaybackOptions, 'clock'>;
   /** Stops the external media clock when timeline playback pauses or leaves active content. */
   stopClock?: () => void;
   /** Named active layer selectors used by the external media surface. */
   layers: Record<LayerName, ActiveLayerSelector>;
   /** Synchronizes external rendering, audio, text, or effects for the active layers. */
   syncLayers?: (details: TimelineLayerSyncDetails<LayerName>) => MaybePromise<void>;
+  /** Realigns the external clock after core loops playback to a range start. */
+  onLoop?: (
+    timelineTime: RationalTime,
+    activeLayers: ActiveLayerResult<LayerName>
+  ) => MaybePromise<void>;
   /** Receives high-level playback status changes. */
   onStatus?: (status: TimelineContentPlaybackStatus) => void;
 }
@@ -204,6 +212,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
   const animationFrameRef = useRef<number | null>(null);
   const pausingRef = useRef(false);
   const playbackFrameCursorRef = useRef<PlaybackFrameCursor | null>(null);
+  const loopTransitionRef = useRef<object | null>(null);
 
   useEffect(() => {
     optionsRef.current = options;
@@ -263,6 +272,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
       pausingRef.current = true;
       cancelTick();
       playbackFrameCursorRef.current = null;
+      loopTransitionRef.current = null;
       try {
         const timelineTime = engine.getTime();
         const currentOptions = optionsRef.current;
@@ -290,8 +300,10 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
 
   const play = useCallback(() => {
     const currentOptions = optionsRef.current;
+    loopTransitionRef.current = null;
     const currentTime = engine.getTime();
-    const startTime = quantizeTimelineTimeToFrame(currentTime, currentOptions.frameRate);
+    const resolvedStartTime = engine.getPlaybackStartTime(currentOptions.playbackOptions);
+    const startTime = quantizeTimelineTimeToFrame(resolvedStartTime, currentOptions.frameRate);
     if (!rationalEquals(currentTime, startTime)) {
       engine.setTime(startTime);
     }
@@ -305,7 +317,7 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
       return timelineCommandFail('content-gap');
     }
 
-    const started = engine.play({ clock: 'external' });
+    const started = engine.play({ ...currentOptions.playbackOptions, clock: 'external' });
     if (!started) {
       return timelineCommandFail('unsupported');
     }
@@ -344,9 +356,33 @@ export function useTimelineMediaPlayback<LayerName extends string = string>(
         );
       }
 
-      engine.setTime(timelineTime);
-
-      const nextActiveLayers = synchronizeLayers(timelineTime, 'tick');
+      const update = engine.updateExternalPlaybackTime(timelineTime);
+      const nextActiveLayers = synchronizeLayers(update.time, 'tick');
+      if (update.action !== 'loop') {
+        loopTransitionRef.current = null;
+      } else if (loopTransitionRef.current === null) {
+        const transition = {};
+        loopTransitionRef.current = transition;
+        try {
+          const loopResult = currentOptions.onLoop?.(update.time, nextActiveLayers);
+          if (isPromiseLike(loopResult)) {
+            void Promise.resolve(loopResult).catch(() => {
+              if (loopTransitionRef.current === transition) {
+                pause('paused');
+              }
+            });
+          }
+        } catch {
+          if (loopTransitionRef.current === transition) {
+            pause('paused');
+          }
+          return;
+        }
+      }
+      if (update.action === 'pause') {
+        pause('paused');
+        return;
+      }
       if (!nextActiveLayers.hasActiveClips) {
         pause('content-gap');
         return;

--- a/packages/react/src/hooks/playback/useTimelineMediaSync.ts
+++ b/packages/react/src/hooks/playback/useTimelineMediaSync.ts
@@ -2,6 +2,7 @@ import type {
   ActiveLayerSelector,
   ActiveLayerResult,
   MaybePromise,
+  PlaybackOptions,
 } from '@techsquidtv/canvas-timeline-core';
 import { rationalEquals, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -35,8 +36,8 @@ export interface TimelineMediaSyncAdapter<LayerName extends string = string> {
   startClock: (timelineTime: RationalTime, playbackRate: number) => MaybePromise<boolean>;
   /** Stops the external media clock if timeline playback cannot start. */
   stopClock?: () => void;
-  /** Resumes browser-gated clocks, such as AudioContext, from a user gesture. */
-  resumeClock?: (playbackRate: number) => MaybePromise<void>;
+  /** Requests browser-gated clock activation without blocking visual transport. */
+  requestClockActivation?: (playbackRate: number) => void;
   /** Updates the external clock rate before timeline playback rate changes. */
   setClockRate?: (playbackRate: number) => void;
   /** Refreshes external media after paused playhead or timeline edits. */
@@ -68,6 +69,8 @@ export interface UseTimelineMediaSyncOptions<LayerName extends string = string> 
   ready?: boolean;
   /** Optional sequence frame rate used to lock media playback to project frames. */
   frameRate?: UseTimelineMediaPlaybackOptions<LayerName>['frameRate'];
+  /** Core playback range and looping policy applied to the external media clock. */
+  playbackOptions?: Omit<PlaybackOptions, 'clock'>;
   /** Named active layer selectors used by the external media surface. */
   layers: Record<LayerName, ActiveLayerSelector>;
   /** External media adapter callbacks. */
@@ -239,7 +242,7 @@ function createPlayFailure(
 export function useTimelineMediaSync<LayerName extends string = string>(
   options: UseTimelineMediaSyncOptions<LayerName>
 ): UseTimelineMediaSyncResult<LayerName> {
-  const { adapter, frameRate, layers, onError, ready = true } = options;
+  const { adapter, frameRate, layers, onError, playbackOptions, ready = true } = options;
   const adapterSeek = adapter.seek;
   const { engine } = useTimeline();
   const activeLayers = useActiveLayers<LayerName>({ layers });
@@ -252,11 +255,18 @@ export function useTimelineMediaSync<LayerName extends string = string>(
 
   const syncPlayback = useTimelineMediaPlayback<LayerName>({
     frameRate,
+    playbackOptions,
     getClockTime: adapter.getClockTime,
     stopClock: adapter.stopClock,
     layers,
     syncLayers: adapter.syncLayers,
     onStatus: adapter.onStatus,
+    onLoop: async (timelineTime, loopLayers) => {
+      await adapter.seek?.(timelineTime, loopLayers);
+      if (!(await adapter.startClock(timelineTime, engine.getPlaybackRate()))) {
+        throw new Error('Media clock could not restart after looping.');
+      }
+    },
   });
   const playingRef = useRef(syncPlayback.playing);
 
@@ -346,7 +356,8 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     const currentTime = engine.getTime();
-    let timelineTime = quantizeTimelineTimeToFrame(currentTime, frameRate);
+    const resolvedStartTime = engine.getPlaybackStartTime(playbackOptions);
+    let timelineTime = quantizeTimelineTimeToFrame(resolvedStartTime, frameRate);
     if (!rationalEquals(currentTime, timelineTime)) {
       engine.setTime(timelineTime);
     }
@@ -378,7 +389,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     try {
-      await adapter.resumeClock?.(syncPlayback.playbackRate);
+      adapter.requestClockActivation?.(syncPlayback.playbackRate);
       await adapter.seek?.(timelineTime, timelineLayers);
       if (!(await adapter.startClock(timelineTime, syncPlayback.playbackRate))) {
         adapter.stopClock?.();
@@ -413,7 +424,7 @@ export function useTimelineMediaSync<LayerName extends string = string>(
     }
 
     return { ok: true, time: timelineTime };
-  }, [adapter, engine, frameRate, layers, onError, ready, syncPlayback]);
+  }, [adapter, engine, frameRate, layers, onError, playbackOptions, ready, syncPlayback]);
 
   const setPlaybackRate = useCallback(
     (playbackRate: number) => {


### PR DESCRIPTION
## Summary\n\n- keep the common source descriptor to sourceId plus input\n- separate per-representation input fallbacks from deliberately selected editing proxies\n- add original/proxy selection, timestamp anchors, retry, replacement, volume, and mute controls\n- map proxy media timestamps into stable logical source time\n- migrate source-backed HTML demos\n\n## Release Impact\n\n- Packages/API: HTML media adapter\n- Docs/demos: HTML media and keyframe demos\n- Breaking changes: replaces the previous source record and variant-array shapes without aliases\n- Release risk: native media loading, proxy switching, and clock mapping\n\n## Stack\n\n2 of 5. Base: fix/playback/external-range-policy.\n\n## Validation\n\n- 12 HTML adapter tests\n- full stack: vp run ci