### PR TITLE
feat(docs): add structured Pagefind search

### DIFF
--- a/.changeset/quiet-search-index.md
+++ b/.changeset/quiet-search-index.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add structured Pagefind indexing and global docs-site search.

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "vp run docs:api && astro dev --port=4321 --host=0.0.0.0",
-    "build": "vp run docs:sponsors && vp run docs:api && vp run docs:demos && vp run docs:links && vp run docs:registry && vp run docs:og && vp run docs:editor && astro build && vp run docs:editor:verify",
+    "build": "vp run docs:sponsors && vp run docs:api && vp run docs:demos && vp run docs:links && vp run docs:registry && vp run docs:og && vp run docs:editor && astro build && vp run docs:search && vp run docs:editor:verify",
     "preview": "astro preview --host=0.0.0.0",
     "docs:api": "node scripts/generate/api-reference.mjs",
     "docs:links": "node scripts/verify/links.mjs",
@@ -20,6 +20,7 @@
     "docs:registry": "node ../../scripts/checks/react-registry.mjs",
     "docs:og": "tsx scripts/generate/open-graph.ts",
     "docs:editor:verify": "node scripts/demos/verify-full-editor-build.mjs",
+    "docs:search": "tsx scripts/generate/search-catalog.ts && pagefind --site dist/client && node scripts/verify/search-build.mjs",
     "docs:demo:new": "node scripts/demos/scaffold.mjs",
     "clean": "rm -rf .astro dist .generated public/open-graph public/demos/full-editor-demo public/full-editor-demo"
   },
@@ -55,6 +56,7 @@
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.3",
     "mdast-util-to-string": "^4.0.0",
+    "pagefind": "^1.5.2",
     "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",

--- a/apps/www/scripts/generate/search-catalog.ts
+++ b/apps/www/scripts/generate/search-catalog.ts
@@ -1,6 +1,8 @@
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { decodeHtmlAttribute } from '#www/lib/html-entities';
 import { assertUniqueSearchDocumentUrls } from '#www/lib/search';
 
 type SearchDocumentKind = 'docs' | 'package' | 'demo' | 'registry' | 'blog' | 'api';
@@ -145,7 +147,7 @@ function collectMetadata(source: string): Record<string, string> {
       continue;
     }
 
-    metadata[field.replace(/\[.*$/u, '')] = decodeHtml(content);
+    metadata[field.replace(/\[.*$/u, '')] = decodeHtmlAttribute(content);
   }
 
   return metadata;
@@ -199,13 +201,4 @@ function splitTerms(value: string): string[] {
     .split('|')
     .map((term) => term.trim())
     .filter(Boolean);
-}
-
-function decodeHtml(value: string): string {
-  return value
-    .replaceAll('&amp;', '&')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', "'")
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>');
 }

--- a/apps/www/scripts/generate/search-catalog.ts
+++ b/apps/www/scripts/generate/search-catalog.ts
@@ -1,0 +1,211 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assertUniqueSearchDocumentUrls } from '#www/lib/search';
+
+type SearchDocumentKind = 'docs' | 'package' | 'demo' | 'registry' | 'blog' | 'api';
+
+interface SearchCatalogDocument {
+  readonly url: string;
+  readonly title: string;
+  readonly description: string;
+  readonly kind: SearchDocumentKind;
+  readonly weight: number;
+  readonly packageSlug?: string;
+  readonly tags: readonly string[];
+  readonly aliases: readonly string[];
+  readonly sourcePath: string;
+}
+
+interface SearchCatalog {
+  readonly generatedAt: string;
+  readonly documents: readonly SearchCatalogDocument[];
+  readonly counts: Readonly<Record<SearchDocumentKind, number>>;
+  readonly excludedHtmlPages: readonly string[];
+}
+
+const searchDocumentKinds = new Set<SearchDocumentKind>([
+  'docs',
+  'package',
+  'demo',
+  'registry',
+  'blog',
+  'api',
+]);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(scriptDir, '../..');
+const distDir = resolve(appDir, 'dist/client');
+const generatedDir = resolve(appDir, '.generated');
+const catalogPath = resolve(generatedDir, 'search-catalog.json');
+
+const htmlPaths = await listHtmlFiles(distDir);
+const documents: SearchCatalogDocument[] = [];
+const excludedHtmlPages: string[] = [];
+
+for (const htmlPath of htmlPaths) {
+  const source = await readFile(htmlPath, 'utf8');
+  const sourcePath = relative(distDir, htmlPath);
+
+  if (!source.includes('data-pagefind-body')) {
+    excludedHtmlPages.push(sourcePath);
+    continue;
+  }
+
+  const metadata = collectMetadata(source);
+  const kind = collectKind(source);
+  const url = collectCanonicalPath(source);
+  const weight = collectWeight(source);
+
+  if (!kind || !searchDocumentKinds.has(kind)) {
+    throw new Error(`${sourcePath} is missing a supported Pagefind kind filter.`);
+  }
+
+  for (const key of ['title', 'description', 'kind', 'tags'] as const) {
+    if (!metadata[key]) {
+      throw new Error(`${sourcePath} is missing Pagefind ${key} metadata.`);
+    }
+  }
+
+  if (!url) {
+    throw new Error(`${sourcePath} is missing a canonical URL.`);
+  }
+
+  if (weight === undefined) {
+    throw new Error(`${sourcePath} is missing a valid Pagefind weight.`);
+  }
+
+  documents.push({
+    url,
+    title: metadata.title,
+    description: metadata.description,
+    kind,
+    weight,
+    packageSlug: metadata.package,
+    tags: splitTerms(metadata.tags),
+    aliases: splitTerms(metadata.aliases ?? ''),
+    sourcePath,
+  });
+}
+
+assertUniqueSearchDocumentUrls(documents);
+
+const counts = Object.fromEntries(
+  [...searchDocumentKinds].map((kind) => [
+    kind,
+    documents.filter((document) => document.kind === kind).length,
+  ])
+) as Record<SearchDocumentKind, number>;
+const catalog: SearchCatalog = {
+  generatedAt: new Date().toISOString(),
+  documents: documents.sort((first, second) => first.url.localeCompare(second.url)),
+  counts,
+  excludedHtmlPages: excludedHtmlPages.sort(),
+};
+
+for (const kind of searchDocumentKinds) {
+  if (counts[kind] === 0) {
+    throw new Error(`Pagefind catalog is missing ${kind} documents.`);
+  }
+}
+
+await mkdir(generatedDir, { recursive: true });
+await writeFile(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
+
+console.info(
+  `Generated ${relative(appDir, catalogPath)} with ${documents.length} documents: ` +
+    [...searchDocumentKinds].map((kind) => `${kind}=${counts[kind]}`).join(', ')
+);
+
+async function listHtmlFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        return listHtmlFiles(path);
+      }
+
+      return entry.isFile() && entry.name.endsWith('.html') ? [path] : [];
+    })
+  );
+
+  return paths.flat();
+}
+
+function collectMetadata(source: string): Record<string, string> {
+  const metadata: Record<string, string> = {};
+
+  for (const match of source.matchAll(/<meta\b[^>]*>/gu)) {
+    const tag = match[0];
+    const field = attributeValue(tag, 'data-pagefind-meta');
+    const content = attributeValue(tag, 'content');
+
+    if (!field || !content) {
+      continue;
+    }
+
+    metadata[field.replace(/\[.*$/u, '')] = decodeHtml(content);
+  }
+
+  return metadata;
+}
+
+function collectKind(source: string): SearchDocumentKind | undefined {
+  for (const match of source.matchAll(/<meta\b[^>]*>/gu)) {
+    const filter = attributeValue(match[0], 'data-pagefind-filter');
+
+    if (filter?.startsWith('kind:')) {
+      return filter.slice('kind:'.length) as SearchDocumentKind;
+    }
+  }
+
+  return undefined;
+}
+
+function collectCanonicalPath(source: string): string | undefined {
+  const canonicalTag = source.match(/<link\b[^>]*rel="canonical"[^>]*>/u)?.[0];
+  const canonicalUrl = canonicalTag ? attributeValue(canonicalTag, 'href') : undefined;
+
+  if (!canonicalUrl) {
+    return undefined;
+  }
+
+  return new URL(canonicalUrl).pathname;
+}
+
+function collectWeight(source: string): number | undefined {
+  const bodyTag = source.match(/<main\b[^>]*>/u)?.[0];
+  const value = bodyTag ? attributeValue(bodyTag, 'data-pagefind-weight') : undefined;
+
+  if (!value) {
+    return undefined;
+  }
+
+  const weight = Number(value);
+
+  return Number.isFinite(weight) && weight >= 0 && weight <= 10 ? weight : undefined;
+}
+
+function attributeValue(tag: string, attribute: string): string | undefined {
+  const escapedAttribute = attribute.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const match = tag.match(new RegExp(`\\b${escapedAttribute}="([^"]*)"`, 'u'));
+
+  return match?.[1];
+}
+
+function splitTerms(value: string): string[] {
+  return value
+    .split('|')
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+function decodeHtml(value: string): string {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>');
+}

--- a/apps/www/scripts/verify/links.mjs
+++ b/apps/www/scripts/verify/links.mjs
@@ -17,6 +17,10 @@ const publicDir = resolve(appDir, 'public');
 const apiReferencePath = resolve(appDir, '.generated/api-reference.json');
 const sameSiteHosts = new Set(['canvastimeline.com']);
 const apiDocTextKeys = new Set(['summary', 'remarks', 'returnsSummary', 'examples', 'see']);
+const generatedAssetPaths = new Set([
+  '/pagefind/pagefind-component-ui.css',
+  '/pagefind/pagefind-component-ui.js',
+]);
 
 const apiReference = await readApiReference().catch((error) => {
   console.error(error.message);
@@ -387,6 +391,10 @@ function validateFragment(filePath, line, raw, route, fragment) {
 }
 
 async function validatePublicPath(filePath, line, routePath, raw) {
+  if (generatedAssetPaths.has(routePath)) {
+    return;
+  }
+
   const publicPath = resolve(publicDir, routePath.slice(1));
   if (!isInsideDirectory(publicDir, publicPath)) {
     errors.push(`${formatLocation(filePath, line)} points outside public assets: ${raw}`);

--- a/apps/www/scripts/verify/search-build.mjs
+++ b/apps/www/scripts/verify/search-build.mjs
@@ -1,0 +1,64 @@
+import { access, readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(scriptDir, '../..');
+const distDir = resolve(appDir, 'dist/client');
+const catalogPath = resolve(appDir, '.generated/search-catalog.json');
+const requiredPagefindAssets = [
+  'pagefind/pagefind-component-ui.css',
+  'pagefind/pagefind-component-ui.js',
+];
+const expectedKinds = ['docs', 'package', 'demo', 'registry', 'blog', 'api'];
+
+await Promise.all(
+  requiredPagefindAssets.map(async (assetPath) => {
+    await access(resolve(distDir, assetPath));
+  })
+);
+
+const catalog = JSON.parse(await readFile(catalogPath, 'utf8'));
+
+if (!Array.isArray(catalog.documents) || catalog.documents.length === 0) {
+  throw new Error('Pagefind search catalog did not contain any indexed documents.');
+}
+
+for (const kind of expectedKinds) {
+  if (!Number.isInteger(catalog.counts?.[kind]) || catalog.counts[kind] < 1) {
+    throw new Error(`Pagefind search catalog did not include ${kind} documents.`);
+  }
+}
+
+const documentWeights = catalog.documents.map((document) => document.weight);
+
+if (!documentWeights.every((weight) => Number.isFinite(weight) && weight >= 0 && weight <= 10)) {
+  throw new Error('Pagefind search catalog contains an invalid document weight.');
+}
+
+const apiWeights = catalog.documents
+  .filter((document) => document.kind === 'api')
+  .map((document) => document.weight);
+const guideWeights = catalog.documents
+  .filter((document) => document.kind === 'docs')
+  .map((document) => document.weight);
+
+if (Math.max(...apiWeights) >= Math.min(...guideWeights)) {
+  throw new Error('Pagefind API documents must rank below documentation guides.');
+}
+
+for (const document of catalog.documents) {
+  if (typeof document.sourcePath !== 'string' || !document.sourcePath.endsWith('.html')) {
+    throw new Error('Pagefind search catalog contains an invalid source path.');
+  }
+
+  const source = await readFile(resolve(distDir, document.sourcePath), 'utf8');
+
+  if (!source.includes(`data-pagefind-filter="kind:${document.kind}"`)) {
+    throw new Error(`${document.sourcePath} is missing its indexed Pagefind kind filter.`);
+  }
+}
+
+console.info(
+  `Verified Pagefind assets and ${catalog.documents.length} indexed documents in ${distDir}.`
+);

--- a/apps/www/src/components/SearchModal.astro
+++ b/apps/www/src/components/SearchModal.astro
@@ -1,0 +1,48 @@
+<pagefind-config excerpt-length="24"></pagefind-config>
+<pagefind-modal reset-on-close>
+  <pagefind-modal-header>
+    <pagefind-input placeholder="Search Canvas Timeline"></pagefind-input>
+  </pagefind-modal-header>
+  <pagefind-modal-body>
+    <div class="site-search-modal__content">
+      <aside class="site-search-modal__filters" aria-label="Search filters">
+        <pagefind-filter-pane open="kind"></pagefind-filter-pane>
+      </aside>
+      <div class="site-search-modal__results">
+        <pagefind-summary></pagefind-summary>
+        <pagefind-results>
+          <script type="text/pagefind-template">
+            <li class="pf-result site-search-result">
+              <div class="pf-result-card">
+                <div class="pf-result-content">
+                  <div class="site-search-result__heading">
+                    <span class="site-search-result__kind">{{ meta.kind }}</span>
+                    <p class="pf-result-title">
+                      <a class="pf-result-link" href="{{ url | safeUrl }}">{{ meta.title }}</a>
+                    </p>
+                  </div>
+                  {{#if excerpt}}
+                  <p class="pf-result-excerpt">{{+ excerpt +}}</p>
+                  {{/if}}
+                </div>
+              </div>
+              {{#if sub_results}}
+              <ul class="pf-heading-chips">
+                {{#each sub_results as sub}}
+                <li class="pf-heading-chip">
+                  <a class="pf-heading-link" href="{{ sub.url | safeUrl }}">{{ sub.title }}</a>
+                  <p class="pf-heading-excerpt">{{+ sub.excerpt +}}</p>
+                </li>
+                {{/each}}
+              </ul>
+              {{/if}}
+            </li>
+          </script>
+        </pagefind-results>
+      </div>
+    </div>
+  </pagefind-modal-body>
+  <pagefind-modal-footer>
+    <pagefind-keyboard-hints></pagefind-keyboard-hints>
+  </pagefind-modal-footer>
+</pagefind-modal>

--- a/apps/www/src/content.config.ts
+++ b/apps/www/src/content.config.ts
@@ -4,6 +4,7 @@ import { z } from 'astro/zod';
 import { docsSectionIds } from '#www/data/docs';
 import { reactRegistryItems } from '#www/data/react-registry';
 import { site } from '#www/data/site';
+import { searchOptionsSchema } from '#www/lib/search';
 
 const reactRegistryKeys = new Set(reactRegistryItems.map((item) => item.slug));
 
@@ -17,6 +18,7 @@ const docs = defineCollection({
     description: z.string(),
     section: z.enum(docsSectionIds),
     order: z.number(),
+    search: searchOptionsSchema.optional(),
   }),
 });
 
@@ -33,6 +35,7 @@ const blog = defineCollection({
       updatedDate: z.date().optional(),
       author: z.string().min(1).max(80),
       tags: z.array(z.string().min(1).max(40)).min(1).max(8),
+      search: searchOptionsSchema.optional(),
       faq: z
         .array(
           z
@@ -71,6 +74,7 @@ const reactRegistryDocs = defineCollection({
     registryKey: z.string().refine((key) => reactRegistryKeys.has(key), {
       message: 'Unknown React registry key',
     }),
+    search: searchOptionsSchema.optional(),
   }),
 });
 

--- a/apps/www/src/content/blog/building-for-canvas-first-timelines.mdx
+++ b/apps/www/src/content/blog/building-for-canvas-first-timelines.mdx
@@ -7,6 +7,12 @@ tags:
   - Architecture
   - React
   - Performance
+search:
+  keywords:
+    - canvas rendering
+    - 60fps timeline
+    - editor performance
+  priority: high
 ---
 
 Canvas Timeline is built around a simple constraint: timeline editors become expensive when every clip, tick, ruler mark, and interaction hint is a DOM node. The library keeps that dense work in the canvas renderer, then lets React handle the lower-count controls that need accessibility, focus management, and product-specific composition.

--- a/apps/www/src/content/docs/getting-started.mdx
+++ b/apps/www/src/content/docs/getting-started.mdx
@@ -3,6 +3,12 @@ title: Getting started
 description: Install Canvas Timeline and render the first editable timeline surface.
 section: intro
 order: 10
+search:
+  keywords:
+    - quickstart
+    - setup
+    - installation
+  priority: high
 ---
 
 import Callout from '#www/components/Callout.astro';

--- a/apps/www/src/data/demos.ts
+++ b/apps/www/src/data/demos.ts
@@ -1,3 +1,5 @@
+import type { SearchOptions } from '#www/lib/search';
+
 type DemoStatus =
   | 'Minimal'
   | 'Media sync'
@@ -37,6 +39,7 @@ export interface DemoDoc {
   externalUrl?: string;
   liveDemoId?: LiveDemoId;
   references?: DemoReference[];
+  search?: SearchOptions;
 }
 
 export const demoDocs: DemoDoc[] = [
@@ -45,6 +48,10 @@ export const demoDocs: DemoDoc[] = [
     title: 'Basic Timeline',
     description:
       'A minimal timeline with draggable clips, a visible playhead, canvas rendering, and enough state to explain the editor model.',
+    search: {
+      keywords: ['starter example', 'basic editor', 'draggable clips'],
+      priority: 'high',
+    },
     status: 'Minimal',
     difficulty: 'Beginner',
     packageFocus: [

--- a/apps/www/src/data/packages.ts
+++ b/apps/www/src/data/packages.ts
@@ -1,4 +1,5 @@
 import { packageResourceLinks } from '#www/data/site';
+import type { SearchOptions } from '#www/lib/search';
 
 interface PackageExample {
   title: string;
@@ -36,6 +37,7 @@ export interface PackageDoc {
   usage: PackageUsage;
   example: PackageExample;
   linkGroups: PackageLinkGroup[];
+  search?: SearchOptions;
 }
 
 function packageLinks(slug: Parameters<typeof packageResourceLinks>[0]): PackageLinkGroup {
@@ -56,6 +58,10 @@ export const packageDocs: PackageDoc[] = [
     purpose: 'React timeline editing toolkit.',
     description:
       'Start here when you want the common Canvas Timeline experience without choosing lower-level package boundaries up front.',
+    search: {
+      keywords: ['timeline editor', 'React timeline', 'quickstart'],
+      priority: 'high',
+    },
     installCommand: 'pnpm add @techsquidtv/canvas-timeline',
     overview: [
       'The main package is the easiest way to start a Canvas Timeline editor. It re-exports the core engine, React bindings, renderer, and time utilities from one dependency so early app code can stay focused on the editor experience.',

--- a/apps/www/src/data/react-registry.ts
+++ b/apps/www/src/data/react-registry.ts
@@ -1,4 +1,5 @@
 import { apiSymbolHref, getApiSymbol } from '#www/lib/api-reference';
+import type { SearchOptions } from '#www/lib/search';
 import {
   timelineHookMetadata,
   type TimelineHookGroupId,
@@ -69,6 +70,7 @@ export interface ReactRegistryItem {
   apis: ReactRegistryApi[];
   props?: ReactRegistryProp[];
   notes?: string[];
+  search?: SearchOptions;
 }
 
 export interface ReactRegistryGroup {

--- a/apps/www/src/layouts/BaseLayout.astro
+++ b/apps/www/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import { site } from '#www/data/site';
 import Breadcrumbs, { type BreadcrumbItem } from '#www/components/Breadcrumbs.astro';
 import GitHubIcon from '#www/components/GitHubIcon.astro';
+import SearchModal from '#www/components/SearchModal.astro';
 import SiteFooter from '#www/components/SiteFooter.astro';
 import {
   createSiteStructuredData,
@@ -9,6 +10,10 @@ import {
   type StructuredDataInput,
 } from '#www/lib/structured-data';
 import { openGraphImage, openGraphRouteForPath } from '#www/lib/open-graph';
+import {
+  assertSearchDocumentMatchesPath,
+  type SearchDocument,
+} from '#www/lib/search';
 import '#www/styles/global.css';
 
 interface Props {
@@ -28,6 +33,7 @@ interface Props {
   tags?: readonly string[];
   noindex?: boolean;
   structuredData?: StructuredDataInput;
+  search?: SearchDocument;
 }
 
 const {
@@ -42,7 +48,12 @@ const {
   tags = [],
   noindex = false,
   structuredData,
+  search,
 } = Astro.props;
+if (search) {
+  assertSearchDocumentMatchesPath(search, Astro.url.pathname);
+}
+const searchDocument = search?.exclude ? undefined : search;
 const pageTitle = title ? `${title} | ${site.name}` : site.name;
 const canonicalUrl = providedCanonicalUrl ?? new URL(Astro.url.pathname, site.url).toString();
 const pageImage =
@@ -73,11 +84,34 @@ const structuredDataItems = [
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    {
+      searchDocument ? (
+        <>
+          <meta data-pagefind-meta="title[content]" content={searchDocument.title} />
+          <meta data-pagefind-meta="description[content]" content={searchDocument.description} />
+          <meta data-pagefind-meta="kind[content]" content={searchDocument.kind} />
+          <meta data-pagefind-meta="tags[content]" content={searchDocument.tags.join('|')} />
+          {
+            searchDocument.aliases.length > 0 ? (
+              <meta data-pagefind-meta="aliases[content]" content={searchDocument.aliases.join('|')} />
+            ) : null
+          }
+          {
+            searchDocument.packageSlug ? (
+              <meta data-pagefind-meta="package[content]" content={searchDocument.packageSlug} />
+            ) : null
+          }
+          <meta data-pagefind-filter={`kind:${searchDocument.kind}`} />
+        </>
+      ) : null
+    }
     {noindex ? <meta name="robots" content="noindex, nofollow" /> : null}
     <meta name="theme-color" content="#ffffff" />
     <link class="canonical-link" rel="canonical" href={canonicalUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
+    <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
     <meta property="og:site_name" content={site.name} />
     <meta property="og:type" content={pageType} />
     <meta property="og:title" content={metaTitle} />
@@ -120,6 +154,10 @@ const structuredDataItems = [
           <nav class="site-nav" aria-label="Primary navigation">
             {site.primaryNav.map((link) => <a href={link.href}>{link.label}</a>)}
           </nav>
+          <pagefind-modal-trigger
+            class="site-search-trigger"
+            placeholder="Search"
+          ></pagefind-modal-trigger>
           <a
             class="site-icon-link"
             href={site.repository.href}
@@ -131,7 +169,11 @@ const structuredDataItems = [
         </div>
       </div>
     </header>
-    <main>
+    <SearchModal />
+    <main
+      data-pagefind-body={searchDocument ? '' : undefined}
+      data-pagefind-weight={searchDocument?.weight}
+    >
       <Breadcrumbs items={breadcrumbs} />
       <slot />
     </main>

--- a/apps/www/src/layouts/DocsLayout.astro
+++ b/apps/www/src/layouts/DocsLayout.astro
@@ -5,6 +5,7 @@ import DocsNav from '#www/components/DocsNav.astro';
 import MarkdownCopyButton from '#www/components/MarkdownCopyButton.astro';
 import { docsSections, type DocsSectionId } from '#www/data/docs';
 import type { StructuredDataInput } from '#www/lib/structured-data';
+import type { SearchDocument } from '#www/lib/search';
 
 interface PagerLink {
   id: string;
@@ -26,6 +27,7 @@ interface Props {
   markdownAriaLabel?: string;
   markdownTooltip?: string;
   structuredData?: StructuredDataInput;
+  search: SearchDocument;
 }
 
 const {
@@ -41,6 +43,7 @@ const {
   markdownAriaLabel,
   markdownTooltip,
   structuredData,
+  search,
 } = Astro.props;
 const tocHeadings = headings.filter((heading) => heading.depth === 2 || heading.depth === 3);
 const currentSection = section
@@ -59,6 +62,7 @@ const breadcrumbs = [
   description={description}
   breadcrumbs={breadcrumbs}
   structuredData={structuredData}
+  search={search}
 >
   <section class="docs-hero">
     <div class="container-page docs-hero__content">

--- a/apps/www/src/lib/html-entities.test.ts
+++ b/apps/www/src/lib/html-entities.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vite-plus/test';
+
+import { decodeHtmlAttribute } from '#www/lib/html-entities';
+
+describe('decodeHtmlAttribute', () => {
+  test('decodes supported entities once', () => {
+    expect(decodeHtmlAttribute('A &amp; B &quot;C&quot; &#39;D&#39; &lt;E&gt;')).toBe(
+      'A & B "C" \'D\' <E>'
+    );
+    expect(decodeHtmlAttribute('&amp;quot;')).toBe('&quot;');
+  });
+});

--- a/apps/www/src/lib/html-entities.ts
+++ b/apps/www/src/lib/html-entities.ts
@@ -1,0 +1,15 @@
+const htmlAttributeEntities: Readonly<Record<string, string>> = {
+  '&amp;': '&',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&lt;': '<',
+  '&gt;': '>',
+};
+
+/** Decodes supported HTML attribute entities without recursively unescaping values. */
+export function decodeHtmlAttribute(value: string): string {
+  return value.replace(
+    /&(amp|quot|#39|lt|gt);/gu,
+    (entity) => htmlAttributeEntities[entity] ?? entity
+  );
+}

--- a/apps/www/src/lib/search.test.ts
+++ b/apps/www/src/lib/search.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'vite-plus/test';
+import {
+  assertSearchDocumentMatchesPath,
+  assertUniqueSearchDocumentUrls,
+  createApiPackageSearchDocument,
+  createApiSymbolSearchDocument,
+  createBlogSearchDocument,
+  createDemoSearchDocument,
+  createDocsSearchDocument,
+  createPackageSearchDocument,
+  createRegistrySearchDocument,
+} from '#www/lib/search';
+
+describe('search documents', () => {
+  test('maps each structured source to a stable route and kind', () => {
+    const documents = [
+      createDocsSearchDocument({
+        id: 'getting-started',
+        title: 'Getting started',
+        description: 'Install Canvas Timeline.',
+        section: 'intro',
+      }),
+      createBlogSearchDocument({
+        id: 'canvas-first',
+        title: 'Canvas first',
+        description: 'Building a responsive editor.',
+        author: 'Canvas Timeline',
+        tags: ['performance'],
+      }),
+      createPackageSearchDocument({
+        slug: 'react',
+        name: '@techsquidtv/canvas-timeline-react',
+        shortName: 'React',
+        purpose: 'React bindings.',
+        description: 'React bindings for Canvas Timeline.',
+      }),
+      createDemoSearchDocument({
+        slug: 'basic-editor-surface',
+        title: 'Basic Timeline',
+        description: 'A minimal editor.',
+        status: 'Minimal',
+        difficulty: 'Beginner',
+        packageFocus: ['@techsquidtv/canvas-timeline-react'],
+      }),
+      createRegistrySearchDocument({
+        slug: 'playhead',
+        title: 'Playhead',
+        name: 'Timeline.Playhead',
+        description: 'Timeline playhead primitives.',
+        kind: 'component',
+        importPath: '@techsquidtv/canvas-timeline-react',
+      }),
+      createApiSymbolSearchDocument({
+        slug: 'react',
+        name: '@techsquidtv/canvas-timeline-react',
+        entryPoint: 'src/index.ts',
+        symbolSlug: 'use-timeline',
+        symbolName: 'useTimeline',
+        symbolKind: 'Function',
+        summary: 'Read the active timeline.',
+        sourcePackage: '@techsquidtv/canvas-timeline-react',
+      }),
+      createApiPackageSearchDocument({
+        slug: 'core',
+        name: '@techsquidtv/canvas-timeline-core',
+        entryPoint: 'src/index.ts',
+      }),
+    ];
+
+    expect(documents.map((document) => document.kind)).toEqual([
+      'docs',
+      'blog',
+      'package',
+      'demo',
+      'registry',
+      'api',
+      'api',
+    ]);
+    expect(new Set(documents.map((document) => document.url))).toHaveLength(documents.length);
+  });
+
+  test('applies editorial aliases, exclusions, and priority to the default weight', () => {
+    const document = createDocsSearchDocument({
+      id: 'getting-started',
+      title: 'Getting started',
+      description: 'Install Canvas Timeline.',
+      section: 'intro',
+      search: {
+        keywords: ['quickstart', 'setup', 'quickstart'],
+        priority: 'high',
+        exclude: true,
+      },
+    });
+
+    expect(document.aliases).toEqual(['quickstart', 'setup']);
+    expect(document.exclude).toBe(true);
+    expect(document.weight).toBe(1.875);
+  });
+
+  test('keeps API symbols searchable at a lower default weight', () => {
+    const document = createApiSymbolSearchDocument({
+      slug: 'core',
+      name: '@techsquidtv/canvas-timeline-core',
+      entryPoint: 'src/index.ts',
+      symbolSlug: 'timeline-engine',
+      symbolName: 'TimelineEngine',
+      symbolKind: 'Class',
+      summary: 'Timeline editing engine.',
+      sourcePackage: '@techsquidtv/canvas-timeline-core',
+    });
+
+    expect(document.weight).toBeLessThan(
+      createDocsSearchDocument({
+        id: 'architecture',
+        title: 'Architecture',
+        description: 'System architecture.',
+        section: 'concepts',
+      }).weight
+    );
+  });
+
+  test('rejects duplicate search document URLs', () => {
+    const document = createDocsSearchDocument({
+      id: 'getting-started',
+      title: 'Getting started',
+      description: 'Install Canvas Timeline.',
+      section: 'intro',
+    });
+
+    expect(() => assertUniqueSearchDocumentUrls([document, document])).toThrow(
+      'Duplicate Pagefind catalog URL: /docs/getting-started'
+    );
+  });
+
+  test('rejects a search document rendered at a different route', () => {
+    const document = createDocsSearchDocument({
+      id: 'getting-started',
+      title: 'Getting started',
+      description: 'Install Canvas Timeline.',
+      section: 'intro',
+    });
+
+    expect(() => assertSearchDocumentMatchesPath(document, '/docs/installation')).toThrow(
+      'Search document URL /docs/getting-started does not match rendered page path /docs/installation.'
+    );
+  });
+});

--- a/apps/www/src/lib/search.ts
+++ b/apps/www/src/lib/search.ts
@@ -1,0 +1,263 @@
+import { z } from 'astro/zod';
+
+const searchPriorityValues = ['high', 'normal', 'low'] as const;
+
+export const searchOptionsSchema = z
+  .object({
+    keywords: z.array(z.string().trim().min(1).max(80)).max(20).optional(),
+    priority: z.enum(searchPriorityValues).optional(),
+    exclude: z.boolean().optional(),
+  })
+  .strict();
+
+export type SearchOptions = z.infer<typeof searchOptionsSchema>;
+
+type SearchDocumentKind = 'docs' | 'package' | 'demo' | 'registry' | 'blog' | 'api';
+
+export interface SearchDocument {
+  readonly url: string;
+  readonly title: string;
+  readonly description: string;
+  readonly kind: SearchDocumentKind;
+  readonly packageSlug?: string;
+  readonly tags: readonly string[];
+  readonly aliases: readonly string[];
+  readonly weight: number;
+  readonly exclude: boolean;
+}
+
+interface SearchDocumentWithUrl {
+  readonly url: string;
+}
+
+interface SearchDocumentInput {
+  readonly url: string;
+  readonly title: string;
+  readonly description: string;
+  readonly kind: SearchDocumentKind;
+  readonly packageSlug?: string;
+  readonly tags?: readonly string[];
+  readonly search?: SearchOptions;
+}
+
+interface DocsSearchInput {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly section: string;
+  readonly search?: SearchOptions;
+}
+
+interface BlogSearchInput {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly author: string;
+  readonly tags: readonly string[];
+  readonly search?: SearchOptions;
+}
+
+interface PackageSearchInput {
+  readonly slug: string;
+  readonly name: string;
+  readonly shortName: string;
+  readonly purpose: string;
+  readonly description: string;
+  readonly search?: SearchOptions;
+}
+
+interface DemoSearchInput {
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+  readonly status: string;
+  readonly difficulty: string;
+  readonly packageFocus: readonly string[];
+  readonly search?: SearchOptions;
+}
+
+interface RegistrySearchInput {
+  readonly slug: string;
+  readonly title: string;
+  readonly name: string;
+  readonly description: string;
+  readonly kind: string;
+  readonly importPath: string;
+  readonly packageName?: string;
+  readonly search?: SearchOptions;
+}
+
+interface ApiPackageSearchInput {
+  readonly slug: string;
+  readonly name: string;
+  readonly entryPoint: string;
+}
+
+interface ApiSymbolSearchInput extends ApiPackageSearchInput {
+  readonly symbolSlug: string;
+  readonly symbolName: string;
+  readonly symbolKind: string;
+  readonly summary: string;
+  readonly sourcePackage: string;
+}
+
+const kindWeights = {
+  docs: 1.5,
+  package: 1.3,
+  demo: 1.3,
+  registry: 1.3,
+  blog: 1,
+  api: 0.45,
+} satisfies Record<SearchDocumentKind, number>;
+
+const priorityMultipliers = {
+  high: 1.25,
+  normal: 1,
+  low: 0.75,
+} satisfies Record<(typeof searchPriorityValues)[number], number>;
+
+export function createSearchDocument(input: SearchDocumentInput): SearchDocument {
+  const tags = uniqueTerms(input.tags ?? []);
+  const aliases = uniqueTerms(input.search?.keywords ?? []);
+  const priority = input.search?.priority ?? 'normal';
+
+  return {
+    url: normalizeUrl(input.url),
+    title: input.title.trim(),
+    description: input.description.trim(),
+    kind: input.kind,
+    packageSlug: input.packageSlug,
+    tags,
+    aliases,
+    weight: kindWeights[input.kind] * priorityMultipliers[priority],
+    exclude: input.search?.exclude ?? false,
+  };
+}
+
+export function assertUniqueSearchDocumentUrls(documents: readonly SearchDocumentWithUrl[]): void {
+  const urls = new Set<string>();
+
+  for (const document of documents) {
+    if (urls.has(document.url)) {
+      throw new Error(`Duplicate Pagefind catalog URL: ${document.url}`);
+    }
+
+    urls.add(document.url);
+  }
+}
+
+export function assertSearchDocumentMatchesPath(document: SearchDocument, pathname: string): void {
+  const normalizedPathname = normalizeUrl(pathname);
+
+  if (document.url !== normalizedPathname) {
+    throw new Error(
+      `Search document URL ${document.url} does not match rendered page path ${normalizedPathname}.`
+    );
+  }
+}
+
+export function createDocsSearchDocument(input: DocsSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/docs/${input.id}`,
+    title: input.title,
+    description: input.description,
+    kind: 'docs',
+    tags: [input.section, 'Canvas Timeline', 'documentation'],
+    search: input.search,
+  });
+}
+
+export function createBlogSearchDocument(input: BlogSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/blog/${input.id}`,
+    title: input.title,
+    description: input.description,
+    kind: 'blog',
+    tags: [...input.tags, input.author, 'Canvas Timeline'],
+    search: input.search,
+  });
+}
+
+export function createPackageSearchDocument(input: PackageSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/packages/${input.slug}`,
+    title: input.name,
+    description: input.description,
+    kind: 'package',
+    packageSlug: input.slug,
+    tags: [input.shortName, input.purpose, input.name, 'Canvas Timeline'],
+    search: input.search,
+  });
+}
+
+export function createDemoSearchDocument(input: DemoSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/demos/${input.slug}`,
+    title: input.title,
+    description: input.description,
+    kind: 'demo',
+    tags: [input.status, input.difficulty, ...input.packageFocus, 'Canvas Timeline'],
+    search: input.search,
+  });
+}
+
+export function createRegistrySearchDocument(input: RegistrySearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/packages/react/registry/${input.slug}`,
+    title: input.title,
+    description: input.description,
+    kind: 'registry',
+    packageSlug: 'react',
+    tags: [
+      input.kind,
+      input.name,
+      input.importPath,
+      input.packageName ?? 'React',
+      'Canvas Timeline',
+    ],
+    search: input.search,
+  });
+}
+
+export function createApiPackageSearchDocument(input: ApiPackageSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/packages/${input.slug}/api`,
+    title: `${input.name} API`,
+    description: `Generated API reference for ${input.name}.`,
+    kind: 'api',
+    packageSlug: input.slug,
+    tags: [input.name, input.entryPoint, 'API reference', 'Canvas Timeline'],
+  });
+}
+
+export function createApiSymbolSearchDocument(input: ApiSymbolSearchInput): SearchDocument {
+  return createSearchDocument({
+    url: `/packages/${input.slug}/api/${input.symbolSlug}`,
+    title: input.symbolName,
+    description: input.summary || `Generated API reference for ${input.symbolName}.`,
+    kind: 'api',
+    packageSlug: input.slug,
+    tags: [
+      input.symbolKind,
+      input.name,
+      input.entryPoint,
+      input.sourcePackage,
+      'API reference',
+      'Canvas Timeline',
+    ],
+  });
+}
+
+function normalizeUrl(url: string): string {
+  const trimmedUrl = url.trim();
+
+  if (!trimmedUrl.startsWith('/') || trimmedUrl.startsWith('//')) {
+    throw new TypeError(`Search document URLs must be root-relative: ${url}`);
+  }
+
+  return trimmedUrl === '/' ? trimmedUrl : trimmedUrl.replace(/\/+$/u, '');
+}
+
+function uniqueTerms(terms: readonly string[]): string[] {
+  return [...new Set(terms.map((term) => term.trim()).filter(Boolean))];
+}

--- a/apps/www/src/pages/blog/[slug].astro
+++ b/apps/www/src/pages/blog/[slug].astro
@@ -15,6 +15,7 @@ import {
   createBlogFaqStructuredData,
   createBlogPostStructuredData,
 } from '#www/lib/structured-data';
+import { createBlogSearchDocument } from '#www/lib/search';
 
 type BlogEntry = CollectionEntry<'blog'>;
 
@@ -43,6 +44,14 @@ const structuredData = [
   createBlogPostStructuredData(entry),
   ...(faqStructuredData ? [faqStructuredData] : []),
 ];
+const search = createBlogSearchDocument({
+  id: entry.id,
+  title: entry.data.title,
+  description: entry.data.description,
+  author: entry.data.author,
+  tags: entry.data.tags,
+  search: entry.data.search,
+});
 ---
 
 <BaseLayout
@@ -61,6 +70,7 @@ const structuredData = [
   tags={entry.data.tags}
   noindex={entry.data.draft}
   structuredData={structuredData}
+  search={entry.data.draft ? undefined : search}
 >
   <article class="blog-post">
     <header class="blog-post__header">

--- a/apps/www/src/pages/blog/index.astro
+++ b/apps/www/src/pages/blog/index.astro
@@ -8,6 +8,7 @@ import {
   getReadingMinutes,
 } from '#www/data/blog';
 import { createBlogIndexStructuredData } from '#www/lib/structured-data';
+import { createSearchDocument } from '#www/lib/search';
 
 const posts = await getBlogPosts();
 const [featuredPost, ...recentPosts] = posts;
@@ -15,6 +16,13 @@ const title = 'Canvas Timeline Blog';
 const description =
   'Engineering notes, release writeups, and practical guides for building high-performance React timeline editors with Canvas Timeline.';
 const structuredData = createBlogIndexStructuredData(posts);
+const search = createSearchDocument({
+  url: '/blog',
+  title,
+  description,
+  kind: 'blog',
+  tags: ['Canvas Timeline', 'engineering', 'React timeline editor'],
+});
 ---
 
 <BaseLayout
@@ -25,6 +33,7 @@ const structuredData = createBlogIndexStructuredData(posts);
     { label: 'Blog' },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <section class="blog-hero">
     <div class="container-page blog-hero__inner">

--- a/apps/www/src/pages/demos/[slug].astro
+++ b/apps/www/src/pages/demos/[slug].astro
@@ -5,6 +5,7 @@ import { demoCodeExamples } from '#www/data/demo-code';
 import CodeExampleTabs from '#www/components/CodeExampleTabs.astro';
 import LiveDemoRenderer from '#www/components/LiveDemoRenderer';
 import { createDemoStructuredData } from '#www/lib/structured-data';
+import { createDemoSearchDocument } from '#www/lib/search';
 
 interface Props {
   demoDoc: DemoDoc;
@@ -25,6 +26,7 @@ const hasAsideLinks = Boolean(demoDoc.externalUrl || demoDoc.references?.length)
 const sourceUrl = `https://github.com/techsquidtv/canvas-timeline/blob/main/${demoDoc.sourcePath}`;
 const sourceFileName = demoDoc.sourcePath.split('/').pop() ?? demoDoc.sourcePath;
 const structuredData = createDemoStructuredData(demoDoc);
+const search = createDemoSearchDocument(demoDoc);
 ---
 
 <BaseLayout
@@ -36,6 +38,7 @@ const structuredData = createDemoStructuredData(demoDoc);
     { label: demoDoc.title },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <section class="page-band">
     <div class="container-page page-heading">

--- a/apps/www/src/pages/demos/index.astro
+++ b/apps/www/src/pages/demos/index.astro
@@ -2,10 +2,18 @@
 import BaseLayout from '#www/layouts/BaseLayout.astro';
 import { demoDocs } from '#www/data/demos';
 import { createDemoIndexStructuredData } from '#www/lib/structured-data';
+import { createSearchDocument } from '#www/lib/search';
 
 const featuredDemoDocs = demoDocs.filter((demoDoc) => demoDoc.featured);
 const standardDemoDocs = demoDocs.filter((demoDoc) => !demoDoc.featured);
 const structuredData = createDemoIndexStructuredData(demoDocs);
+const search = createSearchDocument({
+  url: '/demos',
+  title: 'Canvas Timeline demos',
+  description: 'Source-backed Canvas Timeline demos for editor basics and advanced integrations.',
+  kind: 'demo',
+  tags: ['Canvas Timeline', 'demos', 'examples'],
+});
 ---
 
 <BaseLayout
@@ -16,6 +24,7 @@ const structuredData = createDemoIndexStructuredData(demoDocs);
     { label: 'Demos' },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <section class="page-band">
     <div class="container-page page-heading">

--- a/apps/www/src/pages/docs/[...slug].astro
+++ b/apps/www/src/pages/docs/[...slug].astro
@@ -4,6 +4,7 @@ import { getCollection, render } from 'astro:content';
 import DocsLayout from '#www/layouts/DocsLayout.astro';
 import { adjacentDocs } from '#www/data/docs';
 import { createDocsArticleStructuredData } from '#www/lib/structured-data';
+import { createDocsSearchDocument } from '#www/lib/search';
 
 type DocsEntry = CollectionEntry<'docs'>;
 
@@ -30,6 +31,13 @@ const structuredData = createDocsArticleStructuredData({
   url: `/docs/${entry.id}`,
   keywords: [entry.data.section, 'Canvas Timeline', 'documentation'],
 });
+const search = createDocsSearchDocument({
+  id: entry.id,
+  title: entry.data.title,
+  description: entry.data.description,
+  section: entry.data.section,
+  search: entry.data.search,
+});
 ---
 
 <DocsLayout
@@ -42,6 +50,7 @@ const structuredData = createDocsArticleStructuredData({
   next={next}
   markdownHref={`/docs/${entry.id}.md`}
   structuredData={structuredData}
+  search={search}
 >
   <Content />
 </DocsLayout>

--- a/apps/www/src/pages/docs/index.astro
+++ b/apps/www/src/pages/docs/index.astro
@@ -2,6 +2,7 @@
 import CodeBlock from '#www/components/CodeBlock.astro';
 import DocsLayout from '#www/layouts/DocsLayout.astro';
 import { createDocsArticleStructuredData } from '#www/lib/structured-data';
+import { createSearchDocument } from '#www/lib/search';
 
 const title = 'Canvas Timeline documentation';
 const description = 'Guides, package notes, interactive demos, and generated references for the Canvas Timeline package family.';
@@ -10,6 +11,13 @@ const structuredData = createDocsArticleStructuredData({
   description,
   url: '/docs',
   keywords: ['Canvas Timeline', 'documentation', 'React timeline editor'],
+});
+const search = createSearchDocument({
+  url: '/docs',
+  title,
+  description,
+  kind: 'docs',
+  tags: ['Canvas Timeline', 'documentation', 'React timeline editor'],
 });
 ---
 
@@ -22,6 +30,7 @@ const structuredData = createDocsArticleStructuredData({
   markdownAriaLabel="Copy the documentation index as Markdown"
   markdownTooltip="Copies a generated Markdown map of docs pages, with links to each page and its Markdown endpoint."
   structuredData={structuredData}
+  search={search}
 >
   <div class="docs-home">
     <section class="docs-home__intro">

--- a/apps/www/src/pages/packages/[slug].astro
+++ b/apps/www/src/pages/packages/[slug].astro
@@ -6,6 +6,7 @@ import { packageDocs, type PackageDoc } from '#www/data/packages';
 import { apiPackageHref } from '#www/lib/api-reference';
 import { inlineProseHtml } from '#www/lib/inline-prose';
 import { createPackageStructuredData } from '#www/lib/structured-data';
+import { createPackageSearchDocument } from '#www/lib/search';
 
 interface Props {
   packageDoc: PackageDoc;
@@ -45,6 +46,7 @@ const seoH1s: Record<string, string> = {
 const seoTitle = seoTitles[packageDoc.slug] || packageDoc.name;
 const seoH1 = seoH1s[packageDoc.slug] || packageDoc.name;
 const structuredData = createPackageStructuredData(packageDoc);
+const search = createPackageSearchDocument(packageDoc);
 ---
 
 <BaseLayout
@@ -56,6 +58,7 @@ const structuredData = createPackageStructuredData(packageDoc);
     { label: packageDoc.shortName },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-12 pb-16 md:pt-16 md:pb-20 border-b border-border">

--- a/apps/www/src/pages/packages/[slug]/api/[symbol].astro
+++ b/apps/www/src/pages/packages/[slug]/api/[symbol].astro
@@ -14,6 +14,7 @@ import {
   type ApiSymbol,
 } from '#www/lib/api-reference';
 import { createApiSymbolArticleStructuredData } from '#www/lib/structured-data';
+import { createApiSymbolSearchDocument } from '#www/lib/search';
 
 interface Props {
   packageDoc: ApiPackage;
@@ -72,6 +73,16 @@ const returnMembersHeading =
 const examplesHeading = resolvedSymbol.examples.length > 0 ? 'Examples' : 'Aliased examples';
 const hexColorPattern = /^#[0-9a-f]{3,8}$/i;
 const structuredData = createApiSymbolArticleStructuredData(packageDoc, resolvedSymbol);
+const search = createApiSymbolSearchDocument({
+  slug: packageDoc.slug,
+  name: packageDoc.name,
+  entryPoint: packageDoc.entryPoint,
+  symbolSlug: resolvedSymbol.slug,
+  symbolName: resolvedSymbol.name,
+  symbolKind: resolvedSymbol.kind,
+  summary: resolvedSymbol.summary,
+  sourcePackage: resolvedSymbol.sourcePackage,
+});
 const timelineStateBreakdown =
   resolvedSymbol.name === 'useTimelineState'
     ? [
@@ -175,6 +186,7 @@ function descriptionHtml(
     { label: resolvedSymbol.name },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-12 pb-16 md:pt-16 md:pb-20 border-b border-border">

--- a/apps/www/src/pages/packages/[slug]/api/index.astro
+++ b/apps/www/src/pages/packages/[slug]/api/index.astro
@@ -4,6 +4,7 @@ import MarkdownCopyButton from '#www/components/MarkdownCopyButton.astro';
 import { groupApiSymbols, groupNameForApiSymbol } from '#www/lib/api-symbol-groups';
 import { apiReference, apiSymbolHref, type ApiPackage } from '#www/lib/api-reference';
 import { createApiPackageArticleStructuredData } from '#www/lib/structured-data';
+import { createApiPackageSearchDocument } from '#www/lib/search';
 
 interface Props {
   packageDoc: ApiPackage;
@@ -55,6 +56,7 @@ const commonEntryPoints = (commonEntryPointNames[packageDoc.slug] ?? [])
   .map((symbolName) => packageDoc.symbols.find((symbol) => symbol.name === symbolName))
   .filter(Boolean) as typeof packageDoc.symbols;
 const structuredData = createApiPackageArticleStructuredData(packageDoc);
+const search = createApiPackageSearchDocument(packageDoc);
 ---
 
 <BaseLayout
@@ -67,6 +69,7 @@ const structuredData = createApiPackageArticleStructuredData(packageDoc);
     { label: 'API' },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-12 pb-16 md:pt-16 md:pb-20 border-b border-border">

--- a/apps/www/src/pages/packages/index.astro
+++ b/apps/www/src/pages/packages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '#www/layouts/BaseLayout.astro';
 import { packageDocs } from '#www/data/packages';
 import { createPackageIndexStructuredData } from '#www/lib/structured-data';
+import { createSearchDocument } from '#www/lib/search';
 
 const corePackages = packageDocs.filter(
   (p) => p.slug !== 'html-media-adapter' && p.slug !== 'mediabunny-adapter'
@@ -10,6 +11,13 @@ const adapterPackages = packageDocs.filter(
   (p) => p.slug === 'html-media-adapter' || p.slug === 'mediabunny-adapter'
 );
 const structuredData = createPackageIndexStructuredData(packageDocs);
+const search = createSearchDocument({
+  url: '/packages',
+  title: 'Canvas Timeline Packages',
+  description: 'Explore the Canvas Timeline package family and focused integration entry points.',
+  kind: 'package',
+  tags: ['Canvas Timeline', 'packages', 'React timeline editor'],
+});
 ---
 
 <BaseLayout
@@ -20,6 +28,7 @@ const structuredData = createPackageIndexStructuredData(packageDocs);
     { label: 'Packages' },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-16 pb-20 md:pt-24 md:pb-28 border-b border-border">

--- a/apps/www/src/pages/packages/react/registry/[slug].astro
+++ b/apps/www/src/pages/packages/react/registry/[slug].astro
@@ -11,6 +11,7 @@ import {
 } from '#www/data/react-registry';
 import { apiPackageHref } from '#www/lib/api-reference';
 import { createReactRegistryStructuredData } from '#www/lib/structured-data';
+import { createRegistrySearchDocument } from '#www/lib/search';
 
 type ReactRegistryDocEntry = CollectionEntry<'reactRegistryDocs'>;
 
@@ -82,6 +83,16 @@ const mdxTocLinks = registryHeadings
   }));
 const tocLinks = [...generatedTocLinks, ...mdxTocLinks];
 const structuredData = createReactRegistryStructuredData(item, pageTitle, pageDescription);
+const search = createRegistrySearchDocument({
+  slug: item.slug,
+  title: pageTitle,
+  name: item.name,
+  description: pageDescription,
+  kind: item.kind,
+  importPath: item.importPath,
+  packageName: item.packageName,
+  search: item.search ?? entry.data.search,
+});
 ---
 
 <BaseLayout
@@ -95,6 +106,7 @@ const structuredData = createReactRegistryStructuredData(item, pageTitle, pageDe
     { label: pageTitle },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <section class="page-band registry-page-band">
     <div class="container-page page-heading">

--- a/apps/www/src/pages/packages/react/registry/index.astro
+++ b/apps/www/src/pages/packages/react/registry/index.astro
@@ -7,8 +7,18 @@ import {
 } from '#www/data/react-registry';
 import PackageManagerTabs from '#www/components/PackageManagerTabs.astro';
 import { createReactRegistryIndexStructuredData } from '#www/lib/structured-data';
+import { createSearchDocument } from '#www/lib/search';
 
 const structuredData = createReactRegistryIndexStructuredData(reactRegistryItems);
+const search = createSearchDocument({
+  url: '/packages/react/registry',
+  title: 'React Timeline Component Registry',
+  description:
+    'Browse Canvas Timeline React components, primitives, interaction layers, and hook bindings.',
+  kind: 'registry',
+  packageSlug: 'react',
+  tags: ['Canvas Timeline', 'React', 'component registry', 'hooks'],
+});
 ---
 
 <BaseLayout
@@ -21,6 +31,7 @@ const structuredData = createReactRegistryIndexStructuredData(reactRegistryItems
     { label: 'Registry' },
   ]}
   structuredData={structuredData}
+  search={search}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-12 pb-16 md:pt-16 md:pb-20 border-b border-border">

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -74,6 +74,17 @@
     'Outfit Variable', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   --font-mono: 'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  --pf-font: var(--font-sans);
+  --pf-text: var(--foreground);
+  --pf-text-secondary: var(--muted-foreground);
+  --pf-text-muted: var(--muted-foreground);
+  --pf-background: var(--background);
+  --pf-border: var(--border);
+  --pf-border-focus: var(--ring);
+  --pf-hover: var(--muted);
+  --pf-mark: var(--foreground);
+  --pf-outline-focus: var(--ring);
+  --pf-modal-max-width: 72rem;
 }
 
 @theme inline {
@@ -327,6 +338,58 @@
     color: var(--muted-foreground);
     text-decoration: none;
     transition: all 0.15s ease;
+  }
+
+  .site-search-trigger {
+    display: inline-flex;
+    min-height: 2.25rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--background);
+    color: var(--muted-foreground);
+    font: inherit;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .site-search-trigger:hover {
+    background: var(--muted);
+    color: var(--foreground);
+  }
+
+  .site-search-modal__content {
+    display: grid;
+    grid-template-columns: minmax(10rem, 13rem) minmax(0, 1fr);
+    gap: 1rem;
+  }
+
+  .site-search-modal__filters {
+    min-width: 0;
+  }
+
+  .site-search-result__heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .site-search-result__kind {
+    flex: 0 0 auto;
+    color: var(--primary);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .site-search-trigger:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
 
   .site-icon-link:hover {
@@ -3632,6 +3695,14 @@ html body .expressive-code pre::-webkit-scrollbar-corner {
 
   .site-nav a {
     padding-inline: 0.35rem;
+  }
+
+  .site-search-trigger {
+    margin-left: auto;
+  }
+
+  .site-search-modal__content {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .breadcrumbs ol {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
+      pagefind:
+        specifier: ^1.5.2
+        version: 1.5.2
       remark-mdx:
         specifier: ^3.1.1
         version: 3.1.1
@@ -2143,6 +2146,41 @@ packages:
   '@oxlint/plugins@1.68.0':
     resolution: {integrity: sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -4179,6 +4217,10 @@ packages:
 
   package-manager-detector@1.7.0:
     resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6708,6 +6750,27 @@ snapshots:
 
   '@oxlint/plugins@1.68.0': {}
 
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -9187,6 +9250,16 @@ snapshots:
       quansync: 0.2.11
 
   package-manager-detector@1.7.0: {}
+
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
 
   parent-module@1.0.1:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -117,6 +117,18 @@ export default defineConfig({
         cache: false,
         dependsOn: ['build:www:verify-full-editor-demo'],
       },
+      'build:www:search': {
+        command: 'vp run docs:search',
+        cwd: 'apps/www',
+        dependsOn: ['build:www:astro'],
+        input: [
+          'apps/www/dist/client/**/*.html',
+          'apps/www/scripts/generate/search-catalog.ts',
+          'apps/www/scripts/verify/search-build.mjs',
+          'apps/www/src/lib/search.ts',
+        ],
+        output: ['apps/www/.generated/search-catalog.json', 'apps/www/dist/client/pagefind/**'],
+      },
       'build:www:astro': {
         command: 'vp exec astro build',
         cache: false,
@@ -134,7 +146,7 @@ export default defineConfig({
       'build:www:verify-full-editor-demo': {
         command: 'vp run docs:editor:verify',
         cwd: 'apps/www',
-        dependsOn: ['build:www:astro'],
+        dependsOn: ['build:www:search'],
         input: [
           'apps/www/dist/client/demos/full-editor-demo/index.html',
           'apps/www/dist/client/demos/full-editor-demo/assets/**',


### PR DESCRIPTION
## Summary

- Add source-driven Pagefind metadata for docs, blog posts, packages, demos, registry pages, and generated API symbols.
- Add a global keyboard-accessible search modal with type filters, editorial keywords/priority/exclude controls, and API-aware weighting.
- Validate the generated catalog and deployed Pagefind bundle during the docs build.

## Release Impact

- Packages/API: None.
- Docs/demos: Adds global static search across public structured docs content.
- Breaking changes: None.
- Release risk: Low; the bundle is generated in `dist/client/pagefind` and verified post-build.

## Validation

- `vp run repo:check`
- `vp run build:www:search`
- `vp test run apps/www/src/lib/search.test.ts`
- Browser smoke test: ⌘K opens search, type filters render, and `quickstart` returns Getting Started.

## Checklist

- [x] I added a changeset or an empty changeset.
- [x] I checked package/API impact.
- [x] I checked docs/demo impact.
- [x] I called out breaking changes, if any.