### PR TITLE
docs: explain media source representations

### DIFF
--- a/.changeset/media-adapter-docs.md
+++ b/.changeset/media-adapter-docs.md
@@ -1,0 +1,6 @@
+---
+'@techsquidtv/canvas-timeline-html-media-adapter': patch
+'@techsquidtv/canvas-timeline-mediabunny-adapter': patch
+---
+
+Update media adapter reference documentation for original inputs, per-representation fallbacks, and selectable editing proxies.

--- a/apps/www/src/data/packages.ts
+++ b/apps/www/src/data/packages.ts
@@ -275,7 +275,8 @@ export function TimelineChrome({ engine }: { engine: TimelineEngine }) {
       body: 'Use `useHTMLTimelineMedia` for the normal React path. It creates the adapter, wires it to timeline playback, and returns transport helpers for play, pause, and rate controls.',
       steps: [
         'Give each media clip a stable `sourceId`.',
-        'Create a `sources` record where each key is a source id and each value is a URL, `Blob`, or `File`.',
+        'Create a `sources` array of `{ sourceId, input }` descriptors, one per logical source.',
+        'Add per-representation `fallbacks` or selectable editing `proxies` only when needed.',
         'Attach a ref to one `<video>` or `<audio>` element.',
         'Pass the ref, sources, and layer selector to `useHTMLTimelineMedia` inside a `TimelineProvider`.',
       ],
@@ -286,7 +287,12 @@ export function TimelineChrome({ engine }: { engine: TimelineEngine }) {
       code: `import { useRef } from 'react';
 import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-adapter';
 
-const sources = { 'clip-source-main': '/media/preview.mp4' };
+const sources = [
+  {
+    sourceId: 'clip-source-main',
+    input: '/media/preview.mp4',
+  },
+] as const;
 const layers = {
   visuals: { trackKind: 'visual', sourceId: 'clip-source-main' },
 } as const;
@@ -335,7 +341,8 @@ export function NativePreview() {
       body: 'Timeline clips keep lightweight `sourceId` values. Your app keeps the actual files, URLs, or Mediabunny inputs outside the timeline and passes matching source descriptors to the adapter.',
       steps: [
         'Give each media clip a stable `sourceId`.',
-        'Create a `sources` array where each descriptor has an `id` matching a clip source id.',
+        'Create a `sources` array where each logical source has a matching `sourceId` and original `input`.',
+        'Add `fallbacks` for load failover and `proxies` for deliberately selectable editing media.',
         'Attach a canvas ref for decoded video frames.',
         'Pass the canvas ref, sources, and visual/audio layer selectors to `useMediabunnyTimelineMedia` inside a `TimelineProvider`.',
         'Use the returned transport helpers for playback and the returned duration/frame state for preview UI.',
@@ -348,7 +355,10 @@ export function NativePreview() {
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 
 const sourceId = 'clip-source-main';
-const sources = [{ id: sourceId, url: '/media/preview.mp4' }] as const;
+const sources = [{
+  sourceId,
+  input: { kind: 'url', url: '/media/preview.mp4' },
+}] as const;
 const layers = {
   visuals: { trackKind: 'visual', sourceId },
   audio: { trackKind: 'audio', sourceId },

--- a/packages/html-media-adapter/README.md
+++ b/packages/html-media-adapter/README.md
@@ -31,7 +31,12 @@ import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-ad
 import { useRef } from 'react';
 import { useHTMLTimelineMedia } from '@techsquidtv/canvas-timeline-html-media-adapter';
 
-const sources = { 'clip-source-main': '/media/preview.mp4' };
+const sources = [
+  {
+    sourceId: 'clip-source-main',
+    input: '/media/preview.mp4',
+  },
+] as const;
 const previewLayers = {
   visuals: { trackKind: 'visual', sourceId: 'clip-source-main' },
 } as const;
@@ -47,6 +52,8 @@ export function NativePreview() {
   return <video ref={videoRef} playsInline onClick={() => void media.play()} />;
 }
 ```
+
+Use `fallbacks` for alternate ways to load the currently selected representation. Use `proxies` for deliberately selectable editing media, and switch with `media.adapter.setRepresentation(...)`. A proxy can define its own fallbacks and a `timing` anchor when its container timestamps differ from the logical source.
 
 ```ts
 import { createHTMLMediaAdapter } from '@techsquidtv/canvas-timeline-html-media-adapter';

--- a/packages/mediabunny-adapter/README.md
+++ b/packages/mediabunny-adapter/README.md
@@ -41,7 +41,12 @@ import { TimelineProvider } from '@techsquidtv/canvas-timeline-react';
 import { useMediabunnyTimelineMedia } from '@techsquidtv/canvas-timeline-mediabunny-adapter/react';
 
 const sourceId = 'clip-source-main';
-const sources = [{ id: sourceId, url: '/media/preview.mp4' }] as const;
+const sources = [
+  {
+    sourceId,
+    input: { kind: 'url', url: '/media/preview.mp4' },
+  },
+] as const;
 const previewLayers = {
   visuals: { trackKind: 'visual', sourceId },
   audio: { trackKind: 'audio', sourceId },
@@ -67,7 +72,7 @@ function DecodedPreview() {
 }
 ```
 
-Each item in `sources` uses an `id` that matches timeline clip `sourceId` values. For local files or custom Mediabunny setup, replace the URL descriptor with a `blob`, `input`, or `createInput` descriptor that keeps the same join key.
+Each item in `sources` uses a `sourceId` matching timeline clips and one concise original `input`. Add `fallbacks` for alternate ways to load that representation. Add `proxies` for editing representations that can be selected independently with `setRepresentation`; every proxy can have its own fallbacks and a `timing` anchor when its timestamps differ from logical source time. Inputs can use URLs, blobs, supplied inputs, or input factories. The adapter exposes the selected representation, input attempts, timing, dimensions, and frame-rate metadata through `sourceStateById`.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary\n\n- document the concise sourceId plus input common case\n- distinguish input fallbacks from deliberately selected editing proxies\n- explain per-proxy fallbacks, timestamp anchors, diagnostics, and runtime representation switching\n- update both package pages and READMEs\n\n## Release Impact\n\n- Packages/API: none; documents the preceding adapter APIs\n- Docs/demos: package references and examples\n- Breaking changes: documents the breaking descriptor migration\n- Release risk: low\n\n## Stack\n\n4 of 5. Base: feat/mediabunny/source-runtime.\n\n## Validation\n\n- docs links and generated API references\n- full stack: vp run ci