### PR TITLE
refactor!: streamline timeline state and command APIs

### DIFF
--- a/.changeset/simplify-library-state-and-commands.md
+++ b/.changeset/simplify-library-state-and-commands.md
@@ -1,0 +1,10 @@
+---
+'@techsquidtv/canvas-timeline-core': minor
+'@techsquidtv/canvas-timeline-react': minor
+---
+
+Share unchanged track and clip snapshots across Core, history, and React. Track-row hooks share geometry and avoid unrelated collection subscriptions. Export `useTimelineSelector` for primitive and object selections with configurable equality, without subscribing to per-frame playback.
+
+**BREAKING:** React state and document-derived hook values are readonly. Use engine commands for edits instead of mutating returned snapshots. Core track commands, clip selection commands, and `updateClipProperties` now return `TimelineCommandResult` instead of void or booleans; check `result.ok`. React selection commands use the same contract. Missing selection IDs return `not-found` without changing the current selection, invalid track input returns `invalid-input`, and duplicate track/clip IDs are rejected. There are no compatibility aliases.
+
+Track commands validate current Core state, so consecutive commands in one handler work before React renders. Public examples use package imports and representative TSDoc examples compile against packed packages. Focused unit tests no longer generate API documentation.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,6 +70,12 @@ vp run package:check
 coverage, docs/app build, and package validation against the built package
 output.
 
+Focused package tests run in the `unit` test project without generating API
+documentation. The `docs` test project generates its required API catalog using
+the cached `docs:api` task. A plain `vp test` still runs both projects. Packed
+consumer validation also compiles representative TSDoc examples using published
+imports, without workspace aliases.
+
 `vp run package:check` performs a clean publishable package build, then validates
 packed package metadata with `publint`, Are The Types Wrong, and the packed
 tarball consumer smoke test. Use `vp run package:validate` only when package

--- a/apps/full-editor-demo/src/features/export/timeline-export-plan.ts
+++ b/apps/full-editor-demo/src/features/export/timeline-export-plan.ts
@@ -1,4 +1,4 @@
-import type { Track } from '@techsquidtv/canvas-timeline-core';
+import type { Track, TimelineReadonly } from '@techsquidtv/canvas-timeline-core';
 import { compareRational, toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import type { SourceBinSource } from '#full-editor/features/source-bin/types';
 import type { EditorTrackKind } from '#full-editor/features/project/demo-project';
@@ -57,7 +57,7 @@ function collectSegments(options: {
   issues: TimelineExportValidationIssue[];
   kind: EditorTrackKind;
   sourceById: ReadonlyMap<string, SourceBinSource>;
-  tracks: readonly Track[];
+  tracks: readonly TimelineReadonly<Track>[];
 }) {
   const segments: TimelineExportSegment[] = [];
   const tracks = options.tracks.filter((track) => shouldExportTrack(track, options.kind));
@@ -107,7 +107,10 @@ function isExportableSource(source: SourceBinSource): source is SourceBinSource 
   return source.status === 'ready' && source.file !== null;
 }
 
-function shouldExportTrack(track: Track, kind: EditorTrackKind): track is Track<EditorTrackKind> {
+function shouldExportTrack(
+  track: TimelineReadonly<Track>,
+  kind: EditorTrackKind
+): track is TimelineReadonly<Track<EditorTrackKind>> {
   if (track.kind !== kind || track.muted === true) {
     return false;
   }

--- a/apps/full-editor-demo/src/features/export/timeline-export-types.ts
+++ b/apps/full-editor-demo/src/features/export/timeline-export-types.ts
@@ -1,4 +1,9 @@
-import type { Clip, TimelineState, Track } from '@techsquidtv/canvas-timeline-core';
+import type {
+  Clip,
+  TimelineStateSnapshot,
+  Track,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import type { VideoResolutionPresetId } from '#full-editor/features/project/video-settings';
 import type { EditorTrackKind } from '#full-editor/features/project/demo-project';
 import type { SourceBinSource } from '#full-editor/features/source-bin/types';
@@ -23,16 +28,16 @@ export interface TimelineExportProfile {
 export interface TimelineExportPlanInput {
   profile: TimelineExportProfile;
   sources: readonly SourceBinSource[];
-  state: TimelineState;
+  state: TimelineStateSnapshot;
 }
 
 export interface TimelineExportSegment {
-  clip: Clip;
+  clip: TimelineReadonly<Clip>;
   endSeconds: number;
   source: SourceBinSource & { file: File };
   sourceStartSeconds: number;
   startSeconds: number;
-  track: Track<EditorTrackKind>;
+  track: TimelineReadonly<Track<EditorTrackKind>>;
 }
 
 export interface TimelineExportPlan {

--- a/apps/full-editor-demo/src/features/project/demo-project.ts
+++ b/apps/full-editor-demo/src/features/project/demo-project.ts
@@ -1,4 +1,4 @@
-import type { Marker, Track } from '@techsquidtv/canvas-timeline-core';
+import type { Marker, Track, TimelineReadonly } from '@techsquidtv/canvas-timeline-core';
 export type EditorTrackKind = 'audio' | 'visual';
 
 export const demoProject = {
@@ -40,6 +40,8 @@ export const timelineTracks: Track<EditorTrackKind>[] = [
   },
 ];
 
-export function isEditorTrack(track: Track): track is Track<EditorTrackKind> {
+export function isEditorTrack(
+  track: TimelineReadonly<Track>
+): track is TimelineReadonly<Track<EditorTrackKind>> {
   return track.kind === 'audio' || track.kind === 'visual';
 }

--- a/apps/full-editor-demo/src/features/timeline/TimelineSourceDropFeedback.tsx
+++ b/apps/full-editor-demo/src/features/timeline/TimelineSourceDropFeedback.tsx
@@ -1,4 +1,8 @@
-import { defaultTimelineInteractionGeometry, type Track } from '@techsquidtv/canvas-timeline-core';
+import {
+  defaultTimelineInteractionGeometry,
+  type Track,
+  type TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import {
   useTimelineScrollLeft,
   useTimelineScrollTop,
@@ -17,9 +21,9 @@ import type {
 interface TimelineSourceDropFeedbackProps {
   dropMode: TimelineSourceDropMode;
   dropTime: RationalTime | null;
-  hoveredTrack: Track<EditorTrackKind> | null;
+  hoveredTrack: TimelineReadonly<Track<EditorTrackKind>> | null;
   patch: SourceDropPatch | null;
-  tracks: readonly Track<EditorTrackKind>[];
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[];
   valid: boolean;
 }
 
@@ -42,7 +46,7 @@ export function TimelineSourceDropFeedback({
   const dropLeft = toSeconds(dropTime) * zoomScale - scrollLeft;
   const width = Math.max(8, patch.durationSeconds * zoomScale);
   const previewTracks = [patch.visualTrack, patch.audioTrack].filter(
-    (track): track is Track<EditorTrackKind> => track !== undefined
+    (track): track is TimelineReadonly<Track<EditorTrackKind>> => track !== undefined
   );
 
   return (
@@ -74,7 +78,7 @@ export function TimelineSourceDropFeedback({
 
 function getTrackTop(
   trackId: string,
-  tracks: readonly Track<EditorTrackKind>[],
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[],
   scrollTop: number
 ) {
   let top = defaultTimelineInteractionGeometry.rulerHeight - scrollTop;
@@ -89,7 +93,7 @@ function getTrackTop(
   return top;
 }
 
-function getTrackHeight(track: Track<EditorTrackKind>) {
+function getTrackHeight(track: TimelineReadonly<Track<EditorTrackKind>>) {
   return track.collapsed
     ? defaultTimelineInteractionGeometry.collapsedTrackHeight
     : (track.height ?? defaultTimelineInteractionGeometry.trackHeight);

--- a/apps/full-editor-demo/src/features/timeline/source-drop-placement.ts
+++ b/apps/full-editor-demo/src/features/timeline/source-drop-placement.ts
@@ -1,4 +1,8 @@
-import type { TimelineClipGroupPlacement, Track } from '@techsquidtv/canvas-timeline-core';
+import type {
+  TimelineClipGroupPlacement,
+  Track,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import type { EditorTrackKind } from '#full-editor/features/project/demo-project';
 import type { MediaLibrarySource } from '#full-editor/features/media/library/media-library-types';
@@ -14,9 +18,9 @@ export type SourceDropRejectReason =
   | 'unsupported-source';
 
 interface SourceDropTrackResolution {
-  audioTrack?: Track<EditorTrackKind>;
+  audioTrack?: TimelineReadonly<Track<EditorTrackKind>>;
   reason?: SourceDropRejectReason;
-  visualTrack?: Track<EditorTrackKind>;
+  visualTrack?: TimelineReadonly<Track<EditorTrackKind>>;
 }
 
 export interface SourceDropPatch extends SourceDropTrackResolution {
@@ -27,8 +31,8 @@ export interface SourceDropPatch extends SourceDropTrackResolution {
 export interface CreateSourceDropPlacementsOptions {
   source: MediaLibrarySource;
   startTime: RationalTime;
-  targetTrack: Track<EditorTrackKind>;
-  tracks: readonly Track<EditorTrackKind>[];
+  targetTrack: TimelineReadonly<Track<EditorTrackKind>>;
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[];
 }
 
 export function canCreateSourceDropPlacements(options: CreateSourceDropPlacementsOptions) {
@@ -120,8 +124,8 @@ export function resolveSourceDropPatch({
 }
 
 function resolveLinkedAudioVideoDrop(
-  targetTrack: Track<EditorTrackKind>,
-  tracks: readonly Track<EditorTrackKind>[]
+  targetTrack: TimelineReadonly<Track<EditorTrackKind>>,
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[]
 ): SourceDropTrackResolution {
   const targetTrackIndex = tracks.findIndex((track) => track.id === targetTrack.id);
 
@@ -139,10 +143,10 @@ function resolveLinkedAudioVideoDrop(
 }
 
 function findCompanionTrack(
-  tracks: readonly Track<EditorTrackKind>[],
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[],
   kind: EditorTrackKind,
   targetTrackIndex: number
-): Track<EditorTrackKind> | undefined {
+): TimelineReadonly<Track<EditorTrackKind>> | undefined {
   return (
     tracks.find((track) => track.kind === kind && !track.locked && track.targeted) ??
     findNearestUnlockedTrack(tracks, kind, targetTrackIndex)
@@ -150,10 +154,10 @@ function findCompanionTrack(
 }
 
 function findNearestUnlockedTrack(
-  tracks: readonly Track<EditorTrackKind>[],
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[],
   kind: EditorTrackKind,
   targetTrackIndex: number
-): Track<EditorTrackKind> | undefined {
+): TimelineReadonly<Track<EditorTrackKind>> | undefined {
   const compatibleTracks = tracks
     .map((track, index) => ({ index, track }))
     .filter(({ track }) => track.kind === kind && !track.locked);

--- a/apps/full-editor-demo/src/features/timeline/source-usage.ts
+++ b/apps/full-editor-demo/src/features/timeline/source-usage.ts
@@ -1,7 +1,9 @@
-import type { Track } from '@techsquidtv/canvas-timeline-core';
+import type { Track, TimelineReadonly } from '@techsquidtv/canvas-timeline-core';
 import type { EditorTrackKind } from '#full-editor/features/project/demo-project';
 
-export function countTimelineSourceUsage(tracks: readonly Track<EditorTrackKind>[]) {
+export function countTimelineSourceUsage(
+  tracks: readonly TimelineReadonly<Track<EditorTrackKind>>[]
+) {
   const usageCounts = new Map<string, number>();
 
   for (const track of tracks) {

--- a/apps/full-editor-demo/src/infrastructure/persistence/project/timeline-state-persistence.ts
+++ b/apps/full-editor-demo/src/infrastructure/persistence/project/timeline-state-persistence.ts
@@ -1,10 +1,16 @@
-import type { Clip, Marker, TimelineClipGroup, Track } from '@techsquidtv/canvas-timeline-core';
+import type {
+  Clip,
+  Marker,
+  TimelineClipGroup,
+  Track,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import type { EditorTrackKind } from '#full-editor/features/project/demo-project';
 import type { PersistedTimelineState } from '#full-editor/infrastructure/persistence/project/types';
 
 export function sanitizePersistedTimelineState(
-  state: PersistedTimelineState
+  state: TimelineReadonly<PersistedTimelineState>
 ): PersistedTimelineState {
   return {
     clipGroups: state.clipGroups.map(cloneClipGroup),
@@ -22,7 +28,7 @@ export function sanitizePersistedTimelineState(
   };
 }
 
-function cloneTrack(track: Track): Track<EditorTrackKind> {
+function cloneTrack(track: TimelineReadonly<Track>): Track<EditorTrackKind> {
   return {
     ...track,
     kind: track.kind as EditorTrackKind,
@@ -30,7 +36,7 @@ function cloneTrack(track: Track): Track<EditorTrackKind> {
   };
 }
 
-function cloneClip(clip: Clip): Clip {
+function cloneClip(clip: TimelineReadonly<Clip>): Clip {
   const { editPreview: _editPreview, ...rest } = clip;
 
   return {
@@ -46,14 +52,14 @@ function cloneClip(clip: Clip): Clip {
   };
 }
 
-function cloneClipGroup(group: TimelineClipGroup): TimelineClipGroup {
+function cloneClipGroup(group: TimelineReadonly<TimelineClipGroup>): TimelineClipGroup {
   return {
     ...group,
     clipIds: [...group.clipIds],
   };
 }
 
-function cloneMarker(marker: Marker): Marker {
+function cloneMarker(marker: TimelineReadonly<Marker>): Marker {
   return {
     ...marker,
     time: cloneRationalTime(marker.time),

--- a/apps/www/scripts/generate/api-reference.mjs
+++ b/apps/www/scripts/generate/api-reference.mjs
@@ -22,6 +22,7 @@ const externalSymbolLinkMappings = {
     TimelineLayerSyncDetails: '/packages/core/api/timeline-layer-sync-details',
     TimelineMediaSyncAdapter: '/packages/core/api/timeline-media-sync-adapter',
     TimelineState: '/packages/core/api/timeline-state',
+    TimelineStateSnapshot: '/packages/core/api/timeline-state-snapshot',
   },
   '@techsquidtv/canvas-timeline-react': {
     useTimelineMediaSync: '/packages/react/api/use-timeline-media-sync',
@@ -843,6 +844,11 @@ const symbols = packages.flatMap((packageDoc) =>
     packageName: packageDoc.name,
   }))
 );
+for (const symbol of symbols) {
+  if (symbol.examples.some((example) => /from\s+['"]#/.test(example))) {
+    throw new Error(`${symbol.name} has a repository-private import in a public example.`);
+  }
+}
 const warnings = packages.flatMap((packageDoc) =>
   packageDoc.warnings.map((warning) => `${packageDoc.name}: ${warning}`)
 );

--- a/apps/www/src/content/docs/engine-migration.mdx
+++ b/apps/www/src/content/docs/engine-migration.mdx
@@ -48,6 +48,32 @@ History defaults to 100 snapshots and a conservative 16 MiB serialized-byte budg
 
 ## React and controls
 
+**Breaking:** React state and document-derived hook values now expose the same
+readonly snapshots as Core. Remove assignments to returned tracks, clips,
+groups, and state. Read-only application helpers should accept
+`TimelineReadonly<Track>`, `TimelineReadonly<Clip>`, or `TimelineStateSnapshot`;
+create an explicit application-owned copy only when editing a separate draft.
+
+Core track commands (`addTrack`, `removeTrack`, mute/visibility/lock/target
+toggles, `selectTrack`, `setTrackHeight`, and `setTrackGroup`), clip selection
+commands, and `updateClipProperties` now return `TimelineCommandResult`.
+React selection commands use the same result. Replace boolean/void assumptions
+with a check of `result.ok`. Missing selection IDs fail with `not-found` and
+preserve the current selection. Invalid track input fails with `invalid-input`;
+duplicate track or clip IDs fail with `duplicate-id`.
+
+```ts
+const added = engine.addTrack(newTrack);
+if (added.ok) {
+  const muted = engine.toggleMuteTrack(newTrack.id, true);
+  if (!muted.ok) console.error(muted.reason);
+}
+```
+
+React track commands follow the same current-state validation, so commands may
+run consecutively in one event handler without waiting for a React render.
+There are no compatibility aliases for the old return contracts.
+
 `TimelineProvider` now supplies the stable engine. Use `useTimelineEngine()` for imperative commands, narrow domain hooks for reactive controls, and `useTimelineState()` only when broad state is needed. A playback toolbar no longer rerenders for scrolling or zooming. Custom contexts must pass the engine directly, or use `TimelineProvider`.
 
 Hook and geometry APIs return the engine's actual string track kinds. Remove caller-supplied kind generics and narrow with a predicate that checks your application's allowed kinds. Model types such as `Track<MyKind>` still describe data that your application has validated.

--- a/apps/www/src/content/docs/react-hooks.mdx
+++ b/apps/www/src/content/docs/react-hooks.mdx
@@ -7,6 +7,29 @@ order: 25
 
 Upgrading existing consumers? See the [engine and state migration guide](/docs/engine-migration).
 
+## Select custom state
+
+`useTimelineSelector` reads immutable settled state without cloning the engine's
+snapshot. Primitive selections use `Object.is`; arrays and plain objects compare
+their own enumerable fields shallowly. An optional second argument supplies a
+custom equality function. Unchanged tracks and clips retain their identities
+across unrelated edits, so a selector can subscribe to one document entity.
+
+```tsx
+import { useTimelineSelector } from '@techsquidtv/canvas-timeline-react';
+
+export function TrackCount() {
+  const count = useTimelineSelector((state) => state.tracks.length);
+  return <output>{count} tracks</output>;
+}
+```
+
+Selectors do not subscribe to per-frame playback or edit previews. Use
+`useTimelinePlayheadTime` for live playback readouts. Keep selectors pure and
+change document data through commands; hook snapshots are readonly.
+
+## Choose a domain hook
+
 The React package exposes hooks for binding product chrome, interaction layers,
 media monitors, and accessible controls to a shared `TimelineEngine`.
 This page explains how to choose timeline hooks imported from

--- a/apps/www/src/data/react-hook-metadata.ts
+++ b/apps/www/src/data/react-hook-metadata.ts
@@ -43,6 +43,14 @@ export interface TimelineHookMetadata {
 // useTimelineGeometryRevision stay out of this catalog until they become public.
 export const timelineHookMetadata = [
   {
+    name: 'useTimelineSelector',
+    group: 'timeline-state',
+    category: 'state',
+    reactivity: 'snapshot',
+    description:
+      'Selects primitive or object values from readonly settled state with configurable equality.',
+  },
+  {
     name: 'useTimelineEngine',
     group: 'timeline-state',
     category: 'context',

--- a/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
+++ b/apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx
@@ -18,6 +18,7 @@ import {
 import '#www/demos/keyframe-opacity/timeline-editor.css';
 import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineReadonly,
   TimelineKeyframeBezierHandle,
   TimelineKeyframeInterpolation,
   TimelineKeyframeSidePatch,
@@ -93,7 +94,7 @@ function TrackKeyframeButton({
   label,
   locked,
 }: {
-  track: Track | null;
+  track: TimelineReadonly<Track> | null;
   label: string;
   locked: boolean;
 }) {

--- a/apps/www/src/demos/timeline-stress-test/TimelineStressTest.tsx
+++ b/apps/www/src/demos/timeline-stress-test/TimelineStressTest.tsx
@@ -1,4 +1,8 @@
-import { TimelineEngine, type Track } from '@techsquidtv/canvas-timeline-core';
+import {
+  TimelineEngine,
+  type Track,
+  type TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import {
   TimelineProvider,
   Timeline,
@@ -52,7 +56,7 @@ function TimelineLayers({ displayOptions }: { displayOptions: BenchmarkDisplayOp
   );
 }
 
-function DOMTrackRows({ tracks }: { tracks: Track[] }) {
+function DOMTrackRows({ tracks }: { tracks: readonly TimelineReadonly<Track>[] }) {
   const visibleClips = useTimelineVisibleClips();
 
   return (

--- a/packages/core/src/command-result.ts
+++ b/packages/core/src/command-result.ts
@@ -1,27 +1,18 @@
+import type { TimelineEditRejectionReason } from '#core/types';
 /**
  * Machine-readable reason a timeline command could not be applied.
  */
 export type TimelineCommandFailureReason =
-  | 'not-found'
-  | 'locked'
-  | 'invalid-range'
-  | 'invalid-duration'
+  | TimelineEditRejectionReason
   | 'invalid-input'
-  | 'invalid-track'
-  | 'incompatible-track-kind'
-  | 'duplicate-id'
-  | 'disabled'
   | 'content-gap'
   | 'empty-selection'
   | 'empty-clipboard'
   | 'out-of-bounds'
-  | 'policy-rejected'
-  | 'source-bounds'
-  | 'sync-failed'
-  | 'unsupported';
+  | 'sync-failed';
 
 /**
- * Consistent result returned by React hook command APIs.
+ * Consistent result returned by timeline commands in Core and React.
  *
  * @template Value - Optional successful command payload.
  */

--- a/packages/core/src/document-snapshot.test.ts
+++ b/packages/core/src/document-snapshot.test.ts
@@ -1,0 +1,80 @@
+import { TimelineEngine } from '#core/engine';
+import type { Clip, Track } from '#core/types';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { expect, test, vi } from 'vite-plus/test';
+
+function createEngine() {
+  const clips: Clip[] = ['a', 'b'].map((id, index) => ({
+    id,
+    sourceId: id,
+    timelineStart: fromSeconds(index),
+    timelineEnd: fromSeconds(index + 1),
+    sourceStart: fromSeconds(0),
+    selected: false,
+    metadata: { label: id, nested: { value: 1 } },
+  }));
+  const track: Track = {
+    id: 'track',
+    kind: 'visual',
+    selected: false,
+    locked: false,
+    muted: false,
+    visible: true,
+    clips,
+  };
+  return new TimelineEngine({ tracks: [track] });
+}
+
+test('edits preserve unchanged siblings and history restores owned values', () => {
+  const engine = createEngine();
+  const initial = engine.getState();
+  engine.updateClipProperties('a', { label: 'updated' });
+  const edited = engine.getState();
+  expect(edited.tracks[0]).not.toBe(initial.tracks[0]);
+  expect(edited.tracks[0].clips[1]).toBe(initial.tracks[0].clips[1]);
+  expect(initial.tracks[0].clips[0].label).toBeUndefined();
+  expect(Object.isFrozen(edited.tracks[0].clips[0].metadata?.nested)).toBe(true);
+  engine.undo();
+  expect(engine.getState().tracks[0].clips[0].label).toBeUndefined();
+  engine.redo();
+  expect(engine.getState().tracks[0].clips[0].label).toBe('updated');
+});
+
+test('selection snapshot comparison does not serialize the document', () => {
+  const engine = createEngine();
+  engine.getState();
+  const serialize = vi.spyOn(JSON, 'stringify');
+  try {
+    engine.selectClip('a');
+    const selected = engine.getState();
+    expect(selected.tracks[0].clips[0].selected).toBe(true);
+    expect(serialize).not.toHaveBeenCalled();
+  } finally {
+    serialize.mockRestore();
+  }
+});
+
+test('invalid track commands are atomic and duplicate IDs are rejected', () => {
+  const engine = createEngine();
+  const initial = engine.getState();
+  const track: Track = {
+    id: 'new',
+    kind: 'visual',
+    selected: false,
+    locked: false,
+    muted: false,
+    visible: true,
+    clips: [],
+  };
+  expect(engine.addTrack({ ...track, height: Number.NaN })).toMatchObject({
+    ok: false,
+    reason: 'invalid-input',
+  });
+  expect(engine.addTrack({ ...track, id: 'track' })).toEqual({ ok: false, reason: 'duplicate-id' });
+  expect(
+    engine.addTrack({ ...track, clips: [{ ...initial.tracks[0].clips[0], keyframes: [] }] })
+  ).toEqual({ ok: false, reason: 'duplicate-id' });
+  expect(engine.setTrackHeight('track', 0)).toMatchObject({ ok: false, reason: 'invalid-input' });
+  expect(engine.getState()).toBe(initial);
+  expect(engine.canUndo).toBe(false);
+});

--- a/packages/core/src/document-snapshot.ts
+++ b/packages/core/src/document-snapshot.ts
@@ -1,0 +1,121 @@
+import {
+  createClipSnapshot,
+  createMarkerSnapshots,
+  createClipGroupSnapshots,
+} from '#core/snapshot';
+import type { TimelineReadonly, TimelineState, TimelineStateSnapshot, Track } from '#core/types';
+
+/** Compares model values without serializing or cloning unchanged document nodes. */
+function equalValue(left: unknown, right: unknown, seen = new WeakMap<object, object>()): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (typeof left !== 'object' || left === null || typeof right !== 'object' || right === null) {
+    return false;
+  }
+  if (seen.get(left) === right) {
+    return true;
+  }
+  if (Object.getPrototypeOf(left) !== Object.getPrototypeOf(right)) {
+    return false;
+  }
+  if (Array.isArray(left) && Array.isArray(right) && left.length !== right.length) {
+    return false;
+  }
+  seen.set(left, right);
+  if (left instanceof Date && right instanceof Date) {
+    return left.getTime() === right.getTime();
+  }
+  if (left instanceof Map && right instanceof Map) {
+    return left.size === right.size && equalValue([...left], [...right], seen);
+  }
+  if (left instanceof Set && right instanceof Set) {
+    return left.size === right.size && equalValue([...left], [...right], seen);
+  }
+  // Other structured-cloneable metadata (buffers, blobs, etc.) is copied conservatively.
+  if (
+    !Array.isArray(left) &&
+    Object.getPrototypeOf(left) !== Object.prototype &&
+    Object.getPrototypeOf(left) !== null
+  ) {
+    return false;
+  }
+  const a = left as Record<string, unknown>;
+  const b = right as Record<string, unknown>;
+  const keys = Object.keys(a);
+  return (
+    keys.length === Object.keys(b).length &&
+    keys.every((key) => Object.hasOwn(b, key) && equalValue(a[key], b[key], seen))
+  );
+}
+
+/** Freezes newly owned model values; already shared snapshots need no traversal. */
+function freezeTimelineSnapshot<Value>(
+  value: Value,
+  seen = new WeakSet<object>()
+): TimelineReadonly<Value> {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value) || seen.has(value)) {
+    return value as TimelineReadonly<Value>;
+  }
+  seen.add(value);
+  for (const key of Object.keys(value) as (keyof Value)[]) {
+    freezeTimelineSnapshot(value[key], seen);
+  }
+  return Object.freeze(value) as TimelineReadonly<Value>;
+}
+
+function shareCollection<Value extends { id: string }>(
+  values: readonly Value[],
+  previous: readonly TimelineReadonly<Value>[] | undefined,
+  snapshot: (value: Value, prior: TimelineReadonly<Value> | undefined) => TimelineReadonly<Value>
+): readonly TimelineReadonly<Value>[] {
+  const byId = new Map(previous?.map((value) => [value.id, value]));
+  const next = values.map((value) => snapshot(value, byId.get(value.id)));
+  return previous &&
+    next.length === previous.length &&
+    next.every((value, index) => value === previous[index])
+    ? previous
+    : Object.freeze(next);
+}
+
+function shareTrack(
+  track: Track,
+  previous: TimelineReadonly<Track> | undefined
+): TimelineReadonly<Track> {
+  const clips = shareCollection(track.clips, previous?.clips, (clip, prior) =>
+    prior && equalValue(clip, prior) ? prior : freezeTimelineSnapshot(createClipSnapshot(clip))
+  );
+  const { clips: _clips, ...fields } = track;
+  const { clips: _priorClips, ...priorFields } = previous ?? { clips: [] };
+  if (previous && clips === previous.clips && equalValue(fields, priorFields)) {
+    return previous;
+  }
+  return freezeTimelineSnapshot({ ...structuredClone(fields), clips });
+}
+
+/** Shares document collections across reads and history while preserving unchanged entity identities. */
+export function createDocumentSnapshot(state: TimelineState, previous?: TimelineStateSnapshot) {
+  return {
+    tracks: shareCollection(state.tracks, previous?.tracks, shareTrack),
+    markers: shareCollection(state.markers ?? [], previous?.markers, (marker, prior) =>
+      prior && equalValue(marker, prior)
+        ? prior
+        : freezeTimelineSnapshot(createMarkerSnapshots([marker])[0])
+    ),
+    clipGroups: shareCollection(state.clipGroups, previous?.clipGroups, (group, prior) =>
+      prior && equalValue(group, prior)
+        ? prior
+        : freezeTimelineSnapshot(createClipGroupSnapshots([group])[0])
+    ),
+  };
+}
+
+/** Reuses small feedback values independently of document revisions. */
+export function shareTimelineFeedback<Value>(
+  value: Value,
+  previous: TimelineReadonly<Value> | undefined
+): TimelineReadonly<Value> {
+  return previous !== undefined && equalValue(value, previous)
+    ? previous
+    : freezeTimelineSnapshot(structuredClone(value));
+}

--- a/packages/core/src/engine.test.ts
+++ b/packages/core/src/engine.test.ts
@@ -2009,7 +2009,7 @@ describe('TimelineEngine', () => {
       scrollEngine.on('scroll:change', scrollChange);
 
       expect(scrollEngine.maxScrollTop).toBe(48);
-      expect(scrollEngine.removeTrack('track-3')).toBe(true);
+      expect(scrollEngine.removeTrack('track-3')).toEqual({ ok: true });
 
       expect(scrollEngine.maxScrollTop).toBe(0);
       expect(scrollEngine.scrollTop).toBe(0);

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,3 +1,9 @@
+import {
+  timelineCommandOk,
+  timelineCommandFail,
+  timelineCommandInvalidInput,
+} from '#core/command-result';
+import type { TimelineCommandResult } from '#core/command-result';
 import { ClipboardManager } from '#core/clipboard';
 import { TypedEventEmitter } from '#core/emitter';
 import { TimelineMediaQueries } from '#core/engine/active-media';
@@ -240,8 +246,28 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param track - Track to add. Its id should be unique within the timeline.
    */
-  addTrack(track: Track) {
-    const nextTrack = createTrackSnapshot(track);
+  addTrack(track: Track): TimelineCommandResult {
+    const clipIds = new Set(
+      this.state.tracks.flatMap((entry) => entry.clips.map((clip) => clip.id))
+    );
+    if (
+      this.state.tracks.some((entry) => entry.id === track.id) ||
+      track.clips.some((clip) => {
+        if (clipIds.has(clip.id)) {
+          return true;
+        }
+        clipIds.add(clip.id);
+        return false;
+      })
+    ) {
+      return timelineCommandFail('duplicate-id');
+    }
+    let nextTrack: Track;
+    try {
+      nextTrack = createTrackSnapshot(track);
+    } catch (cause) {
+      return timelineCommandInvalidInput('Invalid track.', cause);
+    }
     this.state.tracks.push(nextTrack);
     this.invalidateContent();
     this.snapshot();
@@ -249,13 +275,14 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
     this.emit('state:settled');
     this.emit('render');
+    return timelineCommandOk();
   }
 
   /**
    * Removes a track by id.
    *
    * @param trackId - Track id to remove.
-   * @returns Whether the track was found and removed.
+   * @returns Command success or a not-found failure.
    */
   removeTrack(trackId: string) {
     const idx = this.state.tracks.findIndex((t) => t.id === trackId);
@@ -272,9 +299,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       }
       this.emit('state:settled');
       this.emit('render');
-      return true;
+      return timelineCommandOk();
     }
-    return false;
+    return timelineCommandFail('not-found');
   }
 
   /**
@@ -293,7 +320,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
       this.emit('state:settled');
       this.emit('render');
+      return timelineCommandOk();
     }
+    return timelineCommandFail('not-found');
   }
 
   /**
@@ -312,7 +341,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
 
       this.emit('state:settled');
       this.emit('render');
+      return timelineCommandOk();
     }
+    return timelineCommandFail('not-found');
   }
 
   /**
@@ -330,7 +361,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       this.emit('track:lock', { trackId: track.id, locked: track.locked });
       this.emit('state:settled');
       this.emit('render');
+      return timelineCommandOk();
     }
+    return timelineCommandFail('not-found');
   }
 
   /**
@@ -338,13 +371,17 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param trackId - Track id to select, or `null` to clear track selection.
    */
-  selectTrack(trackId: string | null) {
+  selectTrack(trackId: string | null): TimelineCommandResult {
+    if (trackId !== null && !this.state.tracks.some((track) => track.id === trackId)) {
+      return timelineCommandFail('not-found');
+    }
     for (const track of this.state.tracks) {
       track.selected = track.id === trackId;
     }
     this.emit('track:select', { trackId });
     this.emit('state:settled');
     this.emit('render');
+    return timelineCommandOk();
   }
 
   /**
@@ -354,8 +391,14 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    * @param height - Expanded row height in pixels.
    */
   setTrackHeight(trackId: string, height: number) {
-    assertPositiveTimelineNumber(height, 'height');
+    if (!this.state.tracks.some((track) => track.id === trackId)) {
+      return timelineCommandFail('not-found');
+    }
+    if (!Number.isFinite(height) || height <= 0) {
+      return timelineCommandFail('invalid-input', 'height must be a positive finite number.');
+    }
     this.setTrackHeights([{ trackId, height }]);
+    return timelineCommandOk();
   }
 
   /**
@@ -1717,7 +1760,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       this.snapshot();
       this.emit('state:settled');
       this.emit('render');
+      return timelineCommandOk();
     }
+    return timelineCommandFail('not-found');
   }
 
   /**
@@ -1734,7 +1779,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       this.snapshot();
       this.emit('state:settled');
       this.emit('render');
+      return timelineCommandOk();
     }
+    return timelineCommandFail('not-found');
   }
 
   // --- Undo / Redo ---
@@ -2000,9 +2047,12 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param clipId - Clip id to select, or `null` to clear clip selection.
    */
-  selectClip(clipId: string | null) {
+  selectClip(clipId: string | null): TimelineCommandResult {
+    if (clipId !== null && !this.geometry.getClip(clipId)) {
+      return timelineCommandFail('not-found');
+    }
     const selectedClipIds = clipId === null ? [] : getLinkedClipIds(this.getEditContext(), clipId);
-    this.selectClips(selectedClipIds);
+    return this.selectClips(selectedClipIds);
   }
 
   /**
@@ -2010,7 +2060,13 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param clipIds - Clip ids to select.
    */
-  selectClips(clipIds: readonly string[]) {
+  selectClips(clipIds: readonly string[]): TimelineCommandResult {
+    const existingIds = new Set(
+      this.state.tracks.flatMap((track) => track.clips.map((clip) => clip.id))
+    );
+    if (clipIds.some((id) => !existingIds.has(id))) {
+      return timelineCommandFail('not-found');
+    }
     const selectedClipIds = new Set(clipIds);
     const selectedClips: Clip[] = [];
     let primaryClip: Clip | null = null;
@@ -2030,6 +2086,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       clips: selectedClips,
     });
     this.emit('render');
+    return timelineCommandOk();
   }
 
   /**
@@ -2040,7 +2097,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    */
   toggleClipSelection(clipId: string, selected?: boolean) {
     if (this.geometry.getClip(clipId) === undefined) {
-      return false;
+      return timelineCommandFail('not-found');
     }
     const currentSelection = new Set(this.getSelectedClipIds());
     const nextSelected = selected ?? !currentSelection.has(clipId);
@@ -2054,7 +2111,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       }
     }
     this.selectClips([...currentSelection]);
-    return true;
+    return timelineCommandOk();
   }
 
   /**
@@ -2062,7 +2119,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param clipId - Clip id to update.
    * @param properties - Partial set of clip label, opacity, and color values.
-   * @returns Whether the clip was found and updated.
+   * @returns Command success or a not-found failure.
    */
   updateClipProperties(
     clipId: string,
@@ -2075,9 +2132,9 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       this.snapshot();
       this.emit('state:settled');
       this.emit('render');
-      return true;
+      return timelineCommandOk();
     }
-    return false;
+    return timelineCommandFail('not-found');
   }
   /** Invalidates content-dependent queries and renderer snapshots. */
   invalidateContent() {

--- a/packages/core/src/engine/active-media.ts
+++ b/packages/core/src/engine/active-media.ts
@@ -13,6 +13,7 @@ import type {
   ActiveLayerResult,
   ActiveLayerSelector,
   Clip,
+  TimelineReadonly,
   ClipSourceRange,
   FirstContentTimeOptions,
   TimelineState,
@@ -261,7 +262,7 @@ export class TimelineMediaQueries {
    * @param clipIdOrClip - Clip object or id to inspect.
    * @returns Source range, or `undefined` when the clip is missing.
    */
-  getClipSourceRange(clipIdOrClip: string | Clip): ClipSourceRange | undefined {
+  getClipSourceRange(clipIdOrClip: string | TimelineReadonly<Clip>): ClipSourceRange | undefined {
     const clip = this.resolveClip(clipIdOrClip);
     if (clip === undefined) {
       return undefined;
@@ -276,7 +277,7 @@ export class TimelineMediaQueries {
    * @param clipIdOrClip - Clip object or id to inspect.
    * @returns Sync key, or `undefined` when the clip is missing.
    */
-  getClipSyncKey(clipIdOrClip: string | Clip): string | undefined {
+  getClipSyncKey(clipIdOrClip: string | TimelineReadonly<Clip>): string | undefined {
     const clip = this.resolveClip(clipIdOrClip);
     if (clip === undefined) {
       return undefined;
@@ -293,7 +294,7 @@ export class TimelineMediaQueries {
    * @returns Source time, or `undefined` when the clip is missing or the time is outside the clip.
    */
   timelineTimeToSourceTime(
-    clipIdOrClip: string | Clip,
+    clipIdOrClip: string | TimelineReadonly<Clip>,
     timelineTime: RationalTime = this.context.getState().playheadTime
   ): RationalTime | undefined {
     const clip = this.resolveClip(clipIdOrClip);
@@ -312,7 +313,7 @@ export class TimelineMediaQueries {
    * @returns Timeline time, or `undefined` when the clip is missing or the source time is outside the clip.
    */
   sourceTimeToTimelineTime(
-    clipIdOrClip: string | Clip,
+    clipIdOrClip: string | TimelineReadonly<Clip>,
     sourceTime: RationalTime
   ): RationalTime | undefined {
     const clip = this.resolveClip(clipIdOrClip);
@@ -322,7 +323,7 @@ export class TimelineMediaQueries {
 
     return mapSourceTimeToTimelineTime(clip, sourceTime);
   }
-  private resolveClip(clip: string | Clip): Clip | undefined {
+  private resolveClip(clip: string | TimelineReadonly<Clip>): TimelineReadonly<Clip> | undefined {
     return typeof clip === 'string' ? this.context.getClip(clip)?.clip : clip;
   }
 }

--- a/packages/core/src/engine/media-sync.ts
+++ b/packages/core/src/engine/media-sync.ts
@@ -1,8 +1,8 @@
-import type { Clip, ClipSourceRange } from '#core/types';
+import type { Clip, ClipSourceRange, TimelineReadonly } from '#core/types';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { addRational, compareRational, subRational } from '@techsquidtv/canvas-timeline-utils';
 
-export function createClipSourceRange(clip: Clip): ClipSourceRange {
+export function createClipSourceRange(clip: TimelineReadonly<Clip>): ClipSourceRange {
   const duration = subRational(clip.timelineEnd, clip.timelineStart);
   return {
     sourceId: clip.sourceId,
@@ -12,7 +12,7 @@ export function createClipSourceRange(clip: Clip): ClipSourceRange {
   };
 }
 
-export function createClipSyncKey(clip: Clip): string {
+export function createClipSyncKey(clip: TimelineReadonly<Clip>): string {
   return [
     clip.id,
     clip.sourceId,
@@ -26,7 +26,7 @@ export function createClipSyncKey(clip: Clip): string {
 }
 
 export function mapTimelineTimeToSourceTime(
-  clip: Clip,
+  clip: TimelineReadonly<Clip>,
   timelineTime: RationalTime
 ): RationalTime | undefined {
   if (
@@ -40,7 +40,7 @@ export function mapTimelineTimeToSourceTime(
 }
 
 export function mapSourceTimeToTimelineTime(
-  clip: Clip,
+  clip: TimelineReadonly<Clip>,
   sourceTime: RationalTime
 ): RationalTime | undefined {
   const sourceEnd = addRational(

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,11 +1,10 @@
 import type { TimelineEngine } from '#core/engine';
 import {
   createClipGroupSnapshots,
-  createClipSnapshot,
   createMarkerSnapshots,
   createTrackSnapshots,
 } from '#core/snapshot';
-import type { Marker, TimelineClipGroup, TimelineState, Track } from '#core/types';
+import type { TimelineState, TimelineStateSnapshot } from '#core/types';
 /** Limits retained document history. The current document is always retained. */
 export interface TimelineHistoryOptions {
   /** Maximum snapshots, including the current document. Defaults to 100. */
@@ -15,9 +14,9 @@ export interface TimelineHistoryOptions {
 }
 
 interface HistoryEntry {
-  tracks: Track[];
-  markers: Marker[];
-  clipGroups: TimelineClipGroup[];
+  tracks: TimelineStateSnapshot['tracks'];
+  markers: TimelineStateSnapshot['markers'];
+  clipGroups: TimelineStateSnapshot['clipGroups'];
   bytes: number;
 }
 
@@ -53,35 +52,12 @@ export class HistoryManager {
     }
     this.revision = revision;
     const last = this.history[this.historyIndex];
-    const previousClips = new Map(
-      last?.tracks.flatMap((track) => track.clips.map((clip) => [clip.id, clip] as const))
-    );
-    const tracks = state.tracks.map((track) => {
-      const clips = track.clips.map((clip) => {
-        const previous = previousClips.get(clip.id);
-        return previous && JSON.stringify(previous) === JSON.stringify(clip)
-          ? previous
-          : createClipSnapshot(clip);
-      });
-      const previousTrack = last?.tracks.find((entry) => entry.id === track.id);
-      if (
-        previousTrack &&
-        clips.length === previousTrack.clips.length &&
-        clips.every((clip, index) => clip === previousTrack.clips[index]) &&
-        JSON.stringify({ ...track, clips: [] }) === JSON.stringify({ ...previousTrack, clips: [] })
-      ) {
-        return previousTrack;
-      }
-      return { ...track, clips };
-    });
-    const markers = createMarkerSnapshots(state.markers);
-    const clipGroups = createClipGroupSnapshots(state.clipGroups);
+    const { tracks, markers, clipGroups } = this.engine.getState();
     if (
       last &&
-      tracks.length === last.tracks.length &&
-      tracks.every((track, index) => track === last.tracks[index]) &&
-      JSON.stringify(markers) === JSON.stringify(last.markers) &&
-      JSON.stringify(clipGroups) === JSON.stringify(last.clipGroups)
+      tracks === last.tracks &&
+      markers === last.markers &&
+      clipGroups === last.clipGroups
     ) {
       return;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from '#core/command-result';
 export * from '#core/engine';
 export * from '#core/events';
 export * from '#core/keyframes';

--- a/packages/core/src/state-snapshot.ts
+++ b/packages/core/src/state-snapshot.ts
@@ -1,37 +1,12 @@
-import type { TimelineState, TimelineStateSnapshot, TimelineReadonly } from '#core/types';
-import {
-  createTrackSnapshots,
-  createMarkerSnapshots,
-  createClipGroupSnapshots,
-} from '#core/snapshot';
+import { createDocumentSnapshot, shareTimelineFeedback } from '#core/document-snapshot';
+import type { TimelineState, TimelineStateSnapshot } from '#core/types';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
-/** Freezes a snapshot recursively without traversing the same metadata object twice. */
-function freezeTimelineSnapshot<Value>(value: Value, seen = new WeakSet<object>()): Value {
-  if (typeof value !== 'object' || value === null || seen.has(value)) {
-    return value;
-  }
-  seen.add(value);
-  for (const key of Object.keys(value) as (keyof Value)[]) {
-    freezeTimelineSnapshot(value[key], seen);
-  }
-  return Object.freeze(value);
-}
-
 /** Reuses unchanged document collections and scalar value objects across read snapshots. */
 export function createTimelineReadSnapshot(
   state: TimelineState,
   previous: TimelineStateSnapshot | undefined,
   documentChanged: boolean
 ): TimelineStateSnapshot {
-  const share = <Value>(
-    value: Value,
-    prior: TimelineReadonly<Value> | undefined
-  ): TimelineReadonly<Value> => {
-    if (prior !== undefined && JSON.stringify(value) === JSON.stringify(prior)) {
-      return prior;
-    }
-    return freezeTimelineSnapshot(value) as TimelineReadonly<Value>;
-  };
   const time = (value: RationalTime | undefined, prior: RationalTime | undefined) =>
     value === undefined
       ? undefined
@@ -40,24 +15,19 @@ export function createTimelineReadSnapshot(
         : { ...value };
   const next: TimelineStateSnapshot = {
     ...state,
-    tracks:
-      documentChanged || !previous
-        ? share(createTrackSnapshots(state.tracks), previous?.tracks)
-        : previous.tracks,
-    markers:
-      documentChanged || !previous
-        ? share(createMarkerSnapshots(state.markers), previous?.markers)
-        : previous.markers,
-    clipGroups:
-      documentChanged || !previous
-        ? share(createClipGroupSnapshots(state.clipGroups), previous?.clipGroups)
-        : previous.clipGroups,
+    ...(documentChanged || !previous
+      ? createDocumentSnapshot(state, previous)
+      : {
+          tracks: previous.tracks,
+          markers: previous.markers,
+          clipGroups: previous.clipGroups,
+        }),
     playheadTime: time(state.playheadTime, previous?.playheadTime) ?? { ...state.playheadTime },
     inPoint: time(state.inPoint, previous?.inPoint),
     outPoint: time(state.outPoint, previous?.outPoint),
     duration: time(state.duration, previous?.duration),
-    snapFeedback: share(structuredClone(state.snapFeedback), previous?.snapFeedback),
-    clipDropFeedback: share({ ...state.clipDropFeedback }, previous?.clipDropFeedback),
+    snapFeedback: shareTimelineFeedback(state.snapFeedback, previous?.snapFeedback),
+    clipDropFeedback: shareTimelineFeedback(state.clipDropFeedback, previous?.clipDropFeedback),
   };
   if (
     previous &&

--- a/packages/react/src/accessibility.ts
+++ b/packages/react/src/accessibility.ts
@@ -1,4 +1,4 @@
-import type { Clip, Track } from '@techsquidtv/canvas-timeline-core';
+import type { Clip, Track, TimelineReadonly } from '@techsquidtv/canvas-timeline-core';
 import { subRational, toSeconds, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
 
 /**
@@ -106,7 +106,7 @@ export function formatTimelineRangeValue(
   return `${range}, duration ${formatTimelineTimeValue(duration, options)}`;
 }
 
-function getTrackLabel<TrackKind = string>(track?: Track<TrackKind>) {
+function getTrackLabel<TrackKind = string>(track?: TimelineReadonly<Track<TrackKind>>) {
   return track?.name?.trim() || track?.id;
 }
 
@@ -120,7 +120,10 @@ function getTrackLabel<TrackKind = string>(track?: Track<TrackKind>) {
  * @returns Short label suitable for `aria-label`, active-descendant text, or
  * inspector headings.
  */
-export function getClipAccessibleName<TrackKind = string>(clip: Clip, track?: Track<TrackKind>) {
+export function getClipAccessibleName<TrackKind = string>(
+  clip: TimelineReadonly<Clip>,
+  track?: TimelineReadonly<Track<TrackKind>>
+) {
   const clipLabel = clip.label?.trim() || clip.id;
   const trackLabel = getTrackLabel(track);
   return trackLabel ? `${clipLabel} on ${trackLabel}` : clipLabel;
@@ -137,8 +140,8 @@ export function getClipAccessibleName<TrackKind = string>(clip: Clip, track?: Tr
  * flags.
  */
 export function getClipAccessibleDescription<TrackKind = string>(
-  clip: Clip,
-  track?: Track<TrackKind>
+  clip: TimelineReadonly<Clip>,
+  track?: TimelineReadonly<Track<TrackKind>>
 ) {
   const duration = subRational(clip.timelineEnd, clip.timelineStart);
   const parts = [

--- a/packages/react/src/hooks/clips/timelineClipModel.ts
+++ b/packages/react/src/hooks/clips/timelineClipModel.ts
@@ -1,5 +1,6 @@
 import type {
   Clip,
+  TimelineReadonly,
   TimelineClipEntry,
   TimelineClipGroup,
   Track,
@@ -14,23 +15,23 @@ export type { TimelineClipEntry } from '@techsquidtv/canvas-timeline-core';
  */
 export interface TimelineSelectionState<TrackKind = string> {
   /** Currently selected clip, or null when no clip is selected. */
-  selectedClip: Clip | null;
+  selectedClip: TimelineReadonly<Clip> | null;
   /** ID of the currently selected clip, or null when no clip is selected. */
   selectedClipId: string | null;
   /** ID of the track containing the selected clip, or null when no clip is selected. */
   selectedClipTrackId: string | null;
   /** All selected clips in track order. */
-  selectedClips: Clip[];
+  selectedClips: TimelineReadonly<Clip>[];
   /** IDs of all selected clips in track order. */
   selectedClipIds: string[];
   /** Selected group when the primary selected clip belongs to one. */
-  selectedGroup: TimelineClipGroup | null;
+  selectedGroup: TimelineReadonly<TimelineClipGroup> | null;
   /** Selected group id when the primary selected clip belongs to one. */
   selectedGroupId: string | null;
   /** Whether any clip or track is selected. */
   hasSelection: boolean;
   /** Currently selected track, or null when no track row is selected. */
-  selectedTrack: Track<TrackKind> | null;
+  selectedTrack: TimelineReadonly<Track<TrackKind>> | null;
   /** ID of the currently selected track, or null when no track row is selected. */
   selectedTrackId: string | null;
 }
@@ -44,8 +45,8 @@ export interface TimelineSelectionState<TrackKind = string> {
  * @returns Flattened clip entries in track order.
  */
 export function flattenTimelineClips<TrackKind>(
-  tracks: Track<TrackKind>[]
-): TimelineClipEntry<TrackKind>[] {
+  tracks: readonly TimelineReadonly<Track<TrackKind>>[]
+): TimelineReadonly<TimelineClipEntry<TrackKind>>[] {
   return tracks.flatMap((track, trackIndex) =>
     track.clips.map((clip, clipIndex) => ({
       clip,
@@ -66,14 +67,14 @@ export function flattenTimelineClips<TrackKind>(
  * @returns Current selection metadata.
  */
 export function deriveTimelineSelection<TrackKind>(
-  tracks: Track<TrackKind>[],
-  clipGroups: TimelineClipGroup[] = []
+  tracks: readonly TimelineReadonly<Track<TrackKind>>[],
+  clipGroups: readonly TimelineReadonly<TimelineClipGroup>[] = []
 ): TimelineSelectionState<TrackKind> {
-  let selectedClip: Clip | null = null;
+  let selectedClip: TimelineReadonly<Clip> | null = null;
   let selectedClipTrackId: string | null = null;
-  let selectedTrack: Track<TrackKind> | null = null;
-  const selectedClips: Clip[] = [];
-  const clipGroupByClipId = new Map<string, TimelineClipGroup>();
+  let selectedTrack: TimelineReadonly<Track<TrackKind>> | null = null;
+  const selectedClips: TimelineReadonly<Clip>[] = [];
+  const clipGroupByClipId = new Map<string, TimelineReadonly<TimelineClipGroup>>();
   for (const group of clipGroups) {
     for (const clipId of group.clipIds) {
       clipGroupByClipId.set(clipId, group);

--- a/packages/react/src/hooks/clips/useActiveLayers.ts
+++ b/packages/react/src/hooks/clips/useActiveLayers.ts
@@ -24,7 +24,7 @@ import { useMemo } from 'react';
  * @example
  * ```tsx
  * import { useMemo } from 'react';
- * import { useActiveLayers } from '#react/hooks';
+ * import { useActiveLayers } from '@techsquidtv/canvas-timeline-react';
  *
  * const previewLayers = {
  *   visuals: { trackKind: 'visual' },

--- a/packages/react/src/hooks/clips/useTimelineClipDrag.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDrag.ts
@@ -1,18 +1,19 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type {
+  TimelineCommandResult,
+  ClipViewportRect,
+  TimelineClipDropFeedback,
+  TimelineClipMoveResult,
+  TimelineInteractionGeometry,
+  TimelineTrackHitTestResult,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineTrackDropTargets } from '#react/hooks/tracks/useTimelineTrackDropTargets';
 import type {
   TimelineTrackDropGuard,
   TimelineTrackDropResult,
 } from '#react/hooks/tracks/useTimelineTrackDropTargets';
-import type {
-  ClipViewportRect,
-  TimelineClipDropFeedback,
-  TimelineClipMoveResult,
-  TimelineInteractionGeometry,
-  TimelineTrackHitTestResult,
-} from '@techsquidtv/canvas-timeline-core';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /** Pointer data needed to begin a clip body drag. */
 export interface TimelineClipDragStartInput {
@@ -87,21 +88,24 @@ interface ActiveClipDrag {
   activeTargetTrackId: string;
   activeTargetTrackIndex: number;
   allowCrossKindTrackMove: boolean;
-  trackTargets: TimelineTrackHitTestResult[];
+  trackTargets: TimelineReadonly<TimelineTrackHitTestResult>[];
 }
 
 function clampRatio(value: number) {
   return Math.max(0, Math.min(1, value));
 }
 
-function findTrackTargetAtY(trackTargets: TimelineTrackHitTestResult[], viewportY: number) {
+function findTrackTargetAtY(
+  trackTargets: TimelineReadonly<TimelineTrackHitTestResult>[],
+  viewportY: number
+) {
   return (
     trackTargets.find(({ rect }) => viewportY >= rect.y && viewportY < rect.y + rect.height) ?? null
   );
 }
 
 function getTrackPenetration(
-  target: TimelineTrackHitTestResult,
+  target: TimelineReadonly<TimelineTrackHitTestResult>,
   activeTargetTrackIndex: number,
   viewportY: number
 ) {
@@ -139,7 +143,7 @@ function getTrackPenetration(
  *
  * @example
  * ```tsx
- * import { useTimelineClipDrag } from '#react/hooks';
+ * import { useTimelineClipDrag } from '@techsquidtv/canvas-timeline-react';
  *
  * export function CustomClipDragHandle({ clipId }: { clipId: string }) {
  *   const drag = useTimelineClipDrag();

--- a/packages/react/src/hooks/clips/useTimelineClipDropFeedback.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDropFeedback.ts
@@ -49,7 +49,7 @@ export interface UseTimelineClipDropFeedbackResult {
  *
  * @example
  * ```tsx
- * import { useTimelineClipDropFeedback } from '#react/hooks';
+ * import { useTimelineClipDropFeedback } from '@techsquidtv/canvas-timeline-react';
  *
  * export function DropStatus() {
  *   const feedback = useTimelineClipDropFeedback();

--- a/packages/react/src/hooks/clips/useTimelineClipGroups.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipGroups.ts
@@ -1,16 +1,20 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type {
+  TimelineCommandResult,
+  TimelineReadonly,
+  TimelineClipEntry,
+  TimelineClipGroup,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
-import type { TimelineClipEntry, TimelineClipGroup } from '@techsquidtv/canvas-timeline-core';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 /** Result returned by `useTimelineClipGroups`. */
 export interface UseTimelineClipGroupsResult {
   /** Current clip groups. */
-  groups: TimelineClipGroup[];
+  groups: readonly TimelineReadonly<TimelineClipGroup>[];
   /** Selected clip group, or null when the primary selected clip is ungrouped. */
-  selectedGroup: TimelineClipGroup | null;
+  selectedGroup: TimelineReadonly<TimelineClipGroup> | null;
   /** Selected clip group id, or null when the primary selected clip is ungrouped. */
   selectedGroupId: string | null;
   /** Returns one clip group by id. */
@@ -39,7 +43,7 @@ export function useTimelineClipGroups(): UseTimelineClipGroupsResult {
   const engine = useTimelineEngine();
   const state = useTimelineSelector((state) => ({ clipGroups: state.clipGroups }));
   const { selectedClipIds, selectedGroup, selectedGroupId } = useTimelineSelection();
-  const groups = useMemo(() => state.clipGroups, [state.clipGroups]);
+  const groups = state.clipGroups;
 
   const getClipGroup = useCallback((groupId: string) => engine.getClipGroup(groupId), [engine]);
   const getClipGroupForClip = useCallback(

--- a/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipNavigation.ts
@@ -1,12 +1,12 @@
 import { getClipAccessibleDescription, getClipAccessibleName } from '#react/accessibility';
 import type { TimelineClipEntry } from '#react/hooks/clips/timelineClipModel';
 import { useTimelineClips } from '#react/hooks/clips/useTimelineClips';
-import { timelineCommandFail } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import { useTimelineEditCommands } from '#react/hooks/editing/useTimelineEditCommands';
 import { useTimelineSnapping } from '#react/hooks/editing/useTimelineSnapping';
-import type { Clip, Track } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineReadonly, Clip, Track } from '@techsquidtv/canvas-timeline-core';
 import { addRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
 import React, { useCallback, useMemo, useState } from 'react';
 /**
@@ -23,9 +23,9 @@ import React, { useCallback, useMemo, useState } from 'react';
  */
 export interface TimelineNavigableClip {
   /** Raw timeline clip represented by this navigation item. */
-  clip: Clip;
+  clip: TimelineReadonly<Clip>;
   /** Track containing the clip. */
-  track: Track<string>;
+  track: TimelineReadonly<Track<string>>;
   /** Zero-based track index in timeline order. */
   trackIndex: number;
   /** Zero-based clip index inside the track. */
@@ -62,15 +62,27 @@ export interface TimelineClipNavigationOptions {
   /** Whether navigation also selects the active clip in the engine. Defaults to false. */
   selectOnNavigate?: boolean;
   /** Optional accessible label formatter for a canvas-rendered clip. */
-  getClipAriaLabel?: (clip: Clip, track: Track<string>) => string;
+  getClipAriaLabel?: (
+    clip: TimelineReadonly<Clip>,
+    track: TimelineReadonly<Track<string>>
+  ) => string;
   /** Optional accessible description formatter for a canvas-rendered clip. */
-  getClipAriaDescription?: (clip: Clip, track: Track<string>) => string;
+  getClipAriaDescription?: (
+    clip: TimelineReadonly<Clip>,
+    track: TimelineReadonly<Track<string>>
+  ) => string;
 }
 
 function buildNavigableClips(
-  clipEntries: TimelineClipEntry<string>[],
-  getClipAriaLabel?: (clip: Clip, track: Track<string>) => string,
-  getClipAriaDescription?: (clip: Clip, track: Track<string>) => string
+  clipEntries: readonly TimelineReadonly<TimelineClipEntry<string>>[],
+  getClipAriaLabel?: (
+    clip: TimelineReadonly<Clip>,
+    track: TimelineReadonly<Track<string>>
+  ) => string,
+  getClipAriaDescription?: (
+    clip: TimelineReadonly<Clip>,
+    track: TimelineReadonly<Track<string>>
+  ) => string
 ): TimelineNavigableClip[] {
   return clipEntries.map(({ clip, clipIndex, track, trackIndex }, index) => ({
     clip,
@@ -109,7 +121,7 @@ function getActiveClipStatus(activeClip: TimelineNavigableClip | null, clipCount
  *
  * @example
  * ```tsx
- * import { useTimelineClipNavigation } from '#react/hooks';
+ * import { useTimelineClipNavigation } from '@techsquidtv/canvas-timeline-react';
  *
  * export function CanvasClipNavigator() {
  *   const clipNavigation = useTimelineClipNavigation({ selectOnNavigate: true });

--- a/packages/react/src/hooks/clips/useTimelineClipRects.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipRects.ts
@@ -34,7 +34,7 @@ export type UseTimelineClipRectsOptions = TimelineClipGeometryOptions;
  *
  * @example
  * ```tsx
- * import { useTimelineClipRects } from '#react/hooks';
+ * import { useTimelineClipRects } from '@techsquidtv/canvas-timeline-react';
  *
  * export function SelectedClipBadges() {
  *   const rects = useTimelineClipRects();

--- a/packages/react/src/hooks/clips/useTimelineClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineClips.ts
@@ -1,17 +1,17 @@
 import { flattenTimelineClips } from '#react/hooks/clips/timelineClipModel';
 import type { TimelineClipEntry } from '#react/hooks/clips/timelineClipModel';
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
 import type {
+  TimelineCommandResult,
   Clip,
+  TimelineReadonly,
   ClipHitTestInput,
   TimelineClipGroup,
   TimelineEngine,
   TimelineInteractionGeometry,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
+import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 export type { TimelineClipEntry } from '#react/hooks/clips/timelineClipModel';
@@ -46,19 +46,19 @@ export type TimelineClipUpdate = Partial<Pick<Clip, 'label' | 'opacity' | 'color
  */
 export interface UseTimelineClipsResult {
   /** Flattened timeline clips in track order. */
-  clips: TimelineClipEntry[];
+  clips: TimelineReadonly<TimelineClipEntry>[];
   /** Currently selected clip, or null when no clip is selected. */
-  selectedClip: Clip | null;
+  selectedClip: TimelineReadonly<Clip> | null;
   /** ID of the currently selected clip, or null when no clip is selected. */
   selectedClipId: string | null;
   /** ID of the track containing the selected clip, or null when no clip is selected. */
   selectedClipTrackId: string | null;
   /** All selected clips in track order. */
-  selectedClips: Clip[];
+  selectedClips: TimelineReadonly<Clip>[];
   /** IDs of all selected clips in track order. */
   selectedClipIds: string[];
   /** Selected group when the primary selected clip belongs to one. */
-  selectedGroup: TimelineClipGroup | null;
+  selectedGroup: TimelineReadonly<TimelineClipGroup> | null;
   /** Selected group id when the primary selected clip belongs to one. */
   selectedGroupId: string | null;
   /** Returns a clip lookup from the engine, including containing track and indexes. */
@@ -108,7 +108,7 @@ export interface UseTimelineClipsResult {
  *
  * @example
  * ```tsx
- * import { useTimelineClips } from '#react/hooks';
+ * import { useTimelineClips } from '@techsquidtv/canvas-timeline-react';
  *
  * export function ClipLabelEditor() {
  *   const { selectedClip, updateClip } = useTimelineClips();
@@ -129,7 +129,7 @@ export interface UseTimelineClipsResult {
  * @example
  * ```tsx
  * import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
- * import { useTimelineClips } from '#react/hooks';
+ * import { useTimelineClips } from '@techsquidtv/canvas-timeline-react';
  *
  * export function ClipInspector() {
  *   const { selectedClip, selectedClipTrackId, timelineTimeToSourceTime } = useTimelineClips();
@@ -145,7 +145,7 @@ export interface UseTimelineClipsResult {
  *       <dt>Track</dt>
  *       <dd>{selectedClipTrackId}</dd>
  *       <dt>Source start</dt>
- *       <dd>{toSeconds(sourceTime).toFixed(2)}s</dd>
+ *       <dd>{sourceTime === undefined ? 'Outside clip' : `${toSeconds(sourceTime).toFixed(2)}s`}</dd>
  *     </dl>
  *   );
  * }
@@ -183,20 +183,21 @@ export function useTimelineClips(): UseTimelineClipsResult {
     [engine]
   );
   const getClipSourceRange = useCallback(
-    (clipIdOrClip: string | Clip) => engine.media.getClipSourceRange(clipIdOrClip),
+    (clipIdOrClip: string | TimelineReadonly<Clip>) =>
+      engine.media.getClipSourceRange(clipIdOrClip),
     [engine]
   );
   const getClipSyncKey = useCallback(
-    (clipIdOrClip: string | Clip) => engine.media.getClipSyncKey(clipIdOrClip),
+    (clipIdOrClip: string | TimelineReadonly<Clip>) => engine.media.getClipSyncKey(clipIdOrClip),
     [engine]
   );
   const timelineTimeToSourceTime = useCallback(
-    (clipIdOrClip: string | Clip, timelineTime?: RationalTime) =>
+    (clipIdOrClip: string | TimelineReadonly<Clip>, timelineTime?: RationalTime) =>
       engine.media.timelineTimeToSourceTime(clipIdOrClip, timelineTime),
     [engine]
   );
   const sourceTimeToTimelineTime = useCallback(
-    (clipIdOrClip: string | Clip, sourceTime: RationalTime) =>
+    (clipIdOrClip: string | TimelineReadonly<Clip>, sourceTime: RationalTime) =>
       engine.media.sourceTimeToTimelineTime(clipIdOrClip, sourceTime),
     [engine]
   );
@@ -232,22 +233,9 @@ export function useTimelineClips(): UseTimelineClipsResult {
     [engine]
   );
 
-  const selectTimelineClip = useCallback(
-    (clipId: string | null) => {
-      if (clipId !== null && !engine.geometry.getClip(clipId)) {
-        return timelineCommandFail('not-found');
-      }
-      selectClip(clipId);
-      return timelineCommandOk();
-    },
-    [engine, selectClip]
-  );
-
   const updateClip = useCallback(
     (clipId: string, properties: TimelineClipUpdate) => {
-      return engine.updateClipProperties(clipId, properties)
-        ? timelineCommandOk()
-        : timelineCommandFail('not-found');
+      return engine.updateClipProperties(clipId, properties);
     },
     [engine]
   );
@@ -272,7 +260,7 @@ export function useTimelineClips(): UseTimelineClipsResult {
     canTrimClip,
     canSlipClip,
     canSlideClip,
-    selectClip: selectTimelineClip,
+    selectClip,
     updateClip,
   };
 }

--- a/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
+++ b/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
@@ -1,16 +1,14 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type {
   TimelineCommandFailureReason,
   TimelineCommandResult,
-} from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import type {
   TimelineClipGroupPlacement,
   TimelineEditCommitResult,
   TimelineEditRejectionReason,
   TimelineInteractionGeometry,
   Track,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -251,7 +249,7 @@ function isLeavingCurrentTarget(event: DragEvent<HTMLElement>) {
  * @example
  * ```tsx
  * import { addRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
- * import { useTimelineExternalClipDrop } from '#react/hooks';
+ * import { useTimelineExternalClipDrop } from '@techsquidtv/canvas-timeline-react';
  *
  * interface MediaAsset {
  *   id: string;

--- a/packages/react/src/hooks/clips/useTimelineVisibleClips.ts
+++ b/packages/react/src/hooks/clips/useTimelineVisibleClips.ts
@@ -34,7 +34,7 @@ export type UseTimelineVisibleClipsOptions = VisibleTimelineClipOptions;
  *
  * @example
  * ```tsx
- * import { useTimelineVisibleClips } from '#react/hooks';
+ * import { useTimelineVisibleClips } from '@techsquidtv/canvas-timeline-react';
  *
  * export function VisibleClipList() {
  *   const visibleClips = useTimelineVisibleClips({ overscanPixels: 160 });

--- a/packages/react/src/hooks/core/index.ts
+++ b/packages/react/src/hooks/core/index.ts
@@ -1,4 +1,12 @@
-export * from '#react/hooks/core/timelineCommandResult';
+export {
+  timelineCommandOk,
+  timelineCommandFail,
+  timelineCommandInvalidInput,
+} from '@techsquidtv/canvas-timeline-core';
+export type {
+  TimelineCommandResult,
+  TimelineCommandFailureReason,
+} from '@techsquidtv/canvas-timeline-core';
 export * from '#react/hooks/core/timelineControlEvents';
 export * from '#react/hooks/core/usePlaybackEffect';
 export * from '#react/hooks/core/useTimeline';
@@ -6,3 +14,4 @@ export * from '#react/hooks/core/useTimelineEvent';
 export * from '#react/hooks/core/useTimelineState';
 
 export { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+export { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';

--- a/packages/react/src/hooks/core/usePlaybackEffect.ts
+++ b/packages/react/src/hooks/core/usePlaybackEffect.ts
@@ -23,7 +23,7 @@ import { useEffect, useRef } from 'react';
  * @example
  * ```tsx
  * import { useState } from 'react';
- * import { usePlaybackEffect } from '#react/hooks';
+ * import { usePlaybackEffect } from '@techsquidtv/canvas-timeline-react';
  *
  * export function ClipActiveBadge({ clipId }: { clipId: string }) {
  *   const [active, setActive] = useState(false);

--- a/packages/react/src/hooks/core/useTimeline.ts
+++ b/packages/react/src/hooks/core/useTimeline.ts
@@ -1,6 +1,6 @@
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineState } from '#react/hooks/core/useTimelineState';
-import type { TimelineEngine, TimelineState } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineEngine, TimelineStateSnapshot } from '@techsquidtv/canvas-timeline-core';
 /**
  * Engine and synchronized state returned by {@link useTimeline}.
  */
@@ -8,7 +8,7 @@ export interface UseTimelineResult {
   /** Shared engine instance that owns timeline state and commands. */
   engine: TimelineEngine;
   /** React-rendered snapshot of the current timeline state. */
-  state: TimelineState;
+  state: TimelineStateSnapshot;
 }
 
 /**
@@ -21,7 +21,7 @@ export interface UseTimelineResult {
  * slice of timeline behavior.
  *
  * @returns Timeline context containing the shared `TimelineEngine` instance and
- * the synchronized `TimelineState` snapshot.
+ * the synchronized `TimelineStateSnapshot` snapshot.
  *
  * @throws Error when called outside of `TimelineProvider`.
  *

--- a/packages/react/src/hooks/core/useTimelineEvent.ts
+++ b/packages/react/src/hooks/core/useTimelineEvent.ts
@@ -41,7 +41,7 @@ export interface TimelineEventOptions {
  * @example
  * ```tsx
  * import { useState } from 'react';
- * import { useTimelineEvent } from '#react/hooks';
+ * import { useTimelineEvent } from '@techsquidtv/canvas-timeline-react';
  *
  * export function PlaybackRateReadout() {
  *   const [rate, setRate] = useState(1);

--- a/packages/react/src/hooks/core/useTimelineSelector.ts
+++ b/packages/react/src/hooks/core/useTimelineSelector.ts
@@ -2,7 +2,7 @@ import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import type {
   EngineEventMap,
   TimelineEngine,
-  TimelineState,
+  TimelineStateSnapshot,
 } from '@techsquidtv/canvas-timeline-core';
 import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react';
 type Store = ReturnType<typeof createStore>;
@@ -20,36 +20,15 @@ const events: readonly (keyof EngineEventMap)[] = [
   'track:select',
 ];
 function createStore(engine: TimelineEngine) {
-  let engineSnapshot = engine.getState();
-  let snapshot = structuredClone(engineSnapshot) as TimelineState;
+  let snapshot = engine.getState();
   const listeners = new Set<() => void>();
   let unsubscribe: (() => void)[] = [];
   const update = () => {
-    const state = engine.getState();
-    snapshot = {
-      ...state,
-      snapFeedback:
-        state.snapFeedback === engineSnapshot.snapFeedback
-          ? snapshot.snapFeedback
-          : (structuredClone(state.snapFeedback) as TimelineState['snapFeedback']),
-      clipDropFeedback:
-        state.clipDropFeedback === engineSnapshot.clipDropFeedback
-          ? snapshot.clipDropFeedback
-          : { ...state.clipDropFeedback },
-      tracks:
-        state.tracks !== engineSnapshot.tracks
-          ? (structuredClone(state.tracks) as TimelineState['tracks'])
-          : snapshot.tracks,
-      markers:
-        state.markers !== engineSnapshot.markers
-          ? (structuredClone(state.markers) as TimelineState['markers'])
-          : snapshot.markers,
-      clipGroups:
-        state.clipGroups !== engineSnapshot.clipGroups
-          ? (structuredClone(state.clipGroups) as TimelineState['clipGroups'])
-          : snapshot.clipGroups,
-    };
-    engineSnapshot = state;
+    const next = engine.getState();
+    if (next === snapshot) {
+      return;
+    }
+    snapshot = next;
     listeners.forEach((listener) => listener());
   };
   return {
@@ -70,9 +49,59 @@ function createStore(engine: TimelineEngine) {
   };
 }
 
-/** Selects state fields with shallow equality and stable document collection identities. */
-export function useTimelineSelector<Value extends object>(
-  selector: (state: TimelineState) => Value
+function shallowEqual<Value>(previous: Value, next: Value): boolean {
+  if (Object.is(previous, next)) {
+    return true;
+  }
+  if (
+    typeof previous !== 'object' ||
+    previous === null ||
+    typeof next !== 'object' ||
+    next === null
+  ) {
+    return false;
+  }
+  if (Object.getPrototypeOf(previous) !== Object.getPrototypeOf(next)) {
+    return false;
+  }
+  if (!Array.isArray(next) && Object.getPrototypeOf(next) !== Object.prototype) {
+    return false;
+  }
+  if (Array.isArray(previous) && Array.isArray(next) && previous.length !== next.length) {
+    return false;
+  }
+  const keys = Object.keys(next) as (keyof Value)[];
+  return (
+    keys.length === Object.keys(previous).length &&
+    keys.every((key) => Object.hasOwn(previous, key) && Object.is(previous[key], next[key]))
+  );
+}
+
+/**
+ * Selects a value from the engine's immutable, settled state snapshot.
+ *
+ * @remarks
+ * Primitive results use Object.is; arrays and plain objects compare their own
+ * enumerable fields shallowly. Supply isEqual for another selection policy.
+ * This hook excludes per-frame playback and edit-preview updates. Use
+ * {@link useTimelinePlayheadTime} for a live playback readout.
+ *
+ * @param selector - Pure projection of the readonly timeline snapshot.
+ * @param isEqual - Equality check used to preserve the last selected value.
+ * @template Value - Selected value, including primitive values.
+ * @returns The selected value, updated only when its equality check changes.
+ * @example
+ * ```tsx
+ * import { useTimelineSelector } from '@techsquidtv/canvas-timeline-react';
+ * export function TrackCount() {
+ *   const count = useTimelineSelector(state => state.tracks.length);
+ *   return <output>{count}</output>;
+ * }
+ * ```
+ */
+export function useTimelineSelector<Value>(
+  selector: (state: TimelineStateSnapshot) => Value,
+  isEqual: (previous: Value, next: Value) => boolean = shallowEqual
 ): Value {
   const engine = useTimelineEngine();
   const store = useMemo(() => {
@@ -83,19 +112,14 @@ export function useTimelineSelector<Value extends object>(
     }
     return result;
   }, [engine]);
-  const previous = useRef<Value | undefined>(undefined);
+  const previous = useRef<{ value: Value } | undefined>(undefined);
   const getSnapshot = useCallback(() => {
     const next = selector(store.getSnapshot());
-    const last = previous.current;
-    if (
-      last &&
-      Object.keys(next).length === Object.keys(last).length &&
-      (Object.keys(next) as (keyof Value)[]).every((key) => Object.is(last[key], next[key]))
-    ) {
-      return last;
+    if (previous.current && isEqual(previous.current.value, next)) {
+      return previous.current.value;
     }
-    previous.current = next;
+    previous.current = { value: next };
     return next;
-  }, [selector, store]);
+  }, [selector, store, isEqual]);
   return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
 }

--- a/packages/react/src/hooks/core/useTimelineState.ts
+++ b/packages/react/src/hooks/core/useTimelineState.ts
@@ -1,7 +1,7 @@
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import type { TimelineState } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineStateSnapshot } from '@techsquidtv/canvas-timeline-core';
 /**
- * Reads the current synchronized {@link TimelineState} snapshot.
+ * Reads the current synchronized {@link TimelineStateSnapshot} snapshot.
  *
  * @remarks
  *
@@ -16,7 +16,7 @@ import type { TimelineState } from '@techsquidtv/canvas-timeline-core';
  * {@link https://canvastimeline.com/docs/react-hooks | React editor hooks} for
  * the hook selection guide.
  *
- * @returns The latest `TimelineState` snapshot published by `TimelineProvider`.
+ * @returns The latest `TimelineStateSnapshot` snapshot published by `TimelineProvider`.
  *
  * @example
  * ```tsx
@@ -38,11 +38,11 @@ import type { TimelineState } from '@techsquidtv/canvas-timeline-core';
  * }
  * ```
  *
- * @see {@link TimelineState}
+ * @see {@link TimelineStateSnapshot}
  * @see {@link TimelineProvider}
  * @see {@link useTimelinePlayheadTime}
  * @see {@link useTimelineViewport}
  */
-export function useTimelineState(): TimelineState {
+export function useTimelineState(): TimelineStateSnapshot {
   return useTimelineSelector((state) => state);
 }

--- a/packages/react/src/hooks/editing/useTimelineEditCommands.ts
+++ b/packages/react/src/hooks/editing/useTimelineEditCommands.ts
@@ -1,11 +1,7 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type {
   TimelineCommandFailureReason,
   TimelineCommandResult,
-} from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
-import type {
   Clip,
   TimelineDeleteRangeEditCommand,
   TimelineEditCommand,
@@ -23,6 +19,8 @@ import type {
   TimelineSplitEditCommand,
   TimelineTrimEditCommand,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 /** Result returned by `useTimelineEditCommands`. */

--- a/packages/react/src/hooks/editing/useTimelineSnapping.ts
+++ b/packages/react/src/hooks/editing/useTimelineSnapping.ts
@@ -1,13 +1,14 @@
-import { timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
+import { timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
+  TimelineReadonly,
   SnapPreparationOptions,
   TimelineSnapFeedback,
   TimelineSnapResult,
   TimelineSnapTarget,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 /** Result returned by `useTimelineSnapping`. */
@@ -17,7 +18,7 @@ export interface UseTimelineSnappingResult {
   /** Magnetic snap radius in screen pixels. */
   thresholdPixels: number;
   /** Current transient snap feedback for canvas guides and UI status. */
-  feedback: TimelineSnapFeedback;
+  feedback: TimelineReadonly<TimelineSnapFeedback>;
   /** Currently active snap target, or null when nothing is snapped. */
   activeTarget: TimelineSnapTarget | null;
   /** Enables or disables magnetic snapping. */

--- a/packages/react/src/hooks/integration/state-contracts.test.tsx
+++ b/packages/react/src/hooks/integration/state-contracts.test.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { act, render, renderHook, cleanup } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vite-plus/test';
+import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineSelector } from '@techsquidtv/canvas-timeline-react';
+import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { TimelineProvider } from '#react/Provider';
+import { useTimelineState } from '#react/hooks/core/useTimelineState';
+import { useTimelineTrack } from '#react/hooks/tracks/useTimelineTrack';
+import { useTimelineTracks } from '#react/hooks/tracks/useTimelineTracks';
+import { createClip, createTrack } from '#react/hooks/integration/testHelpers';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test('commands from a missing row validate newly added tracks before the next render', () => {
+  const engine = new TimelineEngine({ tracks: [] });
+  const { result } = renderHook(() => useTimelineTrack('new'), {
+    wrapper: ({ children }) => <TimelineProvider engine={engine}>{children}</TimelineProvider>,
+  });
+  act(() => {
+    engine.addTrack(createTrack('new', []));
+    expect(result.current.toggleMute(true)).toEqual({ ok: true });
+  });
+  expect(result.current.muted).toBe(true);
+});
+
+test('StrictMode replay retains geometry sharing for subsequently mounted rows', () => {
+  const engine = new TimelineEngine({ tracks: [createTrack('a', []), createTrack('b', [])] });
+  const geometry = vi.spyOn(engine.geometry, 'getTrackRects');
+  function Row({ id }: { id: string }) {
+    useTimelineTrack(id);
+    return null;
+  }
+  const view = render(
+    <React.StrictMode>
+      <TimelineProvider engine={engine}>
+        <Row id="a" />
+      </TimelineProvider>
+    </React.StrictMode>
+  );
+  view.rerender(
+    <React.StrictMode>
+      <TimelineProvider engine={engine}>
+        <Row id="a" />
+        <Row id="b" />
+      </TimelineProvider>
+    </React.StrictMode>
+  );
+  expect(geometry).toHaveBeenCalledTimes(1);
+});
+
+test('track rows ignore unrelated clip edits and keep command identities stable', () => {
+  const engine = new TimelineEngine({
+    tracks: [createTrack('a', []), createTrack('b', [createClip('clip', 0, 1)])],
+  });
+  const geometry = vi.spyOn(engine.geometry, 'getTrackRects');
+  let renders = 0;
+  const { result } = renderHook(
+    () => {
+      renders++;
+      return useTimelineTrack('a');
+    },
+    {
+      wrapper: ({ children }) => <TimelineProvider engine={engine}>{children}</TimelineProvider>,
+    }
+  );
+  const original = result.current;
+  const initialRenders = renders;
+  act(() => {
+    engine.updateClipProperties('clip', { label: 'changed' });
+  });
+  expect(renders).toBe(initialRenders);
+  expect(result.current).toBe(original);
+  expect(geometry).toHaveBeenCalledTimes(1);
+  act(() => {
+    engine.setTrackHeight('a', 80);
+  });
+  expect(result.current.height).toBe(80);
+  expect(result.current.toggleMute).toBe(original.toggleMute);
+});
+
+test('row geometry updates across resize, reorder, removal, options, and StrictMode replay', () => {
+  const engine = new TimelineEngine({ tracks: [createTrack('a', []), createTrack('b', [])] });
+  const { result, rerender, unmount } = renderHook(
+    ({ height }) => useTimelineTrack('b', { trackHeight: height }),
+    {
+      initialProps: { height: 40 },
+      wrapper: ({ children }) => (
+        <React.StrictMode>
+          <TimelineProvider engine={engine}>{children}</TimelineProvider>
+        </React.StrictMode>
+      ),
+    }
+  );
+  expect(result.current.rect?.y).toBe(72);
+  rerender({ height: 60 });
+  expect(result.current.rect?.y).toBe(92);
+  act(() => {
+    engine.removeTrack('a');
+  });
+  expect(result.current.trackIndex).toBe(0);
+  expect(result.current.rect?.y).toBe(32);
+  act(() => {
+    engine.removeTrack('b');
+  });
+  expect(result.current.exists).toBe(false);
+  expect(result.current.rect).toBeNull();
+  expect(result.current.toggleMute()).toEqual({ ok: false, reason: 'not-found' });
+  unmount();
+});
+
+test('selectors support falsy primitives, custom equality, changing selectors, and engine replacement', () => {
+  const first = new TimelineEngine({ tracks: [] });
+  const second = new TimelineEngine({ tracks: [createTrack('other', [])] });
+  let renders = 0;
+  const { result, rerender } = renderHook(
+    ({ field }: { field: 'tracks' | 'markers' }) => {
+      renders++;
+      return {
+        count: useTimelineSelector((state) => state[field]?.length ?? 0),
+        playing: useTimelineSelector((state) => state.playing),
+        ids: useTimelineSelector(
+          (state) => state.tracks.map((track) => track.id),
+          (a, b) => a.join(',') === b.join(',')
+        ),
+      };
+    },
+    {
+      initialProps: { field: 'tracks' },
+      wrapper: ({ children }) => <TimelineProvider engine={first}>{children}</TimelineProvider>,
+    }
+  );
+  const initialRenders = renders;
+  act(() => {
+    first.setScrollLeft(0);
+  });
+  expect(result.current.count).toBe(0);
+  expect(result.current.playing).toBe(false);
+  expect(renders).toBe(initialRenders);
+  act(() => {
+    first.addTrack(createTrack('added', []));
+  });
+  const ids = result.current.ids;
+  act(() => {
+    first.toggleMuteTrack('added', true);
+  });
+  expect(result.current.ids).toBe(ids);
+  rerender({ field: 'markers' });
+  expect(result.current.count).toBe(0);
+  act(() => {
+    first.addMarker(fromSeconds(1));
+  });
+  expect(result.current.count).toBe(1);
+
+  const selected: string[] = [];
+  function Consumer() {
+    selected.push(useTimelineSelector((state) => state.tracks[0]?.id ?? ''));
+    return null;
+  }
+  const view = render(
+    <TimelineProvider engine={first}>
+      <Consumer />
+    </TimelineProvider>
+  );
+  view.rerender(
+    <TimelineProvider engine={second}>
+      <Consumer />
+    </TimelineProvider>
+  );
+  expect(selected.at(-1)).toBe('other');
+});
+
+test('selection and collection hooks share Core command results', () => {
+  const engine = new TimelineEngine({ tracks: [createTrack('a', [createClip('clip', 0, 1)])] });
+  const { result } = renderHook(
+    () => ({ selection: useTimelineSelection(), tracks: useTimelineTracks() }),
+    {
+      wrapper: ({ children }) => <TimelineProvider engine={engine}>{children}</TimelineProvider>,
+    }
+  );
+  expect(result.current.selection.selectClip('missing')).toEqual({
+    ok: false,
+    reason: 'not-found',
+  });
+  expect(result.current.selection.selectTrack('missing')).toEqual(
+    result.current.tracks.selectTrack('missing')
+  );
+  act(() => {
+    expect(result.current.selection.selectClip('clip')).toEqual({ ok: true });
+  });
+  expect(result.current.selection.selectedClipId).toBe('clip');
+  expect(result.current.selection.selectClips(['clip', 'missing'])).toEqual({
+    ok: false,
+    reason: 'not-found',
+  });
+  expect(engine.getState().tracks[0].clips[0].selected).toBe(true);
+  act(() => {
+    expect(result.current.selection.toggleClipSelection('clip')).toEqual({ ok: true });
+  });
+  expect(result.current.selection.selectedClipId).toBeNull();
+});
+
+test('track rows share one geometry computation', () => {
+  const tracks = Array.from({ length: 12 }, (_, index) => createTrack(`track-${index}`, []));
+  const engine = new TimelineEngine({ tracks });
+  const geometry = vi.spyOn(engine.geometry, 'getTrackRects');
+  function Row({ id }: { id: string }) {
+    useTimelineTrack(id);
+    return null;
+  }
+  render(
+    <TimelineProvider engine={engine}>
+      {tracks.map((track) => (
+        <Row key={track.id} id={track.id} />
+      ))}
+    </TimelineProvider>
+  );
+  const rowsAllocated = geometry.mock.results.reduce(
+    (total, result) => total + (result.type === 'return' ? result.value.length : 0),
+    0
+  );
+  expect(geometry).toHaveBeenCalledTimes(1);
+  expect(rowsAllocated).toBe(12);
+});
+
+test('React reuses immutable Core snapshots and unchanged track identities', () => {
+  const engine = new TimelineEngine({
+    tracks: [createTrack('a', [createClip('clip', 0, 1)]), createTrack('b', [])],
+  });
+  const { result } = renderHook(() => useTimelineState(), {
+    wrapper: ({ children }) => <TimelineProvider engine={engine}>{children}</TimelineProvider>,
+  });
+  const originalCoreTrack = engine.getState().tracks[1];
+  const originalReactTrack = result.current.tracks[1];
+  expect(result.current.tracks).toBe(engine.getState().tracks);
+  act(() => {
+    engine.updateClipProperties('clip', { label: 'edited' });
+  });
+  expect(engine.getState().tracks[1]).toBe(originalCoreTrack);
+  expect(result.current.tracks[1]).toBe(originalReactTrack);
+  expect(Object.isFrozen(engine.getState().tracks)).toBe(true);
+  expect(Object.isFrozen(result.current.tracks)).toBe(true);
+});
+
+test('track commands validate current state and return structured failures', () => {
+  const engine = new TimelineEngine({ tracks: [] });
+  const { result } = renderHook(() => useTimelineTracks(), {
+    wrapper: ({ children }) => <TimelineProvider engine={engine}>{children}</TimelineProvider>,
+  });
+  act(() => {
+    expect(result.current.addTrack(createTrack('new', []))).toEqual({ ok: true });
+    expect(result.current.toggleMute('new', true)).toEqual({ ok: true });
+  });
+  expect(engine.getState().tracks[0].muted).toBe(true);
+  expect(result.current.setTrackHeight('new', Number.NaN)).toMatchObject({
+    ok: false,
+    reason: 'invalid-input',
+  });
+  act(() => {
+    expect(result.current.removeTrack('new')).toEqual({ ok: true });
+    expect(result.current.toggleMute('new')).toEqual({ ok: false, reason: 'not-found' });
+  });
+});

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframeDrag.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframeDrag.ts
@@ -1,10 +1,10 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
   TimelineInteractionGeometry,
   TimelineKeyframeRect,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /** Pointer data needed to begin a keyframe drag. */
@@ -104,7 +104,7 @@ function clampRatio(value: number) {
  *
  * @example
  * ```tsx
- * import { useTimelineKeyframeDrag } from '#react/hooks';
+ * import { useTimelineKeyframeDrag } from '@techsquidtv/canvas-timeline-react';
  *
  * export function KeyframeHandle({ clipId, keyframeId }: { clipId: string; keyframeId: string }) {
  *   const drag = useTimelineKeyframeDrag();

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframeSegments.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframeSegments.ts
@@ -2,11 +2,9 @@ import {
   timelineCommandFail,
   timelineCommandInvalidInput,
   timelineCommandOk,
-} from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
+} from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
   TimelineKeyframeMutationOptions,
   TimelineKeyframePropertyId,
   TimelineKeyframeSegment,
@@ -19,6 +17,8 @@ import type {
   TimelineUpdateClipKeyframeSideOptions,
   VisibleTimelineKeyframeSegment,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
 import { useCallback, useMemo } from 'react';
 /** Options accepted by `useTimelineKeyframeSegments`. */
 export interface UseTimelineKeyframeSegmentsOptions extends TimelineKeyframeSegmentGeometryOptions {

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframeTangentDrag.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframeTangentDrag.ts
@@ -2,16 +2,16 @@ import {
   timelineCommandFail,
   timelineCommandInvalidInput,
   timelineCommandOk,
-} from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+} from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
   TimelineKeyframeBezierHandle,
   TimelineKeyframePropertyId,
   TimelineKeyframeSegmentGeometryOptions,
   TimelineKeyframeSide,
   TimelineKeyframeTangentHandle,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /** Pointer data needed to begin a Bezier tangent handle drag by ids. */
 export interface TimelineKeyframeTangentDragIdStartInput {

--- a/packages/react/src/hooks/keyframes/useTimelineKeyframes.ts
+++ b/packages/react/src/hooks/keyframes/useTimelineKeyframes.ts
@@ -2,11 +2,9 @@ import {
   timelineCommandFail,
   timelineCommandInvalidInput,
   timelineCommandOk,
-} from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
+} from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
   TimelineKeyframe,
   TimelineKeyframeGeometryOptions,
   TimelineKeyframeMutationOptions,
@@ -16,6 +14,8 @@ import type {
   TimelineUpdateClipKeyframeOptions,
   VisibleTimelineKeyframe,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 /**
@@ -102,7 +102,7 @@ export interface UseTimelineKeyframesResult {
  * @example
  * ```tsx
  * import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
- * import { useTimelineKeyframes } from '#react/hooks';
+ * import { useTimelineKeyframes } from '@techsquidtv/canvas-timeline-react';
  *
  * export function OpacityKeyframeButton({ clipId }: { clipId: string }) {
  *   const keyframes = useTimelineKeyframes({ clipId, property: 'opacity' });
@@ -127,7 +127,7 @@ export interface UseTimelineKeyframesResult {
  *
  * @example
  * ```tsx
- * import { useTimelineKeyframes } from '#react/hooks';
+ * import { useTimelineKeyframes } from '@techsquidtv/canvas-timeline-react';
  *
  * export function SelectedKeyframeOverlay() {
  *   const { keyframeRects } = useTimelineKeyframes({ selectedClipOnly: true });

--- a/packages/react/src/hooks/markers/useTimelineMarkers.ts
+++ b/packages/react/src/hooks/markers/useTimelineMarkers.ts
@@ -1,8 +1,11 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type {
+  TimelineCommandResult,
+  Marker,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import type { Marker } from '@techsquidtv/canvas-timeline-core';
 import { compareRational } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
@@ -14,30 +17,33 @@ export type TimelineMarkerUpdate = Partial<
 /** Result returned by `useTimelineMarkers`. */
 export interface UseTimelineMarkersResult {
   /** Current timeline markers sorted by time. */
-  markers: Marker[];
+  markers: readonly TimelineReadonly<Marker>[];
   /** Adds a marker at a timeline time. */
   addMarker: (
     time: RationalTime,
     label?: string,
     color?: string,
     description?: string
-  ) => TimelineCommandResult<Marker>;
+  ) => TimelineCommandResult<TimelineReadonly<Marker>>;
   /** Adds a marker at the current playhead. */
   addMarkerAtPlayhead: (
     label?: string,
     color?: string,
     description?: string
-  ) => TimelineCommandResult<Marker>;
+  ) => TimelineCommandResult<TimelineReadonly<Marker>>;
   /** Removes a marker by id. */
   removeMarker: (id: string) => TimelineCommandResult;
   /** Updates marker metadata by id. */
-  updateMarker: (id: string, updates: TimelineMarkerUpdate) => TimelineCommandResult<Marker>;
+  updateMarker: (
+    id: string,
+    updates: TimelineMarkerUpdate
+  ) => TimelineCommandResult<TimelineReadonly<Marker>>;
   /** Moves the playhead to a marker by id. */
-  seekToMarker: (id: string) => TimelineCommandResult<Marker>;
+  seekToMarker: (id: string) => TimelineCommandResult<TimelineReadonly<Marker>>;
   /** Moves the playhead to the next marker after the current playhead. */
-  seekToNextMarker: () => TimelineCommandResult<Marker>;
+  seekToNextMarker: () => TimelineCommandResult<TimelineReadonly<Marker>>;
   /** Moves the playhead to the previous marker before the current playhead. */
-  seekToPreviousMarker: () => TimelineCommandResult<Marker>;
+  seekToPreviousMarker: () => TimelineCommandResult<TimelineReadonly<Marker>>;
 }
 
 /**
@@ -94,7 +100,9 @@ export function useTimelineMarkers(): UseTimelineMarkersResult {
   const updateMarker = useCallback(
     (id: string, updates: TimelineMarkerUpdate) => {
       const marker = engine.updateMarker(id, updates);
-      return marker ? timelineCommandOk(marker) : timelineCommandFail<Marker>('not-found');
+      return marker
+        ? timelineCommandOk(marker)
+        : timelineCommandFail<TimelineReadonly<Marker>>('not-found');
     },
     [engine]
   );
@@ -103,7 +111,7 @@ export function useTimelineMarkers(): UseTimelineMarkersResult {
     (id: string) => {
       const marker = markers.find((candidate) => candidate.id === id);
       if (!marker) {
-        return timelineCommandFail<Marker>('not-found');
+        return timelineCommandFail<TimelineReadonly<Marker>>('not-found');
       }
       engine.updatePlayhead(marker.time);
       return timelineCommandOk(marker);
@@ -114,7 +122,7 @@ export function useTimelineMarkers(): UseTimelineMarkersResult {
   const seekToNextMarker = useCallback(() => {
     const nextMarker = findNextMarker(engine.playheadTime);
     if (!nextMarker) {
-      return timelineCommandFail<Marker>('not-found');
+      return timelineCommandFail<TimelineReadonly<Marker>>('not-found');
     }
     engine.updatePlayhead(nextMarker.time);
     return timelineCommandOk(nextMarker);
@@ -123,7 +131,7 @@ export function useTimelineMarkers(): UseTimelineMarkersResult {
   const seekToPreviousMarker = useCallback(() => {
     const previousMarker = findPreviousMarker(engine.playheadTime);
     if (!previousMarker) {
-      return timelineCommandFail<Marker>('not-found');
+      return timelineCommandFail<TimelineReadonly<Marker>>('not-found');
     }
     engine.updatePlayhead(previousMarker.time);
     return timelineCommandOk(previousMarker);

--- a/packages/react/src/hooks/playback/internal/externalMediaPlaybackTransport.ts
+++ b/packages/react/src/hooks/playback/internal/externalMediaPlaybackTransport.ts
@@ -2,13 +2,9 @@ import {
   timelineCommandFail,
   timelineCommandInvalidInput,
   timelineCommandOk,
-} from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import { toMediaError } from '#react/hooks/playback/mediaError';
-import { quantizeTimelineTimeToFrame } from '#react/hooks/playback/playbackFrameTime';
+} from '@techsquidtv/canvas-timeline-core';
 import type {
+  TimelineCommandResult,
   ActiveLayerResult,
   ActiveLayerSelector,
   MaybePromise,
@@ -17,6 +13,10 @@ import type {
   TimelineLayerSyncDetails,
   TimelineMediaSyncReason,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
+import { toMediaError } from '#react/hooks/playback/mediaError';
+import { quantizeTimelineTimeToFrame } from '#react/hooks/playback/playbackFrameTime';
 import {
   fromSeconds,
   fromTimecodeFrameNumber,

--- a/packages/react/src/hooks/playback/internal/mediaClockOwnership.ts
+++ b/packages/react/src/hooks/playback/internal/mediaClockOwnership.ts
@@ -1,4 +1,11 @@
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import type {
+  TimelineCommandResult,
+  ActiveLayerSelector,
+  PlaybackOptions,
+  TimelineEngine,
+  TimelineMediaError,
+  TimelineMediaSyncAdapter,
+} from '@techsquidtv/canvas-timeline-core';
 import {
   createCancelledMediaPlayResult,
   createMediaPlayFailure,
@@ -7,13 +14,6 @@ import type { TimelineMediaPlayResult } from '#react/hooks/playback/internal/med
 import type { MediaSynchronizationQueue } from '#react/hooks/playback/internal/mediaSynchronizationQueue';
 import { toMediaError, withMediaCauseMessage } from '#react/hooks/playback/mediaError';
 import { quantizeTimelineTimeToFrame } from '#react/hooks/playback/playbackFrameTime';
-import type {
-  ActiveLayerSelector,
-  PlaybackOptions,
-  TimelineEngine,
-  TimelineMediaError,
-  TimelineMediaSyncAdapter,
-} from '@techsquidtv/canvas-timeline-core';
 import { compareRational, rationalEquals } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime, TimecodeFrameRate } from '@techsquidtv/canvas-timeline-utils';
 export interface PendingMediaPlaybackStart<LayerName extends string, PlayResult> {

--- a/packages/react/src/hooks/playback/internal/useTimelineMediaSyncInternal.ts
+++ b/packages/react/src/hooks/playback/internal/useTimelineMediaSyncInternal.ts
@@ -1,5 +1,11 @@
 import { useActiveLayers } from '#react/hooks/clips/useActiveLayers';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import type {
+  TimelineCommandResult,
+  ActiveLayerResult,
+  ActiveLayerSelector,
+  PlaybackOptions,
+  TimelineMediaSyncAdapter,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import {
   MediaClockOwnership,
@@ -13,12 +19,6 @@ import { useTimelineMediaPlaybackInternal } from '#react/hooks/playback/internal
 import { toMediaError, withMediaCauseMessage } from '#react/hooks/playback/mediaError';
 import type { UseTimelineMediaPlaybackOptions } from '#react/hooks/playback/useTimelineMediaPlayback';
 import { TimelineMediaError } from '@techsquidtv/canvas-timeline-core';
-import type {
-  ActiveLayerResult,
-  ActiveLayerSelector,
-  PlaybackOptions,
-  TimelineMediaSyncAdapter,
-} from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**

--- a/packages/react/src/hooks/playback/useTimelinePlayback.ts
+++ b/packages/react/src/hooks/playback/useTimelinePlayback.ts
@@ -1,8 +1,7 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineCommandResult, PlaybackOptions } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import type { PlaybackOptions } from '@techsquidtv/canvas-timeline-core';
 import { addRational, fromSeconds, subRational } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback } from 'react';

--- a/packages/react/src/hooks/selection/useTimelineClipboard.ts
+++ b/packages/react/src/hooks/selection/useTimelineClipboard.ts
@@ -1,5 +1,5 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineExternalStore } from '#react/hooks/core/useTimelineExternalStore';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';

--- a/packages/react/src/hooks/selection/useTimelineHistory.ts
+++ b/packages/react/src/hooks/selection/useTimelineHistory.ts
@@ -1,5 +1,5 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useCallback } from 'react';
 /** Result returned by `useTimelineHistory`. */

--- a/packages/react/src/hooks/selection/useTimelineRangeSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineRangeSelection.ts
@@ -1,8 +1,10 @@
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import type {
+  TimelineCommandResult,
+  TimelineEditCommitResult,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import { useTimelineEditCommands } from '#react/hooks/editing/useTimelineEditCommands';
-import type { TimelineEditCommitResult } from '@techsquidtv/canvas-timeline-core';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 /** Timeline range selected for range edit commands. */

--- a/packages/react/src/hooks/selection/useTimelineSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineSelection.ts
@@ -1,3 +1,5 @@
+import { timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { deriveTimelineSelection } from '#react/hooks/clips/timelineClipModel';
 import type { TimelineSelectionState } from '#react/hooks/clips/timelineClipModel';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
@@ -21,15 +23,15 @@ export type { TimelineSelectionState } from '#react/hooks/clips/timelineClipMode
  */
 export interface UseTimelineSelectionResult extends TimelineSelectionState {
   /** Selects a clip by id, or clears clip selection when passed null. */
-  selectClip: (clipId: string | null) => void;
+  selectClip: (clipId: string | null) => TimelineCommandResult;
   /** Selects multiple clips by id, clearing clips not included. */
-  selectClips: (clipIds: readonly string[]) => void;
+  selectClips: (clipIds: readonly string[]) => TimelineCommandResult;
   /** Toggles one clip in the current multi-selection. */
-  toggleClipSelection: (clipId: string, selected?: boolean) => boolean;
+  toggleClipSelection: (clipId: string, selected?: boolean) => TimelineCommandResult;
   /** Selects a track by id, or clears track selection when passed null. */
-  selectTrack: (trackId: string | null) => void;
+  selectTrack: (trackId: string | null) => TimelineCommandResult;
   /** Clears both clip and track selection. */
-  clearSelection: () => void;
+  clearSelection: () => TimelineCommandResult;
 }
 
 /**
@@ -45,7 +47,7 @@ export interface UseTimelineSelectionResult extends TimelineSelectionState {
  *
  * @example
  * ```tsx
- * import { useTimelineSelection } from '#react/hooks';
+ * import { useTimelineSelection } from '@techsquidtv/canvas-timeline-react';
  *
  * export function SelectionSummary() {
  *   const selection = useTimelineSelection();
@@ -79,21 +81,21 @@ export function useTimelineSelection(): UseTimelineSelectionResult {
 
   const selectClip = useCallback(
     (clipId: string | null) => {
-      engine.selectClip(clipId);
+      return engine.selectClip(clipId);
     },
     [engine]
   );
 
   const selectTrack = useCallback(
     (trackId: string | null) => {
-      engine.selectTrack(trackId);
+      return engine.selectTrack(trackId);
     },
     [engine]
   );
 
   const selectClips = useCallback(
     (clipIds: readonly string[]) => {
-      engine.selectClips(clipIds);
+      return engine.selectClips(clipIds);
     },
     [engine]
   );
@@ -106,6 +108,7 @@ export function useTimelineSelection(): UseTimelineSelectionResult {
   const clearSelection = useCallback(() => {
     engine.selectClip(null);
     engine.selectTrack(null);
+    return timelineCommandOk();
   }, [engine]);
 
   return {

--- a/packages/react/src/hooks/tracks/useTimelineTrack.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrack.ts
@@ -1,14 +1,13 @@
-import { timelineCommandFail } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineGeometryRevision } from '#react/hooks/core/useTimelineGeometryRevision';
-import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import { useTimelineTracks } from '#react/hooks/tracks/useTimelineTracks';
 import type {
+  TimelineCommandResult,
+  TimelineReadonly,
   TimelineTrackGeometryOptions,
   TimelineTrackRect,
   Track,
 } from '@techsquidtv/canvas-timeline-core';
+import { useTimelineTrackGeometry } from '#react/hooks/tracks/useTimelineTrackGeometry';
+import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
+import { useTimelineTrackCommands } from '#react/hooks/tracks/useTimelineTrackCommands';
 import { useCallback, useMemo } from 'react';
 /**
  * Result returned by `useTimelineTrack`.
@@ -27,11 +26,11 @@ export interface UseTimelineTrackResult {
   /** Requested track id. */
   trackId: string;
   /** Current track, or null when the id is missing. */
-  track: Track | null;
+  track: TimelineReadonly<Track> | null;
   /** Zero-based track index, or -1 when the track is missing. */
   trackIndex: number;
   /** Viewport row rectangle matching canvas track geometry. */
-  rect: TimelineTrackRect | null;
+  rect: Readonly<TimelineTrackRect> | null;
   /** Whether the requested track exists. */
   exists: boolean;
   /** App-defined track kind, or null when the track is missing. */
@@ -94,7 +93,7 @@ export interface UseTimelineTrackResult {
  *
  * @example
  * ```tsx
- * import { useTimelineTrack } from '#react/hooks';
+ * import { useTimelineTrack } from '@techsquidtv/canvas-timeline-react';
  *
  * export function TrackMuteButton({ trackId }: { trackId: string }) {
  *   const track = useTimelineTrack(trackId);
@@ -115,51 +114,18 @@ export function useTimelineTrack(
   trackId: string,
   options: TimelineTrackGeometryOptions = {}
 ): UseTimelineTrackResult {
-  const engine = useTimelineEngine();
-  const state = useTimelineSelector((state) => ({ tracks: state.tracks }));
-  const tracksState = useTimelineTracks();
-  const revision = useTimelineGeometryRevision();
-  const trackSnapshot = useMemo(() => {
-    void revision;
-    const tracks = state.tracks;
-    const trackIndex = tracks.findIndex((candidate) => candidate.id === trackId);
-    const track = trackIndex === -1 ? null : tracks[trackIndex];
-
-    if (trackIndex === -1) {
-      return {
-        track: null,
-        trackIndex,
-        rect: null,
-      };
-    }
-
-    const rect =
-      engine.geometry.getTrackRects({
-        collapsedTrackHeight: options.collapsedTrackHeight,
-        edgeThreshold: options.edgeThreshold,
-        rulerHeight: options.rulerHeight,
-        touchEdgeThreshold: options.touchEdgeThreshold,
-        trackHeight: options.trackHeight,
-        viewportWidth: options.viewportWidth,
-      })[trackIndex] ?? null;
-
-    return {
-      track,
-      trackIndex,
-      rect,
-    };
-  }, [
-    engine,
-    options.collapsedTrackHeight,
-    options.edgeThreshold,
-    options.rulerHeight,
-    options.touchEdgeThreshold,
-    options.trackHeight,
-    options.viewportWidth,
-    revision,
-    state.tracks,
-    trackId,
-  ]);
+  const rect = useTimelineTrackGeometry(trackId, options);
+  const track = useTimelineSelector((state) => {
+    const indexed = rect === null ? undefined : state.tracks[rect.trackIndex];
+    return indexed?.id === trackId
+      ? indexed
+      : (state.tracks.find((candidate) => candidate.id === trackId) ?? null);
+  }, Object.is);
+  const tracksState = useTimelineTrackCommands();
+  const trackSnapshot = useMemo(
+    () => ({ track, trackIndex: rect?.trackIndex ?? -1, rect }),
+    [track, rect]
+  );
 
   const selectTrack = useCallback(() => tracksState.selectTrack(trackId), [trackId, tracksState]);
 
@@ -217,8 +183,6 @@ export function useTimelineTrack(
     const { rect, track, trackIndex } = trackSnapshot;
 
     if (track === null) {
-      const fail = () => timelineCommandFail('not-found');
-
       return {
         trackId,
         track: null,
@@ -235,17 +199,17 @@ export function useTimelineTrack(
         locked: false,
         targeted: false,
         collapsed: false,
-        selectTrack: fail,
-        toggleVisibility: fail,
-        setVisible: fail,
-        toggleMute: fail,
-        setMuted: fail,
-        toggleLock: fail,
-        setLocked: fail,
-        setTrackHeight: fail,
-        toggleTrackTarget: fail,
-        setTrackTarget: fail,
-        setTrackGroup: fail,
+        selectTrack,
+        toggleVisibility,
+        setVisible,
+        toggleMute,
+        setMuted,
+        toggleLock,
+        setLocked,
+        setTrackHeight,
+        toggleTrackTarget,
+        setTrackTarget,
+        setTrackGroup,
       };
     }
 

--- a/packages/react/src/hooks/tracks/useTimelineTrackCommands.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackCommands.ts
@@ -1,0 +1,21 @@
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useMemo } from 'react';
+
+/** Stable delegates; all validation reads the current engine state. */
+export function useTimelineTrackCommands() {
+  const engine = useTimelineEngine();
+  return useMemo(
+    () => ({
+      selectTrack: engine.selectTrack.bind(engine),
+      addTrack: engine.addTrack.bind(engine),
+      removeTrack: engine.removeTrack.bind(engine),
+      toggleMute: engine.toggleMuteTrack.bind(engine),
+      toggleVisibility: engine.toggleTrackVisibility.bind(engine),
+      toggleLock: engine.toggleLockTrack.bind(engine),
+      setTrackHeight: engine.setTrackHeight.bind(engine),
+      toggleTrackTarget: engine.toggleTrackTarget.bind(engine),
+      setTrackGroup: engine.setTrackGroup.bind(engine),
+    }),
+    [engine]
+  );
+}

--- a/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
@@ -8,6 +8,7 @@ import type {
   TimelineTrackGeometryOptions,
   TimelineTrackHitTestResult,
   Track,
+  TimelineReadonly,
   TrackHitTestInput,
 } from '@techsquidtv/canvas-timeline-core';
 import { useCallback, useMemo } from 'react';
@@ -27,9 +28,9 @@ export interface TimelineTrackDropContext {
   /** Clip being moved. */
   clip: Clip;
   /** Track that contained the clip at drag start. */
-  sourceTrack: Track;
+  sourceTrack: TimelineReadonly<Track>;
   /** Candidate destination track. */
-  targetTrack: Track;
+  targetTrack: TimelineReadonly<Track>;
   /** Source track index at drag start. */
   sourceTrackIndex: number;
   /** Candidate destination track index. */
@@ -84,9 +85,11 @@ export interface UseTimelineTrackDropTargetsOptions extends TimelineTrackGeometr
  */
 export interface UseTimelineTrackDropTargetsResult {
   /** Viewport-space track rows in timeline order. */
-  trackTargets: TimelineTrackHitTestResult[];
+  trackTargets: TimelineReadonly<TimelineTrackHitTestResult>[];
   /** Hit-tests timeline tracks in viewport coordinates. */
-  getTrackAtViewportPoint: (input: TrackHitTestInput) => TimelineTrackHitTestResult | null;
+  getTrackAtViewportPoint: (
+    input: TrackHitTestInput
+  ) => TimelineReadonly<TimelineTrackHitTestResult> | null;
   /** Resolves whether one clip may drop on one candidate track. */
   canDropClipOnTrack: (
     clipId: string,
@@ -102,8 +105,8 @@ const acceptedDropResult: TimelineTrackDropResult = {
 };
 
 function isTrackDropTarget(
-  target: TimelineTrackHitTestResult | null
-): target is TimelineTrackHitTestResult {
+  target: TimelineReadonly<TimelineTrackHitTestResult> | null
+): target is TimelineReadonly<TimelineTrackHitTestResult> {
   return target !== null;
 }
 
@@ -143,7 +146,7 @@ function normalizeGuardResult(
  *
  * @example
  * ```tsx
- * import { useTimelineTrackDropTargets } from '#react/hooks';
+ * import { useTimelineTrackDropTargets } from '@techsquidtv/canvas-timeline-react';
  *
  * export function TrackDropOverlay({ clipId }: { clipId: string }) {
  *   const targets = useTimelineTrackDropTargets({

--- a/packages/react/src/hooks/tracks/useTimelineTrackGeometry.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackGeometry.ts
@@ -1,0 +1,117 @@
+import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { defaultTimelineInteractionGeometry } from '@techsquidtv/canvas-timeline-core';
+import type {
+  TimelineEngine,
+  TimelineStateSnapshot,
+  TimelineTrackGeometryOptions,
+  TimelineTrackRect,
+} from '@techsquidtv/canvas-timeline-core';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+const stores = new WeakMap<TimelineEngine, Map<string, ReturnType<typeof createStore>>>();
+
+function createStore(
+  engine: TimelineEngine,
+  options: TimelineTrackGeometryOptions,
+  release: () => void,
+  retain: () => void
+) {
+  let previous: TimelineStateSnapshot | undefined;
+  let rectangles = new Map<string, Readonly<TimelineTrackRect>>();
+  const listeners = new Set<() => void>();
+  let unsubscribe: (() => void)[] = [];
+  const update = () => {
+    const state = engine.getState();
+    if (
+      previous &&
+      state.scrollTop === previous.scrollTop &&
+      state.viewportWidth === previous.viewportWidth &&
+      state.tracks.length === previous.tracks.length &&
+      state.tracks.every((track, index) => {
+        const prior = previous?.tracks[index];
+        return (
+          track.id === prior?.id &&
+          track.height === prior.height &&
+          track.collapsed === prior.collapsed
+        );
+      })
+    ) {
+      previous = state;
+      return;
+    }
+    previous = state;
+    rectangles = new Map(
+      engine.geometry.getTrackRects(options).map((rect) => {
+        const prior = rectangles.get(rect.trackId);
+        return [
+          rect.trackId,
+          prior &&
+          (Object.keys(rect) as (keyof TimelineTrackRect)[]).every(
+            (key) => rect[key] === prior[key]
+          )
+            ? prior
+            : Object.freeze(rect),
+        ];
+      })
+    );
+    listeners.forEach((listener) => listener());
+  };
+  update();
+  return {
+    get: (trackId: string) => rectangles.get(trackId) ?? null,
+    subscribe: (listener: () => void) => {
+      if (listeners.size === 0) {
+        retain();
+        unsubscribe = [engine.on('state:settled', update), engine.on('content:change', update)];
+        update();
+      }
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) {
+          unsubscribe.forEach((dispose) => dispose());
+          release();
+        }
+      };
+    },
+  };
+}
+
+/** Shares row geometry across consumers using the same normalized layout options. */
+export function useTimelineTrackGeometry(trackId: string, options: TimelineTrackGeometryOptions) {
+  const engine = useTimelineEngine();
+  const rulerHeight = options.rulerHeight ?? defaultTimelineInteractionGeometry.rulerHeight;
+  const trackHeight = options.trackHeight ?? defaultTimelineInteractionGeometry.trackHeight;
+  const collapsedTrackHeight =
+    options.collapsedTrackHeight ?? defaultTimelineInteractionGeometry.collapsedTrackHeight;
+  const viewportWidth = options.viewportWidth;
+  const store = useMemo(() => {
+    let engineStores = stores.get(engine);
+    if (!engineStores) {
+      engineStores = new Map();
+      stores.set(engine, engineStores);
+    }
+    const key = [rulerHeight, trackHeight, collapsedTrackHeight, viewportWidth ?? 'auto'].join(':');
+    let result = engineStores.get(key);
+    if (!result) {
+      result = createStore(
+        engine,
+        { rulerHeight, trackHeight, collapsedTrackHeight, viewportWidth },
+        () => {
+          if (engineStores.get(key) === result) {
+            engineStores.delete(key);
+          }
+        },
+        () => {
+          if (result) {
+            engineStores.set(key, result);
+          }
+        }
+      );
+      engineStores.set(key, result);
+    }
+    return result;
+  }, [engine, rulerHeight, trackHeight, collapsedTrackHeight, viewportWidth]);
+  const getSnapshot = useCallback(() => store.get(trackId), [store, trackId]);
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/react/src/hooks/tracks/useTimelineTrackHeader.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackHeader.ts
@@ -47,7 +47,7 @@ export interface UseTimelineTrackHeaderResult extends UseTimelineTrackResult {
  *
  * @example
  * ```tsx
- * import { useTimelineTrackHeader } from '#react/hooks';
+ * import { useTimelineTrackHeader } from '@techsquidtv/canvas-timeline-react';
  *
  * export function CustomTrackHeader({ trackId }: { trackId: string }) {
  *   const header = useTimelineTrackHeader(trackId);

--- a/packages/react/src/hooks/tracks/useTimelineTrackLockControl.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackLockControl.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, type ButtonHTMLAttributes } from 'react';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineTrackHeader } from '#react/hooks/tracks/useTimelineTrackHeader';
 
 /** Props returned for a track lock button. */

--- a/packages/react/src/hooks/tracks/useTimelineTracks.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTracks.ts
@@ -1,9 +1,11 @@
-import { timelineCommandFail, timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
-import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { useTimelineTrackCommands } from '#react/hooks/tracks/useTimelineTrackCommands';
+import type {
+  TimelineCommandResult,
+  Track,
+  TimelineReadonly,
+} from '@techsquidtv/canvas-timeline-core';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
-import type { Track } from '@techsquidtv/canvas-timeline-core';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 /**
  * Result returned by `useTimelineTracks`.
  *
@@ -21,17 +23,17 @@ import { useCallback, useMemo } from 'react';
  */
 export interface UseTimelineTracksResult {
   /** Current ordered track list. */
-  tracks: Track[];
+  tracks: readonly TimelineReadonly<Track>[];
   /** Currently selected track, or null when no track is selected. */
-  selectedTrack: Track | null;
+  selectedTrack: TimelineReadonly<Track> | null;
   /** Tracks currently participating in active layer and media lookup. */
-  visibleTracks: Track[];
+  visibleTracks: TimelineReadonly<Track>[];
   /** Tracks currently hidden from active layer and media lookup. */
-  hiddenTracks: Track[];
+  hiddenTracks: TimelineReadonly<Track>[];
   /** Tracks currently targeted for edit operations. */
-  targetedTracks: Track[];
+  targetedTracks: TimelineReadonly<Track>[];
   /** Tracks grouped by group id, with ungrouped tracks under "ungrouped". */
-  tracksByGroupId: Record<string, Track[]>;
+  tracksByGroupId: Record<string, TimelineReadonly<Track>[]>;
   /** Selects a track by id, or clears track selection. */
   selectTrack: (trackId: string | null) => TimelineCommandResult;
   /** Adds a track to the timeline. */
@@ -85,7 +87,7 @@ export interface UseTimelineTracksResult {
  *
  * @example
  * ```tsx
- * import { useTimelineTracks } from '#react/hooks';
+ * import { useTimelineTracks } from '@techsquidtv/canvas-timeline-react';
  *
  * export function TrackVisibilityMenu() {
  *   const { tracks, toggleVisibility } = useTimelineTracks();
@@ -108,15 +110,15 @@ export interface UseTimelineTracksResult {
  * @see {@link https://canvastimeline.com/demos/timeline-editor-controls | Timeline editor controls demo}
  */
 export function useTimelineTracks(): UseTimelineTracksResult {
-  const engine = useTimelineEngine();
+  const commands = useTimelineTrackCommands();
   const state = useTimelineSelector((state) => ({ tracks: state.tracks }));
-  const tracks = useMemo(() => state.tracks, [state.tracks]);
+  const tracks = state.tracks;
   const selectedTrack = useMemo(() => tracks.find((track) => track.selected) || null, [tracks]);
   const visibleTracks = useMemo(() => tracks.filter((track) => track.visible), [tracks]);
   const hiddenTracks = useMemo(() => tracks.filter((track) => !track.visible), [tracks]);
   const targetedTracks = useMemo(() => tracks.filter((track) => track.targeted), [tracks]);
   const tracksByGroupId = useMemo(() => {
-    const groupedTracks: Record<string, Track[]> = {};
+    const groupedTracks: Record<string, TimelineReadonly<Track>[]> = {};
     for (const track of tracks) {
       const groupId = track.groupId || 'ungrouped';
       groupedTracks[groupId] ??= [];
@@ -124,98 +126,6 @@ export function useTimelineTracks(): UseTimelineTracksResult {
     }
     return groupedTracks;
   }, [tracks]);
-
-  const selectTrack = useCallback(
-    (trackId: string | null) => {
-      if (trackId !== null && !tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.selectTrack(trackId);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const addTrack = useCallback(
-    (track: Track) => {
-      engine.addTrack(track as Track);
-      return timelineCommandOk();
-    },
-    [engine]
-  );
-
-  const removeTrack = useCallback(
-    (trackId: string) => {
-      return engine.removeTrack(trackId) ? timelineCommandOk() : timelineCommandFail('not-found');
-    },
-    [engine]
-  );
-
-  const toggleMute = useCallback(
-    (trackId: string, muted?: boolean) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.toggleMuteTrack(trackId, muted);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const toggleVisibility = useCallback(
-    (trackId: string, visible?: boolean) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.toggleTrackVisibility(trackId, visible);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const toggleLock = useCallback(
-    (trackId: string, locked?: boolean) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.toggleLockTrack(trackId, locked);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const setTrackHeight = useCallback(
-    (trackId: string, height: number) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.setTrackHeight(trackId, height);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const toggleTrackTarget = useCallback(
-    (trackId: string, targeted?: boolean) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.toggleTrackTarget(trackId, targeted);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
-
-  const setTrackGroup = useCallback(
-    (trackId: string, groupId: string | undefined) => {
-      if (!tracks.some((track) => track.id === trackId)) {
-        return timelineCommandFail('not-found');
-      }
-      engine.setTrackGroup(trackId, groupId);
-      return timelineCommandOk();
-    },
-    [engine, tracks]
-  );
 
   return useMemo(
     () => ({
@@ -225,32 +135,8 @@ export function useTimelineTracks(): UseTimelineTracksResult {
       hiddenTracks,
       targetedTracks,
       tracksByGroupId,
-      selectTrack,
-      addTrack,
-      removeTrack,
-      toggleMute,
-      toggleVisibility,
-      toggleLock,
-      setTrackHeight,
-      toggleTrackTarget,
-      setTrackGroup,
+      ...commands,
     }),
-    [
-      addTrack,
-      hiddenTracks,
-      removeTrack,
-      selectTrack,
-      selectedTrack,
-      setTrackGroup,
-      setTrackHeight,
-      targetedTracks,
-      toggleLock,
-      toggleMute,
-      toggleVisibility,
-      toggleTrackTarget,
-      tracksByGroupId,
-      tracks,
-      visibleTracks,
-    ]
+    [tracks, selectedTrack, visibleTracks, hiddenTracks, targetedTracks, tracksByGroupId, commands]
   );
 }

--- a/packages/react/src/hooks/viewport/useTimelineTimePosition.ts
+++ b/packages/react/src/hooks/viewport/useTimelineTimePosition.ts
@@ -71,7 +71,7 @@ function parsePositionEventsKey(positionEventsKey: string): TimelineTimePosition
  * @example
  * ```tsx
  * import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
- * import { useTimeline, useTimelineTimePosition } from '#react/hooks';
+ * import { useTimeline, useTimelineTimePosition } from '@techsquidtv/canvas-timeline-react';
  *
  * export function MarkerHead({ markerTime }: { markerTime: RationalTime }) {
  *   const engine = useTimelineEngine();

--- a/packages/react/src/hooks/viewport/useTimelineViewport.ts
+++ b/packages/react/src/hooks/viewport/useTimelineViewport.ts
@@ -1,5 +1,5 @@
-import { timelineCommandOk } from '#react/hooks/core/timelineCommandResult';
-import type { TimelineCommandResult } from '#react/hooks/core/timelineCommandResult';
+import { timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
+import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import { useTimelineScrollLeft } from '#react/hooks/viewport/useTimelineScrollLeft';

--- a/packages/react/src/timecodeInput/TimecodeInput.tsx
+++ b/packages/react/src/timecodeInput/TimecodeInput.tsx
@@ -50,7 +50,7 @@ export interface TimecodeInputProps extends React.ComponentPropsWithoutRef<typeo
  * @example
  * ```tsx
  * import { useState } from 'react';
- * import { TimecodeInput } from '#react/timecode-input';
+ * import { TimecodeInput } from '@techsquidtv/canvas-timeline-react/timecode-input';
  * import { fromSeconds, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
  * import {
  *   type TimecodeFormatOptions,

--- a/scripts/checks/consumer-smoke.mjs
+++ b/scripts/checks/consumer-smoke.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -50,6 +50,24 @@ const packPackage = async (packageDir, packDir) => {
 const writeConsumerFixture = async ({ fixtureDir, tarballs, rootManifest }) => {
   const srcDir = join(fixtureDir, 'src');
   await mkdir(srcDir, { recursive: true });
+
+  // Compile actual TSDoc examples against packed packages, without workspace aliases.
+  const exampleSources = [
+    'core/useTimelineSelector.ts',
+    'clips/useTimelineClips.ts',
+    'tracks/useTimelineTracks.ts',
+  ];
+  for (const [sourceIndex, source] of exampleSources.entries()) {
+    const text = await readFile(join(packagesRoot, 'react/src/hooks', source), 'utf8');
+    const examples = [...text.matchAll(/@example\s*\n\s*\* ```tsx\n([\s\S]*?)\n\s*\* ```/g)];
+    if (examples.length === 0) {
+      throw new Error(`Missing consumer examples in ${source}`);
+    }
+    for (const [index, example] of examples.entries()) {
+      const code = example[1].replace(/^\s*\* ?/gm, '');
+      await writeFile(join(srcDir, `example-${sourceIndex}-${index}.tsx`), `${code}\n`);
+    }
+  }
 
   const packageTarballDependencies = Object.fromEntries(
     [...tarballs.entries()].map(([packageName, tarballPath]) => [

--- a/scripts/checks/react-registry.mjs
+++ b/scripts/checks/react-registry.mjs
@@ -15,7 +15,8 @@ const outputDir = resolve(repoRoot, 'apps/www/.generated/react-registry-snippets
 const internalHookAllowlist = new Set([
   'useTimelineExternalStore',
   'useTimelineGeometryRevision',
-  'useTimelineSelector',
+  'useTimelineTrackCommands',
+  'useTimelineTrackGeometry',
   'useTimelineMediaPlaybackInternal',
   'useTimelineMediaSyncInternal',
 ]);
@@ -385,7 +386,7 @@ async function verifyInternalHookAllowlist({ exportedTimelineHookNames }) {
     (name) => !exportedTimelineHooks.has(name) && !internalHookAllowlist.has(name)
   );
   const staleAllowlistEntries = [...internalHookAllowlist].filter(
-    (name) => !hookFileNames.includes(name)
+    (name) => !hookFileNames.includes(name) || exportedTimelineHooks.has(name)
   );
 
   if (unexpectedInternalHooks.length > 0 || staleAllowlistEntries.length > 0) {
@@ -394,7 +395,10 @@ async function verifyInternalHookAllowlist({ exportedTimelineHookNames }) {
         'Hook files neither exported nor allowlisted as internal',
         unexpectedInternalHooks
       ),
-      formatList('Internal hook allowlist entries without matching files', staleAllowlistEntries),
+      formatList(
+        'Internal hook allowlist entries without matching internal files',
+        staleAllowlistEntries
+      ),
     ]
       .filter(Boolean)
       .join('\n');

--- a/test-utils/setup/api-reference.ts
+++ b/test-utils/setup/api-reference.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, URL } from 'node:url';
+
+// Only the docs test project runs this setup. Reuse the normal cached docs task.
 export default function setup() {
-  execFileSync(process.execPath, ['scripts/generate/api-reference.mjs'], {
-    cwd: fileURLToPath(new URL('../../apps/www/', import.meta.url)),
+  execFileSync('vp', ['run', 'docs:api'], {
+    cwd: fileURLToPath(new URL('../../', import.meta.url)),
     stdio: 'pipe',
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -658,9 +658,25 @@ export default defineConfig({
       },
     },
     globals: true,
-    include: ['apps/**/*.{test,spec}.{ts,tsx}', 'packages/**/*.{test,spec}.{ts,tsx}'],
     setupFiles: ['./test-utils/setup/browser-storage.ts'],
-    globalSetup: ['./test-utils/setup/api-reference.ts'],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['apps/**/*.{test,spec}.{ts,tsx}', 'packages/**/*.{test,spec}.{ts,tsx}'],
+          exclude: ['**/node_modules/**', '**/.git/**', 'apps/www/src/lib/api-markdown.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'docs',
+          include: ['apps/www/src/lib/api-markdown.test.ts'],
+          globalSetup: ['./test-utils/setup/api-reference.ts'],
+        },
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

- Validate track and selection commands in Core and return one result contract. Adding a track and immediately muting it now succeeds before React renders; invalid or missing targets return structured failures.
- Reuse immutable snapshots across Core, history, and React, preserving unchanged tracks and clips. Share row geometry and expose `useTimelineSelector` for custom primitive/object selections.
- Isolate API generation to docs tests, replace private imports in public examples, and compile representative TSDoc examples against packed packages.

## Release impact

- **Breaking:** React snapshot values are readonly. Core track/selection commands and clip presentation updates return `TimelineCommandResult`; React selection commands match. Check `result.ok`, and edit snapshots through commands. Invalid selection IDs preserve current selection.
- Includes a minor Changeset for the pre-1.0 lockstep release, migration documentation, and readonly updates to the demos and read-only source-time helpers. No compatibility aliases.
- Public selector equality and reactivity are documented; playback remains outside settled-state subscriptions.

## Validation

- `vp run ci`: 689 tests passed; package coverage, docs/demo builds, publishing metadata, packed consumer compilation/build, and headless smoke test passed.
- `vp run repo:check`, registry checks, Knip, and commitlint passed. The locked toolchain reports non-failing React Compiler lint warnings in existing components.
- Regression tests cover immediate command sequences, invalid/duplicate input, immutable snapshots, sibling identity, undo/redo, primitive/custom selectors, engine replacement, row rendering, and StrictMode sharing. Twelve row hooks now compute 12 rectangles once rather than allocating 144.
