### PR TITLE
fix(config): remove local path references

### DIFF
--- a/.agents/skills/canvas-timeline-general/SKILL.md
+++ b/.agents/skills/canvas-timeline-general/SKILL.md
@@ -7,9 +7,9 @@ description: Orient before engineering, refactoring, or testing in the Canvas Ti
 
 ## Quick Start Procedure
 
-- [ ] **Check Scope**: Use [manage-live-demos](file:///Users/techsquidtv/Documents/Git/canvas-timeline/.agents/skills/manage-live-demos/SKILL.md) instead if editing `apps/www/src/demos` or demo registries.
+- [ ] **Check Scope**: Use [manage-live-demos](../manage-live-demos/SKILL.md) instead if editing `apps/www/src/demos` or demo registries.
 - [ ] **Locate Package**: Ensure changes reside in the lowest appropriate boundary (see map below).
-- [ ] **Docs**: Read [architecture.mdx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/architecture.mdx) for architecture and [styling.mdx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/styling.mdx) for styling.
+- [ ] **Docs**: Read [architecture.mdx](../../../apps/www/src/content/docs/architecture.mdx) for architecture and [styling.mdx](../../../apps/www/src/content/docs/styling.mdx) for styling.
 
 ---
 
@@ -25,8 +25,8 @@ To maintain a responsive 60fps editor, rendering and interaction are split stric
 
 ### React & CSS Layer (Low-Density / DOM chrome)
 
-- **Responsibility**: Manages viewport structure, scrollbars, playhead grabbers, in/out grabbers, active focus rings, and the [ClipInteractionLayer.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/interactions/ClipInteractionLayer.tsx).
-- **Clip Hit-Testing**: Rather than mounting a React/DOM subtree for every clip, [ClipInteractionLayer.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/interactions/ClipInteractionLayer.tsx) uses engine hit testing to overlay **a single, delegated active affordance** for the clip currently hovered or edited.
+- **Responsibility**: Manages viewport structure, scrollbars, playhead grabbers, in/out grabbers, active focus rings, and the [ClipInteractionLayer.tsx](../../../packages/react/src/components/interactions/ClipInteractionLayer.tsx).
+- **Clip Hit-Testing**: Rather than mounting a React/DOM subtree for every clip, [ClipInteractionLayer.tsx](../../../packages/react/src/components/interactions/ClipInteractionLayer.tsx) uses engine hit testing to overlay **a single, delegated active affordance** for the clip currently hovered or edited.
 - **Pointer Capture**: Use pointer capture on pointer-down events for drag/trim interactions to bypass window-level fallback listeners.
 
 ### Decoupled Application Metadata
@@ -39,13 +39,13 @@ To maintain a responsive 60fps editor, rendering and interaction are split stric
 
 ## Gotchas & Invariants
 
-- **RationalTime**: All times must be `RationalTime` objects, **not decimal seconds**. Convert only at outer UI edges via [packages/utils](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/utils).
+- **RationalTime**: All times must be `RationalTime` objects, **not decimal seconds**. Convert only at outer UI edges via [packages/utils](../../../packages/utils).
 - **Stable IDs**: Track and clip IDs must be stable strings. **Do not use array indices** (causes edits, history, and undo glitches).
 - **Sort Order**: Clips must stay sorted by `timelineStart`.
 - **No Per-Frame React State**: Do not map high-frequency ticks (render/playhead events) to React state. Use refs or direct DOM manipulations.
 - **DOM-Free Worker**: Renderer/worker modules must be completely DOM-free. Read CSS variables on the main thread inside `CanvasRenderer` theme resolution and post serializable options to the worker.
 - **Theme Resolution Performance**: Resolve CSS variables only when the theme changes (using a stable `themeKey` like `'light'`, `'dark'`), **never** during scrolling, scrubbing, zooming, playback, or drawing frames.
-- **CSS Geometry**: Structural geometry or hit-testing CSS rules must go in [base.css](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/base.css), never in demo or docs CSS.
+- **CSS Geometry**: Structural geometry or hit-testing CSS rules must go in [base.css](../../../packages/react/src/base.css), never in demo or docs CSS.
 
 ---
 
@@ -53,26 +53,26 @@ To maintain a responsive 60fps editor, rendering and interaction are split stric
 
 ### Publishable Packages
 
-- [packages/utils](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/utils): rational time, timecode, and shared math utilities. Keep it dependency-light and framework-free.
-- [packages/core](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core): framework-free timeline model, state (`TimelineState`, `Track`, `Clip`, `Marker`), playback, history, clipboard, snapping, hit testing, and edit commands.
-- [packages/react](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react): React provider/context, hooks, DOM interaction components, scrollbars, timecode controls, range scrollbar, base styles, and docs metadata exports.
-- [packages/renderer](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer): canvas renderer, worker-backed drawing loop, renderer theme resolution, and draw modules.
-- [packages/html-media-adapter](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/html-media-adapter): HTMLMediaElement sync adapter and React helper hooks for media playback.
-- [packages/mediabunny-adapter](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/mediabunny-adapter): Mediabunny frame/media adapter plus optional React helpers under the `./react` export.
-- [packages/timeline](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/timeline): batteries-included aggregate package. Prefer re-exports and package-level style copies here instead of new behavior.
+- [packages/utils](../../../packages/utils): rational time, timecode, and shared math utilities. Keep it dependency-light and framework-free.
+- [packages/core](../../../packages/core): framework-free timeline model, state (`TimelineState`, `Track`, `Clip`, `Marker`), playback, history, clipboard, snapping, hit testing, and edit commands.
+- [packages/react](../../../packages/react): React provider/context, hooks, DOM interaction components, scrollbars, timecode controls, range scrollbar, base styles, and docs metadata exports.
+- [packages/renderer](../../../packages/renderer): canvas renderer, worker-backed drawing loop, renderer theme resolution, and draw modules.
+- [packages/html-media-adapter](../../../packages/html-media-adapter): HTMLMediaElement sync adapter and React helper hooks for media playback.
+- [packages/mediabunny-adapter](../../../packages/mediabunny-adapter): Mediabunny frame/media adapter plus optional React helpers under the `./react` export.
+- [packages/timeline](../../../packages/timeline): batteries-included aggregate package. Prefer re-exports and package-level style copies here instead of new behavior.
 
 ### Applications & Documentation
 
-- [apps/www](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www): Astro docs site, source-backed demos, blog/docs content, API reference generation, React registry snippets, Open Graph images, and the primary QA playground.
-- [apps/www/src/demos](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/demos): executable demo sources. Use [manage-live-demos](file:///Users/techsquidtv/Documents/Git/canvas-timeline/.agents/skills/manage-live-demos/SKILL.md) for demo or registry work.
-- [.github](file:///Users/techsquidtv/Documents/Git/canvas-timeline/.github): contributor docs, Dependabot, and GitHub Actions workflows.
-- [.agents/skills](file:///Users/techsquidtv/Documents/Git/canvas-timeline/.agents/skills): repo-local Codex skills. Keep maps and validation commands synchronized with source moves.
+- [apps/www](../../../apps/www): Astro docs site, source-backed demos, blog/docs content, API reference generation, React registry snippets, Open Graph images, and the primary QA playground.
+- [apps/www/src/demos](../../../apps/www/src/demos): executable demo sources. Use [manage-live-demos](../manage-live-demos/SKILL.md) for demo or registry work.
+- [.github](../../../.github): contributor docs, Dependabot, and GitHub Actions workflows.
+- [.agents/skills](../../../.agents/skills): repo-local Codex skills. Keep maps and validation commands synchronized with source moves.
 
 ### Repository Tooling
 
-- [vite.config.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/vite.config.ts): Vite+ workspace config, aliases, staged formatting, repo tasks, and Oxlint rules.
-- [scripts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/scripts): repository validators and docs/package verification scripts.
-- [tools](file:///Users/techsquidtv/Documents/Git/canvas-timeline/tools): local tooling extensions, including custom Oxlint rules.
+- [vite.config.ts](../../../vite.config.ts): Vite+ workspace config, aliases, staged formatting, repo tasks, and Oxlint rules.
+- [scripts](../../../scripts): repository validators and docs/package verification scripts.
+- [tools](../../../tools): local tooling extensions, including custom Oxlint rules.
 - Generated outputs such as `dist`, `.astro`, `.generated`, `.wrangler`, `coverage`, and `node_modules` are build artifacts, not source boundaries.
 
 Before moving docs demo code into `packages/react`, distinguish reusable timeline
@@ -85,15 +85,15 @@ into `packages/core` or `packages/renderer`.
 
 ## Source Hotspots
 
-- **Core**: [index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/index.ts) | [types.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/types.ts) | [engine.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/engine.ts) | [playback.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/playback.ts) | [history.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/history.ts)
-- **React Components**: [components](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components) is split into `controls`, `interactions`, `playhead`, `scrollbars`, `surface`, and `tracks`.
-- **React Hooks**: [hooks](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/hooks) is split into `clips`, `core`, `editing`, `keyframes`, `markers`, `playback`, `selection`, `tracks`, and `viewport`; public exports flow through [hooks/index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/hooks/index.ts).
-- **React Exports & Styles**: [index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/index.ts) | [components/index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/index.ts) | [base.css](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/base.css) | [theme.css](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/theme.css) | [docs-metadata.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/docs-metadata.ts)
-- **Renderer**: [index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/index.ts) | [CanvasRenderer.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/CanvasRenderer.tsx) | [renderTimeline.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/renderTimeline.ts) | [theme.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/theme.ts) | [worker.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/worker.ts)
-- **Drawers**: [clips.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/render/clips.ts) | [tracks.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/render/tracks.ts) | [ruler.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/render/ruler.ts)
-- **Adapters**: [html-media-adapter/src/index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/html-media-adapter/src/index.ts) | [mediabunny-adapter/src/index.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/mediabunny-adapter/src/index.ts) | [mediabunny-adapter/src/react.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/mediabunny-adapter/src/react.ts)
-- **Docs Site**: [content/docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs) | [demos](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/demos) | [data/react-registry.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/data/react-registry.ts) | [scripts/generate/api-reference.mjs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/scripts/generate/api-reference.mjs)
-- **Quality Gates**: [repository-policy.mjs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/scripts/checks/repository-policy.mjs) | [react-registry.mjs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/scripts/checks/react-registry.mjs) | [oxlint-plugin](file:///Users/techsquidtv/Documents/Git/canvas-timeline/tools/oxlint-plugin/index.mjs)
+- **Core**: [index.ts](../../../packages/core/src/index.ts) | [types.ts](../../../packages/core/src/types.ts) | [engine.ts](../../../packages/core/src/engine.ts) | [playback.ts](../../../packages/core/src/playback.ts) | [history.ts](../../../packages/core/src/history.ts)
+- **React Components**: [components](../../../packages/react/src/components) is split into `controls`, `interactions`, `playhead`, `scrollbars`, `surface`, and `tracks`.
+- **React Hooks**: [hooks](../../../packages/react/src/hooks) is split into `clips`, `core`, `editing`, `keyframes`, `markers`, `playback`, `selection`, `tracks`, and `viewport`; public exports flow through [hooks/index.ts](../../../packages/react/src/hooks/index.ts).
+- **React Exports & Styles**: [index.ts](../../../packages/react/src/index.ts) | [components/index.ts](../../../packages/react/src/components/index.ts) | [base.css](../../../packages/react/src/base.css) | [theme.css](../../../packages/react/src/theme.css)
+- **Renderer**: [index.ts](../../../packages/renderer/src/index.ts) | [CanvasRenderer.tsx](../../../packages/renderer/src/CanvasRenderer.tsx) | [renderTimeline.ts](../../../packages/renderer/src/renderTimeline.ts) | [theme.ts](../../../packages/renderer/src/theme.ts) | [worker.ts](../../../packages/renderer/src/worker.ts)
+- **Drawers**: [clips.ts](../../../packages/renderer/src/render/clips.ts) | [tracks.ts](../../../packages/renderer/src/render/tracks.ts) | [ruler.ts](../../../packages/renderer/src/render/ruler.ts)
+- **Adapters**: [html-media-adapter/src/index.ts](../../../packages/html-media-adapter/src/index.ts) | [mediabunny-adapter/src/index.ts](../../../packages/mediabunny-adapter/src/index.ts) | [mediabunny-adapter/src/react.ts](../../../packages/mediabunny-adapter/src/react.ts)
+- **Docs Site**: [content/docs](../../../apps/www/src/content/docs) | [demos](../../../apps/www/src/demos) | [data/react-registry.ts](../../../apps/www/src/data/react-registry.ts) | [scripts/generate/api-reference.mjs](../../../apps/www/scripts/generate/api-reference.mjs)
+- **Quality Gates**: [repository-policy.mjs](../../../scripts/checks/repository-policy.mjs) | [react-registry.mjs](../../../scripts/checks/react-registry.mjs) | [oxlint-plugin](../../../tools/oxlint-plugin/index.mjs)
 
 ---
 
@@ -101,8 +101,8 @@ into `packages/core` or `packages/renderer`.
 
 Run unit tests relative to your change, then verify overall status with `vp run repo:check`.
 
-- **Core Engine**: [engine.test.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/core/src/engine.test.ts)
-- **Hooks**: [integration tests](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/hooks/integration) are split into editing, keyframe, media, and state suites with shared typed fixtures.
-- **Interactions**: [ClipInteractionLayer.test.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/interactions/ClipInteractionLayer.test.tsx) | [tapBehavior.test.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/playhead/tapBehavior.test.tsx)
-- **Scrollbars**: [ViewportScrollbar.test.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components/scrollbars/ViewportScrollbar.test.tsx) | [RangeScrollbar.test.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/rangeScrollbar/RangeScrollbar.test.tsx)
-- **Renderer & Theme**: [CanvasRenderer.test.tsx](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/CanvasRenderer.test.tsx) | [renderTimeline.test.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/renderTimeline.test.ts) | [theme.test.ts](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/theme.test.ts)
+- **Core Engine**: [engine.test.ts](../../../packages/core/src/engine.test.ts)
+- **Hooks**: [integration tests](../../../packages/react/src/hooks/integration) are split into editing, keyframe, media, and state suites with shared typed fixtures.
+- **Interactions**: [ClipInteractionLayer.test.tsx](../../../packages/react/src/components/interactions/ClipInteractionLayer.test.tsx) | [tapBehavior.test.tsx](../../../packages/react/src/components/playhead/tapBehavior.test.tsx)
+- **Scrollbars**: [ViewportScrollbar.test.tsx](../../../packages/react/src/components/scrollbars/ViewportScrollbar.test.tsx) | [RangeScrollbar.test.tsx](../../../packages/react/src/rangeScrollbar/RangeScrollbar.test.tsx)
+- **Renderer & Theme**: [CanvasRenderer.test.tsx](../../../packages/renderer/src/CanvasRenderer.test.tsx) | [renderTimeline.test.ts](../../../packages/renderer/src/renderTimeline.test.ts) | [theme.test.ts](../../../packages/renderer/src/theme.test.ts)

--- a/.agents/skills/canvas-timeline-pr/SKILL.md
+++ b/.agents/skills/canvas-timeline-pr/SKILL.md
@@ -11,9 +11,8 @@ Create PRs that are easy to merge and easy to audit against the public release
 bar. Keep the release-impact analysis in the PR body concise, concrete, and tied
 to the files that changed.
 
-Use [git-workflow](file:///Users/techsquidtv/.codex/skills/git-workflow/SKILL.md)
-for generic Git mechanics: status inspection, staging, commit naming, pushing,
-and avoiding duplicate PRs.
+Use the available `git-workflow` skill for generic Git mechanics: status
+inspection, staging, commit naming, pushing, and avoiding duplicate PRs.
 
 ## PR Preparation Workflow
 

--- a/.agents/skills/canvas-timeline-react-headless-hooks/SKILL.md
+++ b/.agents/skills/canvas-timeline-react-headless-hooks/SKILL.md
@@ -13,11 +13,11 @@ without making the hook depend on visual implementation details.
 
 Before editing hook APIs, inspect:
 
-- [React hooks](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/hooks)
-- [React component chrome](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/components)
-- [Provider](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/Provider.tsx)
-- [System architecture docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/architecture.mdx)
-- [React editor hooks docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/react-hooks.mdx)
+- [React hooks](../../../packages/react/src/hooks)
+- [React component chrome](../../../packages/react/src/components)
+- [Provider](../../../packages/react/src/Provider.tsx)
+- [System architecture docs](../../../apps/www/src/content/docs/architecture.mdx)
+- [React editor hooks docs](../../../apps/www/src/content/docs/react-hooks.mdx)
 
 ## Hook Shape
 

--- a/.agents/skills/canvas-timeline-styling-contract/SKILL.md
+++ b/.agents/skills/canvas-timeline-styling-contract/SKILL.md
@@ -28,14 +28,14 @@ timeline behavior.
 
 Open the relevant source before changing behavior:
 
-- [Styling docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/styling.mdx) for the public styling contract.
-- [Canvas renderer customization docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/renderer-customization.mdx) for renderer styling overrides and custom dense layers.
-- [System architecture docs](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/content/docs/architecture.mdx) for the DOM/canvas architecture split.
-- [React base CSS](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/base.css) for mechanics, geometry, hit targets, and affordance shapes.
-- [React theme CSS](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/theme.css) for shadcn-token visual treatment and `--timeline-*` aliases.
-- [Renderer theme resolver](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/theme.ts) and [CanvasRenderer](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/renderer/src/CanvasRenderer.tsx) for CSS-variable-to-worker behavior.
-- [CSS export tests](file:///Users/techsquidtv/Documents/Git/canvas-timeline/packages/react/src/styles-exports.test.ts) for guardrails around package CSS and docs drift.
-- [React DOM timeline demo](file:///Users/techsquidtv/Documents/Git/canvas-timeline/apps/www/src/demos/react-dom-timeline/ReactDOMTimeline.tsx) for DOM implementation parity.
+- [Styling docs](../../../apps/www/src/content/docs/styling.mdx) for the public styling contract.
+- [Canvas renderer customization docs](../../../apps/www/src/content/docs/renderer-customization.mdx) for renderer styling overrides and custom dense layers.
+- [System architecture docs](../../../apps/www/src/content/docs/architecture.mdx) for the DOM/canvas architecture split.
+- [React base CSS](../../../packages/react/src/base.css) for mechanics, geometry, hit targets, and affordance shapes.
+- [React theme CSS](../../../packages/react/src/theme.css) for shadcn-token visual treatment and `--timeline-*` aliases.
+- [Renderer theme resolver](../../../packages/renderer/src/theme.ts) and [CanvasRenderer](../../../packages/renderer/src/CanvasRenderer.tsx) for CSS-variable-to-worker behavior.
+- [CSS export tests](../../../packages/react/src/styles-exports.test.ts) for guardrails around package CSS and docs drift.
+- [React DOM timeline demo](../../../apps/www/src/demos/react-dom-timeline/ReactDOMTimeline.tsx) for DOM implementation parity.
 
 ## DOM vs Canvas Boundary
 

--- a/scripts/checks/repository-policy.mjs
+++ b/scripts/checks/repository-policy.mjs
@@ -5,9 +5,10 @@ import ts from 'typescript';
 
 const repoRootUrl = new URL('../../', import.meta.url);
 const repoRootPath = fileURLToPath(repoRootUrl);
-const localPathPattern = /(['"`])\/(?:Users|home)\//;
+const localPathPattern = /(?:file:\/\/\/|\/(?:Users|home)\/[^/\s]+\/|[a-z]:\\Users\\[^\\\s]+\\)/i;
 const sourceFilePattern = /\.(?:cjs|cts|js|jsx|mjs|mts|ts|tsx)$/;
 const contentImportFilePattern = /\.(?:astro|mdx)$/;
+const skillFilePattern = /^\.agents\/skills\/.*\/SKILL\.md$/;
 const relativeContentImportPattern =
   /^\s*import(?:\s+[\s\S]*?\s+from)?\s+['"](?<specifier>\.{1,2}\/[^'"]+)['"]/gm;
 const hookFilePattern = /\.(?:cts|mts|ts|tsx)$/;
@@ -75,13 +76,21 @@ const failures = [];
 checkRemovedPublicApiGuards();
 
 for (const file of files) {
-  if (!sourceFilePattern.test(file) && !contentImportFilePattern.test(file)) {
+  if (
+    !sourceFilePattern.test(file) &&
+    !contentImportFilePattern.test(file) &&
+    !skillFilePattern.test(file)
+  ) {
     continue;
   }
 
   const sourceText = readFileSync(resolveRepoFile(file), 'utf8');
   if (localPathPattern.test(sourceText)) {
     failures.push(`${file}: contains a hardcoded local absolute path`);
+  }
+
+  if (skillFilePattern.test(file)) {
+    continue;
   }
 
   if (contentImportFilePattern.test(file)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -162,6 +162,7 @@ export default defineConfig({
       'custom:rules': {
         command: 'node scripts/checks/repository-policy.mjs',
         input: [
+          '.agents/skills/**',
           '.github/**',
           'apps/www/src/**/*.astro',
           'apps/www/src/**/*.mdx',


### PR DESCRIPTION
## Summary

- Replace machine-specific skill links with portable relative links.
- Reject local home-directory and file-URI paths in the repository policy check.
- Include repo skill changes in the policy-check inputs.

## Release Impact

- Packages/API: None.
- Docs/demos: None.
- Breaking changes: None.
- Release risk: None; configuration and contributor tooling only.

## Validation

- `vp run custom:rules`
- Focused formatting check
- Skill metadata and relative-link validation

`vp run repo:check` could not complete in the clean worktree because TypeDoc exited without diagnostic output during API generation.