### PR TITLE
fix!: preserve timeline timing and immutable state boundaries

### DIFF
--- a/.changeset/accurate-owned-timeline.md
+++ b/.changeset/accurate-owned-timeline.md
@@ -1,0 +1,21 @@
+---
+'@techsquidtv/canvas-timeline-utils': minor
+'@techsquidtv/canvas-timeline-core': minor
+'@techsquidtv/canvas-timeline-react': minor
+'@techsquidtv/canvas-timeline-renderer': minor
+'@techsquidtv/canvas-timeline-html-media-adapter': minor
+'@techsquidtv/canvas-timeline-mediabunny-adapter': minor
+'@techsquidtv/canvas-timeline': minor
+---
+
+Fix playback at low tick rates, fractional-time HTML media recovery, and drop-frame
+timecode cache collisions. Restore saved playback ranges, own constructor time
+values, and reject invalid track-height batches before applying any changes.
+
+**BREAKING:** Geometry, active-media, and keyframe queries now expose readonly
+document records. Accept `TimelineReadonly<Clip>` and `TimelineReadonly<Track>` in
+read-only helpers, and use engine commands to edit the document. Metadata uses
+`TimelineMetadata`: plain objects and arrays of strings, finite numbers, booleans,
+`null`, or `undefined`. Move Maps, Sets, Dates, buffers, class instances, and cyclic
+data into application-owned stores keyed by clip or source ID. These values are
+rejected instead of being retained in mutable history snapshots.

--- a/apps/full-editor-demo/src/app/App.test.tsx
+++ b/apps/full-editor-demo/src/app/App.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vite-plus/test';
+import { useTimelineEngine } from '@techsquidtv/canvas-timeline-react';
+import { App } from '#full-editor/app/App';
+import { loadEditorBootstrap } from '#full-editor/app/bootstrap/loadEditorBootstrap';
+import { getDefaultProjectMetadata } from '#full-editor/features/project/project-metadata';
+
+vi.mock('#full-editor/app/bootstrap/loadEditorBootstrap', () => ({ loadEditorBootstrap: vi.fn() }));
+vi.mock('#full-editor/features/project/ProjectAutosave', () => ({ ProjectAutosave: () => null }));
+vi.mock('#full-editor/features/project/ProjectProvider', () => ({
+  ProjectProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('#full-editor/features/source-bin/SourceBinProvider', () => ({
+  SourceBinProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('#full-editor/features/media/MediaSyncProvider', () => ({
+  MediaSyncProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('#full-editor/features/timeline/TimelineDropModeProvider', () => ({
+  TimelineDropModeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('#full-editor/app/shell/EditorShell', () => ({
+  EditorShell: () => {
+    const state = useTimelineEngine().getState();
+    return (
+      <output data-testid="range">
+        {state.inPoint?.v ?? 'missing'}:{state.outPoint?.v ?? 'missing'}
+      </output>
+    );
+  },
+}));
+
+test('restoring a saved project preserves its In/Out points', async () => {
+  vi.mocked(loadEditorBootstrap).mockResolvedValue({
+    projectMetadata: getDefaultProjectMetadata(),
+    projectState: {
+      tracks: [],
+      clipGroups: [],
+      markers: [],
+      duration: { v: 10, r: 1 },
+      inPoint: { v: 2, r: 1 },
+      outPoint: { v: 8, r: 1 },
+      playheadTime: { v: 0, r: 1 },
+      scrollLeft: 0,
+      scrollTop: 0,
+      zoomScale: 100,
+      snapEnabled: true,
+      snapThresholdPixels: 10,
+    },
+    sources: [],
+    storageAvailable: false,
+  });
+  render(<App />);
+  expect((await screen.findByTestId('range')).textContent).toBe('2:8');
+});

--- a/apps/full-editor-demo/src/app/App.tsx
+++ b/apps/full-editor-demo/src/app/App.tsx
@@ -129,6 +129,8 @@ function LoadedEditor({
       new TimelineEngine({
         clipGroups: bootstrapState.projectState.clipGroups,
         duration: bootstrapState.projectState.duration,
+        inPoint: bootstrapState.projectState.inPoint,
+        outPoint: bootstrapState.projectState.outPoint,
         markers: bootstrapState.projectState.markers,
         playheadTime: bootstrapState.projectState.playheadTime,
         scrollLeft: bootstrapState.projectState.scrollLeft,

--- a/apps/www/src/content/docs/engine-migration.mdx
+++ b/apps/www/src/content/docs/engine-migration.mdx
@@ -44,6 +44,25 @@ Move former direct calls to the corresponding service. Playback, document operat
 
 `getState()`, `getRenderState()`, and the engine's track/group/marker collections are readonly snapshots. Initial times and metadata are owned by the engine. Change content through commands instead of assigning to returned state. Unchanged collections and time values retain their references across viewport changes.
 
+**Breaking:** Clip lookup, hit tests, geometry entries, active-media queries, and
+keyframe queries now return readonly document records too. Helpers that consume
+these records should accept `TimelineReadonly<Clip>` or `TimelineReadonly<Track>`.
+Use `updateClipProperties`, `commitEdit`, or the keyframe commands to change them.
+Geometry includes current edit previews; `geometry.getClip()` and media queries
+inspect committed content. Repeated queries reuse cached document snapshots.
+
+**Breaking:** Clip, snap-target, and edit-guide metadata use `TimelineMetadata`.
+Values may be plain objects, arrays, strings, finite numbers, booleans, `null`,
+or `undefined`. Cycles, accessors, symbol keys, Maps, Sets, Dates, buffers, and
+class instances are rejected on input. Store domain objects in an application
+store keyed by `clip.id` or `sourceId`; keep only lightweight values or identifiers
+in metadata. Metadata is copied on input and deeply frozen in read snapshots.
+
+The constructor accepts `inPoint` and `outPoint` alongside `playheadTime` and
+`duration`. Pass all four when restoring a saved project; the engine owns copies
+of each time. `setTrackHeights` validates the complete batch, including its
+optional `scrollTop`, before changing any track or publishing events.
+
 History defaults to 100 snapshots and a conservative 16 MiB serialized-byte budget. Configure `history: { maxEntries, maxBytes }` when constructing an engine. The current document is always retained, even if it exceeds the budget; older undo entries are evicted first. Unchanged clip records are shared, and unchanged checkpoints are skipped.
 
 ## React and controls

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,6 +50,13 @@ if (preview.valid) {
 }
 ```
 
+State, geometry, and active-media queries expose readonly document snapshots.
+Update content through engine commands. Clip metadata accepts lightweight plain
+objects and arrays containing strings, finite numbers, booleans, `null`, or
+`undefined`; store Maps, Dates, buffers, and other domain objects outside the
+engine. See the [migration guide](https://canvastimeline.com/docs/engine-migration/)
+for the readonly and metadata contracts.
+
 ```ts
 import { SnapIndex } from '@techsquidtv/canvas-timeline-core/snapping';
 ```

--- a/packages/core/src/document-snapshot.test.ts
+++ b/packages/core/src/document-snapshot.test.ts
@@ -78,3 +78,164 @@ test('invalid track commands are atomic and duplicate IDs are rejected', () => {
   expect(engine.getState()).toBe(initial);
   expect(engine.canUndo).toBe(false);
 });
+
+test('constructor owns playback times and restores range boundaries', () => {
+  const playheadTime = { v: 3, r: 1 };
+  const duration = { v: 10, r: 1 };
+  const inPoint = { v: 2, r: 1 };
+  const outPoint = { v: 8, r: 1 };
+  const engine = new TimelineEngine({ tracks: [], playheadTime, duration, inPoint, outPoint });
+  const initial = engine.getState();
+  for (const time of [playheadTime, duration, inPoint, outPoint]) {
+    time.v = 99;
+  }
+  expect(engine.getState()).toBe(initial);
+  expect(engine.getTime()).toEqual({ v: 3, r: 1 });
+  expect(engine.maxContentTime).toEqual({ v: 10, r: 1 });
+  expect(initial.inPoint).toEqual({ v: 2, r: 1 });
+  expect(initial.outPoint).toEqual({ v: 8, r: 1 });
+  engine.play({ clock: 'external' });
+  expect(engine.updateExternalPlaybackTime(fromSeconds(9)).action).toBe('pause');
+  expect(engine.getTime()).toEqual({ v: 8, r: 1 });
+});
+
+test.each(['height', 'scrollTop'])(
+  'track height batches reject invalid %s without partial mutations',
+  (field) => {
+    const engine = createEngine();
+    const initial = engine.getState();
+    const settled = vi.fn();
+    const resize = vi.fn();
+    engine.on('state:settled', settled);
+    engine.on('track:resize', resize);
+    const updates = [{ trackId: 'track', height: 100 }];
+    if (field === 'height') {
+      updates.push({ trackId: 'track', height: Number.NaN });
+    }
+    expect(() =>
+      engine.setTrackHeights(updates, field === 'scrollTop' ? { scrollTop: Number.NaN } : {})
+    ).toThrow(RangeError);
+    expect(engine.getState()).toBe(initial);
+    expect(engine.geometry.getClip('a')?.track.height).toBeUndefined();
+    expect(engine.canUndo).toBe(false);
+    expect(settled).not.toHaveBeenCalled();
+    expect(resize).not.toHaveBeenCalled();
+  }
+);
+
+test('geometry and active-media queries share frozen document records', () => {
+  const engine = createEngine();
+  const initial = engine.getState();
+  const queries = [
+    engine.geometry.getClip('a'),
+    engine.geometry.getClipAtPoint({ x: 50, y: 40 }),
+    engine.geometry.getClipRects()[0],
+    engine.geometry.getVisibleTimelineClips()[0],
+    engine.media.getActiveClips(fromSeconds(0.5))[0],
+  ];
+  for (const query of queries) {
+    expect(query?.clip).toBe(initial.tracks[0].clips[0]);
+    expect(query?.track).toBe(initial.tracks[0]);
+    expect(() => Object.assign(query?.clip ?? {}, { label: 'leaked' })).toThrow(TypeError);
+    expect(() => Object.assign(query?.track ?? {}, { locked: true })).toThrow(TypeError);
+  }
+  expect(engine.geometry.getTrackAtPoint({ y: 40 })?.track).toBe(initial.tracks[0]);
+  expect(engine.canUndo).toBe(false);
+  expect(engine.getState()).toBe(initial);
+  engine.selectClip('a');
+  expect(engine.media.getActiveClips(fromSeconds(0.5))[0].clip.selected).toBe(true);
+  expect(initial.tracks[0].clips[0].selected).toBe(false);
+  engine.updateClipProperties('a', { label: 'command' });
+  engine.undo();
+  expect(engine.geometry.getClip('a')?.clip.label).toBeUndefined();
+});
+
+test('geometry reads frozen preview records while clip lookup retains committed content', () => {
+  const engine = createEngine();
+  engine.previewEdit({ type: 'move', clipId: 'a', startTime: fromSeconds(4), snap: false });
+  const previewClip = engine.getRenderState().tracks[0].clips.find(({ id }) => id === 'a');
+  const rect = engine.geometry.getClipRects().find(({ clip }) => clip.id === 'a');
+  expect(rect?.clip).toBe(previewClip);
+  expect(() => Object.assign(rect?.clip ?? {}, { label: 'leaked' })).toThrow(TypeError);
+  expect(engine.geometry.getClip('a')?.clip.timelineStart).toEqual(fromSeconds(0));
+  engine.cancelEdit();
+  expect(engine.canUndo).toBe(false);
+});
+
+const cyclicMetadata: Record<string, object> = {};
+cyclicMetadata.self = cyclicMetadata;
+
+test.each([
+  new Map([['value', { nested: 1 }]]),
+  new Set([1]),
+  new Date(),
+  new Uint8Array([1]),
+  new ArrayBuffer(1),
+  /expression/,
+  1n,
+  Number.NaN,
+  Infinity,
+  Symbol('value'),
+  () => 1,
+  cyclicMetadata,
+])('rejects unsupported metadata before it enters the document: %s', (value) => {
+  const engine = createEngine();
+  const initial = engine.getState();
+  const invalidClip: Clip = {
+    id: 'invalid',
+    sourceId: 'source',
+    timelineStart: fromSeconds(2),
+    timelineEnd: fromSeconds(3),
+    sourceStart: fromSeconds(0),
+    selected: false,
+  };
+  // Model unchecked JavaScript callers without weakening the public TypeScript contract.
+  Object.assign(invalidClip, { metadata: { value } });
+  expect(
+    () => new TimelineEngine({ tracks: [{ ...initial.tracks[0], clips: [invalidClip] }] })
+  ).toThrow(/metadata/);
+  expect(
+    engine.addTrack({ ...initial.tracks[0], id: 'invalid-track', clips: [invalidClip] })
+  ).toMatchObject({ ok: false, reason: 'invalid-input' });
+  expect(engine.getState()).toBe(initial);
+  expect(engine.canUndo).toBe(false);
+});
+
+test('plain metadata arrays are owned and immutable throughout undo and redo', () => {
+  const metadata = { values: [{ count: 1 }], optional: undefined, empty: null };
+  const engine = new TimelineEngine({
+    tracks: [
+      {
+        ...createEngine().tracks[0],
+        clips: [
+          {
+            id: 'clip',
+            sourceId: 'source',
+            timelineStart: fromSeconds(0),
+            timelineEnd: fromSeconds(1),
+            sourceStart: fromSeconds(0),
+            selected: false,
+            metadata,
+          },
+        ],
+      },
+    ],
+  });
+  const initial = engine.getState();
+  metadata.values[0].count = 99;
+  expect(initial.tracks[0].clips[0].metadata).toEqual({
+    values: [{ count: 1 }],
+    optional: undefined,
+    empty: null,
+  });
+  expect(Object.isFrozen(initial.tracks[0].clips[0].metadata?.values)).toBe(true);
+  engine.updateClipProperties('clip', { label: 'changed' });
+  engine.undo();
+  expect(engine.getState().tracks[0].clips[0].metadata).toEqual(
+    initial.tracks[0].clips[0].metadata
+  );
+  engine.redo();
+  expect(engine.getState().tracks[0].clips[0].metadata).toEqual(
+    initial.tracks[0].clips[0].metadata
+  );
+});

--- a/packages/core/src/document-snapshot.ts
+++ b/packages/core/src/document-snapshot.ts
@@ -23,16 +23,6 @@ function equalValue(left: unknown, right: unknown, seen = new WeakMap<object, ob
     return false;
   }
   seen.set(left, right);
-  if (left instanceof Date && right instanceof Date) {
-    return left.getTime() === right.getTime();
-  }
-  if (left instanceof Map && right instanceof Map) {
-    return left.size === right.size && equalValue([...left], [...right], seen);
-  }
-  if (left instanceof Set && right instanceof Set) {
-    return left.size === right.size && equalValue([...left], [...right], seen);
-  }
-  // Other structured-cloneable metadata (buffers, blobs, etc.) is copied conservatively.
   if (
     !Array.isArray(left) &&
     Object.getPrototypeOf(left) !== Object.prototype &&

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,3 +1,4 @@
+import { findClipInTracks } from '#core/engine/clip-lookup';
 import {
   timelineCommandOk,
   timelineCommandFail,
@@ -411,11 +412,16 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     updates: readonly TimelineTrackHeightUpdate[],
     options: TimelineTrackHeightBatchOptions = {}
   ) {
+    for (const update of updates) {
+      assertPositiveTimelineNumber(update.height, `height for track "${update.trackId}"`);
+    }
+    if (options.scrollTop !== undefined) {
+      assertNonNegativeTimelineNumber(options.scrollTop, 'options.scrollTop');
+    }
     const resizeEvents: TimelineTrackHeightUpdate[] = [];
     const previousScrollTop = this.state.scrollTop;
 
     for (const update of updates) {
-      assertPositiveTimelineNumber(update.height, `height for track "${update.trackId}"`);
       const track = this.state.tracks.find((t) => t.id === update.trackId);
       if (!track || track.height === update.height) {
         continue;
@@ -426,7 +432,6 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     }
 
     if (options.scrollTop !== undefined) {
-      assertNonNegativeTimelineNumber(options.scrollTop, 'options.scrollTop');
       this.state.scrollTop = options.scrollTop;
     }
 
@@ -1072,6 +1077,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    * @param initialState.scrollLeft - Optional initial horizontal scroll pan in pixels.
    * @param initialState.scrollTop - Optional initial vertical scroll pan in pixels.
    * @param initialState.playheadTime - Optional initial playback cursor as a rational time.
+   * @param initialState.inPoint - Optional restored playback range start.
+   * @param initialState.outPoint - Optional restored playback range end.
    */
   constructor(initialState: {
     tracks: TimelineStateSnapshot['tracks'];
@@ -1083,6 +1090,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     scrollTop?: number;
     playheadTime?: RationalTime;
     duration?: RationalTime;
+    inPoint?: RationalTime;
+    outPoint?: RationalTime;
     zoomConstraints?: TimelineZoomConstraints;
     snapEnabled?: boolean;
     snapThresholdPixels?: number;
@@ -1110,7 +1119,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       tracks: createTrackSnapshots(initialState.tracks),
       clipGroups: createClipGroupSnapshots(initialState.clipGroups),
       contentRevision: 0,
-      playheadTime: initialState.playheadTime ?? { v: 0, r: 24000 },
+      playheadTime: cloneRationalTime(initialState.playheadTime ?? { v: 0, r: 24000 }),
       zoomScale: initialState.zoomScale ?? 100, // 100 px per second
       scrollLeft: initialState.scrollLeft ?? 0,
       scrollTop: initialState.scrollTop ?? 0,
@@ -1121,12 +1130,16 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       markers: createMarkerSnapshots(initialState.markers),
       playing: false,
       playbackRate: 1.0,
-      duration: initialState.duration,
+      duration:
+        initialState.duration === undefined ? undefined : cloneRationalTime(initialState.duration),
+      inPoint:
+        initialState.inPoint === undefined ? undefined : cloneRationalTime(initialState.inPoint),
+      outPoint:
+        initialState.outPoint === undefined ? undefined : cloneRationalTime(initialState.outPoint),
     };
     this.geometry = new TimelineGeometry({
-      getState: () => this.state,
-      getRenderState: () =>
-        this.previewTracks ? { ...this.state, tracks: this.previewTracks } : this.state,
+      getState: () => this.getState(),
+      getRenderState: () => this.getRenderState(),
       timeToPixel: (time) => this.timeToPixel(time),
       pixelToTime: (pixel, rate) => this.pixelToTime(pixel, rate),
     });
@@ -1140,7 +1153,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       snapshot: () => this.snapshot(),
     });
     this.media = new TimelineMediaQueries({
-      getState: () => this.state,
+      getState: () => this.getState(),
       getClip: (id) => this.geometry.getClip(id),
     });
     this.playbackManager = new PlaybackManager(this, this.state);
@@ -2125,7 +2138,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     clipId: string,
     properties: Partial<Pick<Clip, 'label' | 'opacity' | 'color'>>
   ) {
-    const found = this.geometry.getClip(clipId);
+    const found = findClipInTracks(this.state.tracks, clipId);
     if (found) {
       Object.assign(found.clip, properties);
       this.invalidateContent();

--- a/packages/core/src/engine/active-media.ts
+++ b/packages/core/src/engine/active-media.ts
@@ -5,7 +5,6 @@ import {
   mapSourceTimeToTimelineTime,
   mapTimelineTimeToSourceTime,
 } from '#core/engine/media-sync';
-import type { TimelineClipLookup } from '#core/engine/types';
 import type {
   ActiveClip,
   ActiveClipQuery,
@@ -16,23 +15,28 @@ import type {
   TimelineReadonly,
   ClipSourceRange,
   FirstContentTimeOptions,
-  TimelineState,
+  TimelineStateSnapshot,
+  TimelineClipEntry,
   Track,
 } from '#core/types';
 import { compareRational } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 interface MediaContext {
-  getState: () => TimelineState;
-  getClip: (id: string) => TimelineClipLookup | undefined;
+  getState: () => TimelineStateSnapshot;
+  getClip: (id: string) => TimelineClipEntry | undefined;
 }
 
 /** Indexed active-media queries and source-time mapping. */
 export class TimelineMediaQueries {
   constructor(private context: MediaContext) {}
 
-  private timeIndexes = new WeakMap<Track, { revision: number; index: ClipTimeIndex }>();
+  private timeIndexes = new WeakMap<TimelineReadonly<Track>, ClipTimeIndex>();
   private activeMediaCache:
-    | { revision: number; time: RationalTime; entries: Pick<ActiveClip, 'track' | 'clip'>[] }
+    | {
+        tracks: TimelineStateSnapshot['tracks'];
+        time: RationalTime;
+        entries: Pick<ActiveClip, 'track' | 'clip'>[];
+      }
     | undefined;
 
   /**
@@ -48,9 +52,8 @@ export class TimelineMediaQueries {
    */
   getActiveClips(time: RationalTime = this.context.getState().playheadTime): ActiveClip[] {
     const state = this.context.getState();
-    const revision = state.contentRevision;
     if (
-      this.activeMediaCache?.revision !== revision ||
+      this.activeMediaCache?.tracks !== state.tracks ||
       compareRational(this.activeMediaCache.time, time) !== 0
     ) {
       const entries: Pick<ActiveClip, 'track' | 'clip'>[] = [];
@@ -59,18 +62,18 @@ export class TimelineMediaQueries {
           continue;
         }
         let cached = this.timeIndexes.get(track);
-        if (!cached || cached.revision !== revision) {
-          cached = { revision, index: new ClipTimeIndex(track.clips) };
+        if (!cached) {
+          cached = new ClipTimeIndex(track.clips);
           this.timeIndexes.set(track, cached);
         }
-        for (const clip of cached.index.at(time)) {
+        for (const clip of cached.at(time)) {
           if (!clip.disabled) {
             entries.push({ track, clip });
           }
         }
       }
       // Cache membership only; caller-owned times and public result objects must stay outside it.
-      this.activeMediaCache = { revision, time: { ...time }, entries };
+      this.activeMediaCache = { tracks: state.tracks, time: { ...time }, entries };
     }
     const activeClips: ActiveClip[] = [];
     for (const { track, clip } of this.activeMediaCache.entries) {
@@ -232,8 +235,8 @@ export class TimelineMediaQueries {
   }
 
   private createActiveClip(
-    track: Track,
-    clip: Clip,
+    track: TimelineReadonly<Track>,
+    clip: TimelineReadonly<Clip>,
     timelineTime: RationalTime
   ): ActiveClip | undefined {
     const sourceTime = this.timelineTimeToSourceTime(clip, timelineTime);

--- a/packages/core/src/engine/clip-lookup.ts
+++ b/packages/core/src/engine/clip-lookup.ts
@@ -1,0 +1,27 @@
+import type { TimelineClipLookup } from '#core/engine/types';
+import type { TimelineClipEntry, TimelineReadonly, Track } from '#core/types';
+
+export function findClipInTracks(
+  tracks: readonly Track[],
+  clipId: string
+): TimelineClipLookup | undefined;
+export function findClipInTracks(
+  tracks: readonly TimelineReadonly<Track>[],
+  clipId: string
+): TimelineClipEntry | undefined;
+/** Shared lookup for private mutable models and public readonly snapshots. */
+export function findClipInTracks(
+  tracks: readonly TimelineReadonly<Track>[],
+  clipId: string
+): TimelineClipEntry | undefined {
+  for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
+    const track = tracks[trackIndex];
+    for (let clipIndex = 0; clipIndex < track.clips.length; clipIndex++) {
+      const clip = track.clips[clipIndex];
+      if (clip.id === clipId) {
+        return { track, clip, trackIndex, clipIndex };
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/engine/clip-time-index.ts
+++ b/packages/core/src/engine/clip-time-index.ts
@@ -1,4 +1,4 @@
-import type { Clip } from '#core/types';
+import type { Clip, TimelineReadonly } from '#core/types';
 import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 /** Ordered starts plus prefix maximum ends preserve overlapping clip intervals. */
@@ -6,7 +6,7 @@ export class ClipTimeIndex {
   private readonly entries;
   private readonly maximumEnds: number[];
 
-  constructor(clips: readonly Clip[]) {
+  constructor(clips: readonly TimelineReadonly<Clip>[]) {
     this.entries = clips
       .map((clip, order) => ({
         clip,
@@ -19,7 +19,7 @@ export class ClipTimeIndex {
     this.maximumEnds = this.entries.map(({ end }) => (maximum = Math.max(maximum, end)));
   }
 
-  at(time: RationalTime): Clip[] {
+  at(time: RationalTime): TimelineReadonly<Clip>[] {
     const seconds = toSeconds(time);
     let low = 0;
     let high = this.entries.length;

--- a/packages/core/src/engine/edit-evaluator.ts
+++ b/packages/core/src/engine/edit-evaluator.ts
@@ -1,3 +1,4 @@
+import { findClipInTracks } from '#core/engine/clip-lookup';
 import { filterClipKeyframesToClipRange, shiftClipKeyframes } from '#core/engine/clip-keyframes';
 import { defaultTimelineEditValidationResult } from '#core/engine/feedback';
 import type {
@@ -82,7 +83,7 @@ export function resolveInteractiveEdit(
   const winners =
     command.type === 'move' ? getLinkedClipIds(context, command.clipId) : [command.clipId];
   for (const id of winners) {
-    const found = getClipInTracks(context, resolved.tracks, id);
+    const found = findClipInTracks(resolved.tracks, id);
     if (!found) {
       continue;
     }
@@ -332,7 +333,7 @@ function validateMoveEditCommand(
   context: EditContext,
   command: TimelineMoveEditCommand
 ): TimelineEditValidationResult {
-  const found = getClipInTracks(context, context.state.tracks, command.clipId);
+  const found = findClipInTracks(context.state.tracks, command.clipId);
   if (!found) {
     return rejectEdit(context, 'not-found');
   }
@@ -356,7 +357,7 @@ function validateMoveEditCommand(
     return rejectEdit(context, 'unsupported');
   }
   for (const linkedClipId of linkedClipIds) {
-    const linked = getClipInTracks(context, context.state.tracks, linkedClipId);
+    const linked = findClipInTracks(context.state.tracks, linkedClipId);
     if (!linked) {
       return rejectEdit(context, 'not-found');
     }
@@ -387,7 +388,7 @@ function validateTrimEditCommand(
     return clipValidation;
   }
 
-  const found = getClipInTracks(context, context.state.tracks, command.clipId);
+  const found = findClipInTracks(context.state.tracks, command.clipId);
   if (!found) {
     return rejectEdit(context, 'not-found');
   }
@@ -407,7 +408,7 @@ function validateClipEditCommand(
   clipId: string,
   capability: 'movable' | 'resizable'
 ): TimelineEditValidationResult {
-  const found = getClipInTracks(context, context.state.tracks, clipId);
+  const found = findClipInTracks(context.state.tracks, clipId);
   if (!found) {
     return rejectEdit(context, 'not-found');
   }
@@ -427,8 +428,8 @@ function validateRollTrimEditCommand(
   context: EditContext,
   command: TimelineRollTrimEditCommand
 ): TimelineEditValidationResult {
-  const left = getClipInTracks(context, context.state.tracks, command.leftClipId);
-  const right = getClipInTracks(context, context.state.tracks, command.rightClipId);
+  const left = findClipInTracks(context.state.tracks, command.leftClipId);
+  const right = findClipInTracks(context.state.tracks, command.rightClipId);
   if (!left || !right) {
     return rejectEdit(context, 'not-found');
   }
@@ -451,8 +452,8 @@ function validateResolvedRollTrimBoundary(
   command: TimelineRollTrimEditCommand,
   boundaryTime: RationalTime
 ): TimelineEditValidationResult {
-  const left = getClipInTracks(context, context.state.tracks, command.leftClipId);
-  const right = getClipInTracks(context, context.state.tracks, command.rightClipId);
+  const left = findClipInTracks(context.state.tracks, command.leftClipId);
+  const right = findClipInTracks(context.state.tracks, command.rightClipId);
   if (!left || !right) {
     return rejectEdit(context, 'not-found');
   }
@@ -476,7 +477,7 @@ function validateSplitEditCommand(
   const requestedClipIds = getLinkedCommandClipIds(context, command.clipIds);
   let hasOverlappingClip = false;
   for (const clipId of requestedClipIds) {
-    const found = getClipInTracks(context, context.state.tracks, clipId);
+    const found = findClipInTracks(context.state.tracks, clipId);
     if (!found) {
       return rejectEdit(context, 'not-found');
     }
@@ -515,7 +516,7 @@ function validateDeleteClipsEditCommand(
   }
   const requestedClipIds = getLinkedCommandClipIds(context, command.clipIds);
   for (const clipId of requestedClipIds) {
-    const found = getClipInTracks(context, context.state.tracks, clipId);
+    const found = findClipInTracks(context.state.tracks, clipId);
     if (!found) {
       return rejectEdit(context, 'not-found');
     }
@@ -530,7 +531,7 @@ function validatePlaceClipCommand(
   context: EditContext,
   command: TimelineInsertEditCommand | TimelineOverwriteEditCommand
 ): TimelineEditValidationResult {
-  if (getClipInTracks(context, context.state.tracks, command.clip.id)) {
+  if (findClipInTracks(context.state.tracks, command.clip.id)) {
     return rejectEdit(context, 'duplicate-id');
   }
   const targetTrack = context.state.tracks.find((track) => track.id === command.targetTrackId);
@@ -564,7 +565,7 @@ function validatePlaceClipGroupCommand(
   for (const placement of command.placements) {
     if (
       clipIds.has(placement.clip.id) ||
-      getClipInTracks(context, context.state.tracks, placement.clip.id)
+      findClipInTracks(context.state.tracks, placement.clip.id)
     ) {
       return rejectEdit(context, 'duplicate-id');
     }
@@ -703,9 +704,7 @@ function createPolicyContext(
 ): TimelineEditPolicyContext {
   const sourceClipId = getEditCommandSourceClipId(context, command);
   const found =
-    sourceClipId !== undefined
-      ? getClipInTracks(context, context.state.tracks, sourceClipId)
-      : undefined;
+    sourceClipId !== undefined ? findClipInTracks(context.state.tracks, sourceClipId) : undefined;
   const targetTrackId =
     command.type === 'move'
       ? (command.targetTrackId ?? found?.track.id)
@@ -871,7 +870,7 @@ function resolveMoveEdit(
   command: TimelineMoveEditCommand
 ): TimelineResolvedEdit {
   const tracks = createTrackSnapshots(context.state.tracks);
-  const found = getClipInTracks(context, tracks, command.clipId);
+  const found = findClipInTracks(tracks, command.clipId);
   if (!found) {
     return createRejectedResolvedEdit(context, command, tracks, rejectEdit(context, 'not-found'));
   }
@@ -910,7 +909,7 @@ function resolveMoveEdit(
   const deltaTime = subRational(startTime, previousStartTime);
   const changedClips: Clip[] = [];
   for (const linkedClipId of linkedClipIds) {
-    const linked = getClipInTracks(context, tracks, linkedClipId);
+    const linked = findClipInTracks(tracks, linkedClipId);
     if (!linked) {
       return createRejectedResolvedEdit(context, command, tracks, rejectEdit(context, 'not-found'));
     }
@@ -946,7 +945,7 @@ function resolveMoveEdit(
   for (const track of tracks) {
     track.clips.sort((a, b) => compareRational(a.timelineStart, b.timelineStart));
   }
-  const moved = getClipInTracks(context, tracks, command.clipId);
+  const moved = findClipInTracks(tracks, command.clipId);
   if (!moved) {
     return createRejectedResolvedEdit(context, command, tracks, rejectEdit(context, 'not-found'));
   }
@@ -985,23 +984,6 @@ function resolveMoveEdit(
   return createResolvedEdit(context, command, tracks, preview, { moveResult });
 }
 
-function getClipInTracks(
-  context: EditContext,
-  tracks: Track[],
-  clipId: string
-): { track: Track; clip: Clip; trackIndex: number; clipIndex: number } | undefined {
-  for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
-    const track = tracks[trackIndex];
-    for (let clipIndex = 0; clipIndex < track.clips.length; clipIndex++) {
-      const clip = track.clips[clipIndex];
-      if (clip.id === clipId) {
-        return { track, clip, trackIndex, clipIndex };
-      }
-    }
-  }
-  return undefined;
-}
-
 function createResolvedEditPreview(
   context: EditContext,
   command: TimelineEditCommand,
@@ -1021,7 +1003,7 @@ function resolveTrimEdit(
   ripple: boolean
 ): TimelineResolvedEdit {
   const tracks = createTrackSnapshots(context.state.tracks);
-  const found = getClipInTracks(context, tracks, command.clipId);
+  const found = findClipInTracks(tracks, command.clipId);
   if (!found) {
     return createRejectedResolvedEdit(context, command, tracks, rejectEdit(context, 'not-found'));
   }
@@ -1100,8 +1082,8 @@ function resolveRollTrimEdit(
   command: TimelineRollTrimEditCommand
 ): TimelineResolvedEdit {
   const tracks = createTrackSnapshots(context.state.tracks);
-  const left = getClipInTracks(context, tracks, command.leftClipId);
-  const right = getClipInTracks(context, tracks, command.rightClipId);
+  const left = findClipInTracks(tracks, command.leftClipId);
+  const right = findClipInTracks(tracks, command.rightClipId);
   if (!left || !right || left.track.id !== right.track.id) {
     return createRejectedResolvedEdit(
       context,
@@ -1174,7 +1156,7 @@ function resolveSlipEdit(
   command: TimelineSlipEditCommand
 ): TimelineResolvedEdit {
   const tracks = createTrackSnapshots(context.state.tracks);
-  const found = getClipInTracks(context, tracks, command.clipId);
+  const found = findClipInTracks(tracks, command.clipId);
   if (!found) {
     return createRejectedResolvedEdit(context, command, tracks, rejectEdit(context, 'not-found'));
   }
@@ -1220,7 +1202,7 @@ function resolveSlideEdit(
   context: EditContext,
   command: TimelineSlideEditCommand
 ): TimelineResolvedEdit {
-  const found = getClipInTracks(context, context.state.tracks, command.clipId);
+  const found = findClipInTracks(context.state.tracks, command.clipId);
   if (!found) {
     return createRejectedResolvedEdit(
       context,

--- a/packages/core/src/engine/interaction-geometry.ts
+++ b/packages/core/src/engine/interaction-geometry.ts
@@ -1,3 +1,4 @@
+import { findClipInTracks } from '#core/engine/clip-lookup';
 import {
   defaultTimelineViewportWidth,
   normalizeViewportCoordinate,
@@ -14,7 +15,9 @@ import type {
   TimelineClipGeometryOptions,
   TimelineClipRect,
   TimelineInteractionGeometry,
-  TimelineState,
+  TimelineStateSnapshot,
+  TimelineReadonly,
+  TimelineClipEntry,
   TimelineTrackGeometryOptions,
   TimelineTrackHitTestResult,
   TimelineTrackRect,
@@ -32,8 +35,8 @@ import {
 } from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 interface GeometryContext {
-  getState: () => TimelineState;
-  getRenderState: () => TimelineState;
+  getState: () => TimelineStateSnapshot;
+  getRenderState: () => TimelineStateSnapshot;
   timeToPixel: (time: RationalTime) => number;
   pixelToTime: (pixel: number, rate?: number) => RationalTime;
 }
@@ -48,19 +51,8 @@ export class TimelineGeometry {
    * @param clipId - Clip id to look up.
    * @returns Clip lookup details, or `undefined` when the clip is not found.
    */
-  getClip(
-    clipId: string
-  ): { track: Track; clip: Clip; trackIndex: number; clipIndex: number } | undefined {
-    for (let trackIndex = 0; trackIndex < this.context.getState().tracks.length; trackIndex++) {
-      const track = this.context.getState().tracks[trackIndex];
-      for (let clipIndex = 0; clipIndex < track.clips.length; clipIndex++) {
-        const clip = track.clips[clipIndex];
-        if (clip.id === clipId) {
-          return { track, clip, trackIndex, clipIndex };
-        }
-      }
-    }
-    return undefined;
+  getClip(clipId: string): TimelineClipEntry | undefined {
+    return findClipInTracks(this.context.getState().tracks, clipId);
   }
 
   /**
@@ -306,7 +298,10 @@ export class TimelineGeometry {
   }
 
   /** @internal Shared row geometry for engine services. */
-  getTrackViewportHeight(track: Track, geometry: ResolvedTimelineInteractionGeometry): number {
+  getTrackViewportHeight(
+    track: TimelineReadonly<Track>,
+    geometry: ResolvedTimelineInteractionGeometry
+  ): number {
     return Math.floor(
       track.collapsed ? geometry.collapsedTrackHeight : (track.height ?? geometry.trackHeight)
     );
@@ -316,8 +311,8 @@ export class TimelineGeometry {
   forEachTimelineClipGeometry(
     options: TimelineClipGeometryOptions,
     visit: (
-      track: Track,
-      clip: Clip,
+      track: TimelineReadonly<Track>,
+      clip: TimelineReadonly<Clip>,
       trackIndex: number,
       clipIndex: number,
       rect: ClipViewportRect
@@ -353,7 +348,7 @@ export class TimelineGeometry {
   }
 
   private findClipHitInTrack(
-    track: Track,
+    track: TimelineReadonly<Track>,
     trackIndex: number,
     trackY: number,
     trackHeight: number,
@@ -415,8 +410,8 @@ export class TimelineGeometry {
   }
 
   private createClipViewportRect(
-    track: Track,
-    clip: Clip,
+    track: TimelineReadonly<Track>,
+    clip: TimelineReadonly<Clip>,
     trackIndex: number,
     clipIndex: number,
     y: number,
@@ -438,7 +433,7 @@ export class TimelineGeometry {
   }
 
   private createTrackViewportRect(
-    track: Track,
+    track: TimelineReadonly<Track>,
     trackIndex: number,
     y: number,
     height: number,
@@ -455,8 +450,8 @@ export class TimelineGeometry {
   }
 
   private createTimelineClipRect(
-    track: Track,
-    clip: Clip,
+    track: TimelineReadonly<Track>,
+    clip: TimelineReadonly<Clip>,
     trackIndex: number,
     clipIndex: number,
     rect: ClipViewportRect

--- a/packages/core/src/engine/keyframes.ts
+++ b/packages/core/src/engine/keyframes.ts
@@ -1,3 +1,4 @@
+import { findClipInTracks } from '#core/engine/clip-lookup';
 import type { TypedEventEmitter } from '#core/emitter';
 import { clampViewportCoordinate, defaultTimelineViewportWidth } from '#core/engine/geometry';
 import type { TimelineGeometry } from '#core/engine/interaction-geometry';
@@ -45,6 +46,7 @@ import type {
   TimelineRegisteredKeyframePropertyDefinition,
   TimelineSetClipKeyframeOptions,
   TimelineState,
+  TimelineReadonly,
   TimelineUpdateClipKeyframeOptions,
   TimelineUpdateClipKeyframeSideOptions,
   TimelineUpdateClipKeyframeSidesOptions,
@@ -79,7 +81,9 @@ interface KeyframeContext {
 export class TimelineKeyframes {
   constructor(private context: KeyframeContext) {}
 
-  private resolveClip(clipIdOrClip: string | Clip): Clip | undefined {
+  private resolveClip(
+    clipIdOrClip: string | TimelineReadonly<Clip>
+  ): TimelineReadonly<Clip> | undefined {
     return typeof clipIdOrClip === 'string'
       ? this.context.geometry.getClip(clipIdOrClip)?.clip
       : clipIdOrClip;
@@ -88,7 +92,10 @@ export class TimelineKeyframes {
   /**
    * Returns keyframes owned by one clip, optionally filtered by property.
    */
-  getClipKeyframes(clipId: string, property?: TimelineKeyframePropertyId): TimelineKeyframe[] {
+  getClipKeyframes(
+    clipId: string,
+    property?: TimelineKeyframePropertyId
+  ): TimelineReadonly<TimelineKeyframe>[] {
     const clip = this.context.geometry.getClip(clipId)?.clip;
     if (clip?.keyframes === undefined) {
       return [];
@@ -103,7 +110,7 @@ export class TimelineKeyframes {
    * Evaluates a keyframed clip property at a timeline time.
    */
   getClipPropertyValueAtTime(
-    clipIdOrClip: string | Clip,
+    clipIdOrClip: string | TimelineReadonly<Clip>,
     property: TimelineKeyframePropertyId,
     timelineTime: RationalTime = this.context.state.playheadTime
   ): number | undefined {
@@ -240,7 +247,7 @@ export class TimelineKeyframes {
     options: TimelineKeyframeMutationOptions = {}
   ): TimelineKeyframe | null {
     assertValidRationalTime(input.time, 'input.time');
-    const found = this.context.geometry.getClip(input.clipId);
+    const found = findClipInTracks(this.context.state.tracks, input.clipId);
     if (!found || found.track.locked) {
       return null;
     }
@@ -289,7 +296,7 @@ export class TimelineKeyframes {
       keyframe: cloneTimelineKeyframe(keyframe),
     } satisfies ClipKeyframeChangeEvent);
     this.commitKeyframeMutation(options);
-    return keyframe;
+    return cloneTimelineKeyframe(keyframe);
   }
 
   /**
@@ -304,7 +311,7 @@ export class TimelineKeyframes {
     input: TimelineUpdateClipKeyframeOptions,
     options: TimelineKeyframeMutationOptions = {}
   ): TimelineKeyframe | null {
-    const found = this.context.geometry.getClip(input.clipId);
+    const found = findClipInTracks(this.context.state.tracks, input.clipId);
     if (!found || found.track.locked || found.clip.keyframes === undefined) {
       return null;
     }
@@ -364,7 +371,7 @@ export class TimelineKeyframes {
       keyframe: cloneTimelineKeyframe(keyframe),
     } satisfies ClipKeyframeChangeEvent);
     this.commitKeyframeMutation(options);
-    return keyframe;
+    return cloneTimelineKeyframe(keyframe);
   }
 
   /**
@@ -391,7 +398,7 @@ export class TimelineKeyframes {
     input: TimelineUpdateClipKeyframeSidesOptions,
     options: TimelineKeyframeMutationOptions = {}
   ): TimelineKeyframe | null {
-    const found = this.context.geometry.getClip(input.clipId);
+    const found = findClipInTracks(this.context.state.tracks, input.clipId);
     if (!found || found.track.locked || found.clip.keyframes === undefined) {
       return null;
     }
@@ -437,7 +444,7 @@ export class TimelineKeyframes {
       keyframe: cloneTimelineKeyframe(keyframe),
     } satisfies ClipKeyframeChangeEvent);
     this.commitKeyframeMutation(options);
-    return keyframe;
+    return cloneTimelineKeyframe(keyframe);
   }
 
   /**
@@ -448,7 +455,7 @@ export class TimelineKeyframes {
     keyframeId: string,
     options: TimelineKeyframeMutationOptions = {}
   ): boolean {
-    const found = this.context.geometry.getClip(clipId);
+    const found = findClipInTracks(this.context.state.tracks, clipId);
     if (!found || found.track.locked || found.clip.keyframes === undefined) {
       return false;
     }
@@ -773,8 +780,8 @@ export class TimelineKeyframes {
   }
 
   private createTimelineKeyframeRect(
-    track: Track<string>,
-    clip: Clip,
+    track: TimelineReadonly<Track>,
+    clip: TimelineReadonly<Clip>,
     trackIndex: number,
     clipIndex: number,
     keyframe: TimelineKeyframe,
@@ -827,8 +834,8 @@ export class TimelineKeyframes {
   }
 
   private createTimelineKeyframeSegment(
-    track: Track<string>,
-    clip: Clip,
+    track: TimelineReadonly<Track>,
+    clip: TimelineReadonly<Clip>,
     trackIndex: number,
     clipIndex: number,
     startKeyframe: TimelineKeyframe,
@@ -960,8 +967,8 @@ export class TimelineKeyframes {
   }
 
   private createTimelineKeyframeTangentHandle(input: {
-    track: Track<string>;
-    clip: Clip;
+    track: TimelineReadonly<Track>;
+    clip: TimelineReadonly<Clip>;
     trackIndex: number;
     clipIndex: number;
     segmentId: string;
@@ -1038,7 +1045,7 @@ export class TimelineKeyframes {
     );
   }
 
-  private clampKeyframeTimeToClip(clip: Clip, time: RationalTime): RationalTime {
+  private clampKeyframeTimeToClip(clip: TimelineReadonly<Clip>, time: RationalTime): RationalTime {
     return minRational(maxRational(time, clip.timelineStart), clip.timelineEnd);
   }
 

--- a/packages/core/src/engine/types.ts
+++ b/packages/core/src/engine/types.ts
@@ -2,17 +2,16 @@ import type { ClipCreatedReason, ClipRemovedReason } from '#core/events';
 import type {
   Clip,
   TimelineClipGroup,
+  TimelineClipEntry,
   TimelineClipMoveResult,
   TimelineEditPreview,
   TimelineEditValidationResult,
   TimelineSnapResult,
   Track,
 } from '#core/types';
-export interface TimelineClipLookup {
+export interface TimelineClipLookup extends TimelineClipEntry {
   track: Track;
   clip: Clip;
-  trackIndex: number;
-  clipIndex: number;
 }
 
 export interface TimelineResolvedEdit {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,0 +1,47 @@
+import type { TimelineMetadata } from '#core/types';
+
+/** Validate unchecked JavaScript input before it enters snapshots or history. */
+function assertPlainMetadata(value: unknown, ancestors: Set<object>): void {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return;
+  }
+  if (
+    typeof value !== 'object' ||
+    (Object.getPrototypeOf(value) !== Object.prototype &&
+      Object.getPrototypeOf(value) !== null &&
+      !(Array.isArray(value) && Object.getPrototypeOf(value) === Array.prototype))
+  ) {
+    throw new TypeError(
+      'Timeline metadata must contain only plain objects, arrays, and finite primitive values.'
+    );
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError('Timeline metadata must not contain cycles.');
+  }
+  ancestors.add(value);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (typeof key === 'symbol' || descriptor?.get || descriptor?.set) {
+      throw new TypeError('Timeline metadata must not contain symbol keys or accessors.');
+    }
+    assertPlainMetadata(descriptor?.value, ancestors);
+  }
+  ancestors.delete(value);
+}
+
+/** Own lightweight app data without retaining mutable collection or host objects. */
+export function cloneTimelineMetadata(metadata: TimelineMetadata): TimelineMetadata {
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new TypeError('Timeline metadata must be a plain object.');
+  }
+  assertPlainMetadata(metadata, new Set());
+  return structuredClone(metadata);
+}

--- a/packages/core/src/playback.test.ts
+++ b/packages/core/src/playback.test.ts
@@ -1,0 +1,94 @@
+import { TimelineEngine } from '#core/engine';
+import { fromSeconds, toSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { afterEach, expect, test, vi } from 'vite-plus/test';
+
+function createPlayback(rate = 24) {
+  let frame: FrameRequestCallback = () => {};
+  let milliseconds = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => milliseconds);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frame = callback;
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  const engine = new TimelineEngine({
+    tracks: [],
+    playheadTime: fromSeconds(0, rate),
+    duration: fromSeconds(100, rate),
+  });
+  return {
+    engine,
+    advance: (seconds: number, frames = 60) => {
+      const start = milliseconds;
+      for (let index = 1; index <= frames; index++) {
+        milliseconds = start + (seconds * 1000 * index) / frames;
+        frame(milliseconds);
+      }
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test.each([1, 24, 25, 30, 60, 24000])(
+  'internal playback retains sub-tick time at %i ticks/second',
+  (rate) => {
+    const { engine, advance } = createPlayback(rate);
+    engine.play();
+    advance(10, 600);
+    expect(toSeconds(engine.getTime())).toBe(10);
+    engine.pause();
+  }
+);
+
+test('internal playback carries fractional ticks through rate changes and rebases after a seek', () => {
+  const { engine, advance } = createPlayback();
+  engine.play();
+  advance(1);
+  engine.setPlaybackRate(0.5);
+  advance(1);
+  expect(toSeconds(engine.getTime())).toBe(1.5);
+  engine.setTime(fromSeconds(10, 24));
+  advance(1);
+  expect(toSeconds(engine.getTime())).toBe(10.5);
+  engine.pause();
+  engine.play();
+  advance(1);
+  expect(toSeconds(engine.getTime())).toBe(11);
+  engine.pause();
+});
+
+test('internal playback resets fractional carry when looping and stops at an exact target', () => {
+  const { engine, advance } = createPlayback();
+  engine.setInPoint(fromSeconds(2, 24));
+  engine.setOutPoint(fromSeconds(3, 24));
+  engine.setTime(fromSeconds(2, 24));
+  engine.play({ loop: true });
+  advance(1);
+  expect(toSeconds(engine.getTime())).toBe(2);
+  advance(0.5, 30);
+  expect(toSeconds(engine.getTime())).toBe(2.5);
+  engine.pause();
+  engine.play({ toTime: fromSeconds(2.75, 24) });
+  advance(0.5, 30);
+  expect(toSeconds(engine.getTime())).toBe(2.75);
+  expect(engine.getState().playing).toBe(false);
+  engine.pause();
+});
+
+test('seeking discards the prior frame remainder', () => {
+  const { engine, advance } = createPlayback();
+  engine.play();
+  advance(0.016, 1);
+  engine.setTime(fromSeconds(10, 24));
+  advance(0.006, 1);
+  expect(toSeconds(engine.getTime())).toBe(10);
+  engine.pause();
+  engine.play();
+  advance(0.016, 1);
+  expect(toSeconds(engine.getTime())).toBe(10);
+  engine.pause();
+});

--- a/packages/core/src/playback.ts
+++ b/packages/core/src/playback.ts
@@ -5,7 +5,12 @@ import type {
   PlaybackOptions,
   TimelineState,
 } from '#core/types';
-import { addRational, compareRational, fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import {
+  addRational,
+  compareRational,
+  fromSeconds,
+  toSeconds,
+} from '@techsquidtv/canvas-timeline-utils';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 export class PlaybackManager {
   private engine: TimelineEngine;
@@ -48,6 +53,8 @@ export class PlaybackManager {
     }
 
     this.lastFrameTime = performance.now();
+    let lastPlayheadTime = state.playheadTime;
+    let remainderSeconds = 0;
 
     const loop = (time: number) => {
       const currentState = this.state;
@@ -57,10 +64,19 @@ export class PlaybackManager {
       const deltaMs = time - this.lastFrameTime;
       this.lastFrameTime = time;
 
-      const deltaSec = (deltaMs / 1000) * (currentState.playbackRate ?? 1.0);
+      // Keep sub-tick time across frames, but discard it after an explicit seek.
+      if (currentState.playheadTime !== lastPlayheadTime) {
+        remainderSeconds = 0;
+      }
+      const deltaSec = (deltaMs / 1000) * (currentState.playbackRate ?? 1.0) + remainderSeconds;
       const deltaRt = fromSeconds(deltaSec, currentState.playheadTime.r);
+      remainderSeconds = deltaSec - toSeconds(deltaRt);
       const nextTime = addRational(currentState.playheadTime, deltaRt);
       const update = this.advanceTo(nextTime);
+      lastPlayheadTime = currentState.playheadTime;
+      if (update.action === 'loop' || compareRational(update.time, nextTime) !== 0) {
+        remainderSeconds = 0;
+      }
       if (update.action === 'pause') {
         return;
       }

--- a/packages/core/src/snapping.ts
+++ b/packages/core/src/snapping.ts
@@ -1,5 +1,6 @@
 import { fromSeconds, toSeconds, type RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import type { TimelineSnapResult, TimelineSnapTarget } from '#core/types';
+import { cloneTimelineMetadata } from '#core/metadata';
 
 /**
  * Controls which built-in timeline boundaries are indexed as magnetic snap targets.
@@ -90,11 +91,18 @@ export class SnapIndex {
    * @param targets - Timeline snap targets to index.
    */
   build(targets: TimelineSnapTarget[]) {
+    const ownedTargets = targets.map((target) => ({
+      ...target,
+      time: { ...target.time },
+      ...(target.metadata === undefined
+        ? {}
+        : { metadata: cloneTimelineMetadata(target.metadata) }),
+    }));
     this.ensureCapacity(targets.length);
 
     for (let i = 0; i < targets.length; i++) {
       this.times[i] = toSeconds(targets[i].time);
-      this.targets[i] = targets[i];
+      this.targets[i] = ownedTargets[i];
     }
 
     for (let i = targets.length; i < this.count; i++) {

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -3,6 +3,7 @@ import {
   defaultTimelineOutgoingBezierHandle,
   normalizeTimelineKeyframeSideInterpolation,
 } from '#core/keyframes';
+import { cloneTimelineMetadata } from '#core/metadata';
 import type {
   Clip,
   Marker,
@@ -99,7 +100,9 @@ export function cloneTimelineKeyframe(
   return next;
 }
 
-export function sortTimelineKeyframes(keyframes: TimelineKeyframe[]) {
+export function sortTimelineKeyframes<Keyframe extends TimelineReadonly<TimelineKeyframe>>(
+  keyframes: Keyframe[]
+) {
   keyframes.sort((a, b) => {
     const propertyCompare = a.property.localeCompare(b.property);
     return propertyCompare === 0 ? compareRational(a.time, b.time) : propertyCompare;
@@ -189,7 +192,7 @@ export function createClipSnapshot(
 
   const metadata = overrides.metadata ?? clip.metadata;
   if (metadata !== undefined) {
-    next.metadata = structuredClone(metadata);
+    next.metadata = cloneTimelineMetadata(metadata);
   }
 
   assertValidClipTiming(next, `clip "${next.id}"`);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -301,7 +301,7 @@ export interface TrackHitTestInput extends TimelineTrackGeometryOptions {
  */
 export interface TimelineTrackHitTestResult<TrackKind = string> {
   /** Track under the queried point. */
-  track: Track<TrackKind>;
+  track: TimelineReadonly<Track<TrackKind>>;
   /** Zero-based track index in timeline order. */
   trackIndex: number;
   /** Viewport-space track row bounds. */
@@ -311,9 +311,9 @@ export interface TimelineTrackHitTestResult<TrackKind = string> {
 /** Hit-test result for a clip pointer target. */
 export interface ClipHitTestResult {
   /** Track containing the matched clip. */
-  track: Track;
+  track: TimelineReadonly<Track>;
   /** Clip matched by the pointer query. */
-  clip: Clip;
+  clip: TimelineReadonly<Clip>;
   /** Zero-based track index in timeline order. */
   trackIndex: number;
   /** Zero-based clip index inside the containing track. */
@@ -354,7 +354,7 @@ export interface TimelineKeyframePropertyDefinition<PropertyId extends string = 
   /** Optional app-facing formatter for inspectors and labels. */
   formatValue?: (value: number) => string;
   /** Optional source of a clip-specific base value when no keyframes exist. */
-  getBaseValue?: (clip: Clip) => number;
+  getBaseValue?: (clip: TimelineReadonly<Clip>) => number;
 }
 
 /** Immutable scalar keyframe property definition stored by the engine registry. */
@@ -510,7 +510,7 @@ export interface TimelineKeyframeHitTestInput extends TimelineKeyframeGeometryOp
  */
 export interface TimelineKeyframeRect<TrackKind = string> extends TimelineClipEntry<TrackKind> {
   /** Raw keyframe represented by this entry. */
-  keyframe: TimelineKeyframe;
+  keyframe: TimelineReadonly<TimelineKeyframe>;
   /** Zero-based keyframe index inside the containing clip. */
   keyframeIndex: number;
   /** Keyframe bounds in viewport CSS pixels. */
@@ -532,7 +532,7 @@ export interface TimelineKeyframeTangentHandle<
   /** Keyframe side mutated by this tangent. */
   side: TimelineKeyframeSide;
   /** Anchor keyframe whose side data is edited by this tangent. */
-  keyframe: TimelineKeyframe;
+  keyframe: TimelineReadonly<TimelineKeyframe>;
   /** Zero-based index of `keyframe` inside the containing clip. */
   keyframeIndex: number;
   /** Segment endpoint this control handle is visually anchored to. */
@@ -564,9 +564,9 @@ export interface TimelineKeyframeSegment<TrackKind = string> extends TimelineCli
   /** Property animated by the segment. */
   property: TimelineKeyframePropertyId;
   /** Left keyframe in the segment. */
-  startKeyframe: TimelineKeyframe;
+  startKeyframe: TimelineReadonly<TimelineKeyframe>;
   /** Right keyframe in the segment. */
-  endKeyframe: TimelineKeyframe;
+  endKeyframe: TimelineReadonly<TimelineKeyframe>;
   /** Zero-based start keyframe index inside the containing clip. */
   startKeyframeIndex: number;
   /** Zero-based end keyframe index inside the containing clip. */
@@ -807,10 +807,9 @@ export interface TimelineSnapTarget {
   /**
    * Lightweight application metadata for custom snap targets.
    *
-   * Values stay `unknown` because the core engine snapshots and carries this
-   * record without interpreting app-owned domain data.
+   * Uses the same plain-data contract as clip metadata.
    */
-  metadata?: Record<string, unknown>;
+  metadata?: TimelineMetadata;
 }
 
 /** Transient snap feedback consumed by canvas rendering and focused hooks. */
@@ -1387,10 +1386,9 @@ export interface TimelineEditPreview {
   /**
    * Lightweight app/UI metadata for custom edit guides.
    *
-   * Values stay `unknown` because the core engine forwards this record without
-   * interpreting app-owned domain data.
+   * Uses the same plain-data contract as clip metadata.
    */
-  guideMetadata?: Record<string, unknown>;
+  guideMetadata?: TimelineMetadata;
 }
 
 /** Result returned after committing an edit command. */
@@ -1401,6 +1399,25 @@ export interface TimelineEditCommitResult {
   preview: TimelineEditPreview;
   /** Whether the command committed. */
   committed: boolean;
+}
+
+/** Lightweight application data supported by timeline snapshots and history. */
+export type TimelineMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | TimelineMetadataArray
+  | TimelineMetadata;
+
+/** Readonly list of lightweight metadata values. */
+// oxlint-disable-next-line typescript/no-empty-object-type -- A recursive interface prevents excessive instantiation in TimelineReadonly.
+export interface TimelineMetadataArray extends ReadonlyArray<TimelineMetadataValue> {}
+
+/** Plain metadata record. Numbers must be finite; cycles and host objects are rejected. */
+export interface TimelineMetadata {
+  readonly [key: string]: TimelineMetadataValue;
 }
 
 /**
@@ -1445,10 +1462,11 @@ export interface Clip {
   /**
    * Arbitrary custom application metadata attached to this clip.
    *
-   * Values stay `unknown` because Canvas Timeline preserves this record through
-   * snapshots and edits while leaving the schema to the host application.
+   * Use plain objects, arrays, strings, finite numbers, booleans, null, or undefined.
+   * Store Maps, Sets, Dates, buffers, and other domain objects outside the engine.
+   * Metadata is copied on input and deeply frozen in public snapshots.
    */
-  metadata?: Record<string, unknown>;
+  metadata?: TimelineMetadata;
 }
 
 /**
@@ -1457,10 +1475,10 @@ export interface Clip {
  * @template TrackKind - App-defined track kind.
  */
 export interface TimelineClipEntry<TrackKind = string> {
-  /** Raw timeline clip represented by this entry. */
-  clip: Clip;
+  /** Readonly timeline clip represented by this entry. */
+  clip: TimelineReadonly<Clip>;
   /** Track containing the clip. */
-  track: Track<TrackKind>;
+  track: TimelineReadonly<Track<TrackKind>>;
   /** Zero-based track index in timeline order. */
   trackIndex: number;
   /** Zero-based clip index inside the containing track. */
@@ -1634,9 +1652,9 @@ export type TimelineRulerTickOptions = TimelineRulerGeometryOptions & TimelineRu
  */
 export interface ActiveClip<TrackKind = string> {
   /** Track containing the active clip. */
-  track: Track<TrackKind>;
+  track: TimelineReadonly<Track<TrackKind>>;
   /** Clip active under the playhead or inspected timeline time. */
-  clip: Clip;
+  clip: TimelineReadonly<Clip>;
   /** Timeline time used for the lookup. */
   timelineTime: RationalTime;
   /** Source-media time corresponding to `timelineTime`. */

--- a/packages/html-media-adapter/src/index.test.ts
+++ b/packages/html-media-adapter/src/index.test.ts
@@ -1056,3 +1056,41 @@ test('createHTMLMediaAdapter loads an app-resolved proxy through source replacem
   expect(adapter.getClockTime()).toBe(1);
   expect(adapter.sourceStateById.get('source-1')?.selectedInputIndex).toBe(0);
 });
+
+test.each(['retry', 'replacement', 'registry', 'fallback'] as const)(
+  'createHTMLMediaAdapter preserves fractional seek times during %s recovery',
+  async (operation) => {
+    const engine = createMediaSyncEngine();
+    const element = document.createElement('video');
+    vi.spyOn(element, 'pause').mockImplementation(() => {});
+    vi.spyOn(element, 'play').mockResolvedValue(undefined);
+    const adapter = createHTMLMediaAdapter({
+      element,
+      sources: [{ sourceId: 'source-1', input: '/primary.mp4', fallbacks: ['/fallback.mp4'] }],
+    });
+    const time = fromSeconds(1.5);
+    const layers = engine.media.getActiveLayers({
+      time,
+      layers: { visuals: { trackKind: 'visual' } },
+    });
+    await adapter.seek?.(time, layers);
+    await adapter.startClock(time, 1);
+    if (operation === 'retry') {
+      await expect(adapter.retrySource('source-1')).resolves.toMatchObject({ ok: true });
+    } else if (operation === 'replacement') {
+      await expect(
+        adapter.replaceSource({ sourceId: 'source-1', input: '/replacement.mp4' })
+      ).resolves.toMatchObject({ ok: true });
+    } else if (operation === 'registry') {
+      adapter.setSources([{ sourceId: 'source-1', input: '/registry.mp4' }]);
+    } else {
+      element.dispatchEvent(new Event('error'));
+      expect(element.src).toBe('http://localhost:3000/fallback.mp4');
+      expect(adapter.sourceStateById.get('source-1')?.selectedInputIndex).toBe(1);
+    }
+    expect(element.currentTime).toBe(11.5);
+    expect(adapter.getClockTime()).toBe(1.5);
+    adapter.dispose();
+    engine.pause();
+  }
+);

--- a/packages/html-media-adapter/src/index.ts
+++ b/packages/html-media-adapter/src/index.ts
@@ -149,7 +149,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
   const selectedInputIndexBySourceId = new Map<string, number>();
   const objectUrlsBySourceId = new Map<string, Map<string, string>>();
   let activeClip: ActiveClip | undefined;
-  let timelineTimeAtStart = 0;
+  let timelineTimeAtStart: RationalTime = { v: 0, r: 1 };
   let playbackRate = 1;
   let shouldPlay = false;
   let clockStartPending = false;
@@ -316,7 +316,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
       });
     }
     activeClip = clip;
-    timelineTimeAtStart = toSeconds(timelineTime);
+    timelineTimeAtStart = { ...timelineTime };
     element.playbackRate = playbackRate;
 
     if (
@@ -520,7 +520,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
       error: null,
     });
     const clip = activeClip;
-    loadClip(clip, { v: timelineTimeAtStart, r: 1 }, { forceReload: true, status: 'recovering' });
+    loadClip(clip, timelineTimeAtStart, { forceReload: true, status: 'recovering' });
     resumeIntendedPlayback();
   };
 
@@ -589,7 +589,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
       changedSourceIds.has(activeSourceId)
     ) {
       selectedInputIndexBySourceId.set(activeSourceId, 0);
-      loadClip(activeClip, { v: timelineTimeAtStart, r: 1 }, { forceReload: true });
+      loadClip(activeClip, timelineTimeAtStart, { forceReload: true });
       resumeIntendedPlayback();
     }
   };
@@ -610,7 +610,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
     setSources: reconcileSources,
     getClockTime: () => {
       if (activeClip === undefined) {
-        return timelineTimeAtStart;
+        return toSeconds(timelineTimeAtStart);
       }
 
       const sourceInputs = getSourceInputs(activeClip.clip.sourceId);
@@ -625,7 +625,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
       );
     },
     startClock: async (timelineTime, rate) => {
-      timelineTimeAtStart = toSeconds(timelineTime);
+      timelineTimeAtStart = { ...timelineTime };
       playbackRate = rate;
       shouldPlay = true;
       element.playbackRate = rate;
@@ -678,7 +678,7 @@ export function createHTMLMediaAdapter(options: CreateHTMLMediaAdapterOptions): 
         error: null,
       });
       if (activeClip?.clip.sourceId === sourceId) {
-        loadClip(activeClip, { v: timelineTimeAtStart, r: 1 }, { forceReload: true });
+        loadClip(activeClip, timelineTimeAtStart, { forceReload: true });
         resumeIntendedPlayback();
       }
       return { ok: true, sourceId, state: 'configured' };

--- a/packages/mediabunny-adapter/src/internal/audioRuntime.ts
+++ b/packages/mediabunny-adapter/src/internal/audioRuntime.ts
@@ -1,4 +1,4 @@
-import type { ActiveClip, Clip } from '@techsquidtv/canvas-timeline-core';
+import type { ActiveClip, Clip, TimelineReadonly } from '@techsquidtv/canvas-timeline-core';
 import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
 import type * as Mediabunny from 'mediabunny';
 import type {
@@ -299,7 +299,7 @@ function stopAudioIterator(controller: MediabunnyAudioController) {
 async function runAudioIterator(
   controller: MediabunnyAudioController,
   iterator: AsyncGenerator<Mediabunny.WrappedAudioBuffer, void, void>,
-  audioClip: Clip,
+  audioClip: TimelineReadonly<Clip>,
   audioSyncKey: string,
   generation: number
 ) {

--- a/packages/react/src/hooks/clips/timelineClipModel.ts
+++ b/packages/react/src/hooks/clips/timelineClipModel.ts
@@ -46,7 +46,7 @@ export interface TimelineSelectionState<TrackKind = string> {
  */
 export function flattenTimelineClips<TrackKind>(
   tracks: readonly TimelineReadonly<Track<TrackKind>>[]
-): TimelineReadonly<TimelineClipEntry<TrackKind>>[] {
+): TimelineClipEntry<TrackKind>[] {
   return tracks.flatMap((track, trackIndex) =>
     track.clips.map((clip, clipIndex) => ({
       clip,

--- a/packages/react/src/hooks/clips/useActiveClips.ts
+++ b/packages/react/src/hooks/clips/useActiveClips.ts
@@ -1,6 +1,5 @@
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelinePlayheadTime } from '#react/hooks/playback/useTimelinePlayheadTime';
-import type { Clip } from '@techsquidtv/canvas-timeline-core';
 /**
  * Returns clips that intersect the current playhead time.
  *
@@ -22,5 +21,5 @@ export function useActiveClips() {
   const engine = useTimelineEngine();
   const playheadTime = useTimelinePlayheadTime();
 
-  return engine.media.getActiveClips(playheadTime).map(({ clip }) => clip) satisfies Clip[];
+  return engine.media.getActiveClips(playheadTime).map(({ clip }) => clip);
 }

--- a/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
+++ b/packages/react/src/hooks/clips/useTimelineExternalClipDrop.ts
@@ -7,6 +7,7 @@ import type {
   TimelineEditRejectionReason,
   TimelineInteractionGeometry,
   Track,
+  TimelineReadonly,
 } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { toSeconds } from '@techsquidtv/canvas-timeline-utils';
@@ -46,7 +47,7 @@ export interface TimelineExternalClipDropContext<DragData> {
   /** Native browser data transfer payload. */
   dataTransfer: DataTransfer;
   /** Track currently under the pointer. */
-  targetTrack: Track<string>;
+  targetTrack: TimelineReadonly<Track>;
   /** Zero-based index of the target track. */
   targetTrackIndex: number;
   /** Timeline time under the pointer. */
@@ -164,7 +165,7 @@ export interface UseTimelineExternalClipDropResult {
   /** Valid target track id currently accepting the payload. */
   targetTrackId: string | null;
   /** Valid target track currently accepting the payload. */
-  targetTrack: Track<string> | null;
+  targetTrack: TimelineReadonly<Track> | null;
   /** Timeline time under the pointer, when a track is resolved. */
   dropTime: RationalTime | null;
   /** Timeline seconds under the pointer, when a track is resolved. */
@@ -183,7 +184,7 @@ interface ExternalDropFeedback {
   dragging: boolean;
   hoveredTrackId: string | null;
   targetTrackId: string | null;
-  targetTrack: Track<string> | null;
+  targetTrack: TimelineReadonly<Track> | null;
   dropTime: RationalTime | null;
   dropSeconds: number | null;
   valid: boolean;

--- a/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
+++ b/packages/react/src/hooks/tracks/useTimelineTrackDropTargets.ts
@@ -26,7 +26,7 @@ import { useCallback, useMemo } from 'react';
  */
 export interface TimelineTrackDropContext {
   /** Clip being moved. */
-  clip: Clip;
+  clip: TimelineReadonly<Clip>;
   /** Track that contained the clip at drag start. */
   sourceTrack: TimelineReadonly<Track>;
   /** Candidate destination track. */
@@ -85,11 +85,9 @@ export interface UseTimelineTrackDropTargetsOptions extends TimelineTrackGeometr
  */
 export interface UseTimelineTrackDropTargetsResult {
   /** Viewport-space track rows in timeline order. */
-  trackTargets: TimelineReadonly<TimelineTrackHitTestResult>[];
+  trackTargets: TimelineTrackHitTestResult[];
   /** Hit-tests timeline tracks in viewport coordinates. */
-  getTrackAtViewportPoint: (
-    input: TrackHitTestInput
-  ) => TimelineReadonly<TimelineTrackHitTestResult> | null;
+  getTrackAtViewportPoint: (input: TrackHitTestInput) => TimelineTrackHitTestResult | null;
   /** Resolves whether one clip may drop on one candidate track. */
   canDropClipOnTrack: (
     clipId: string,
@@ -105,8 +103,8 @@ const acceptedDropResult: TimelineTrackDropResult = {
 };
 
 function isTrackDropTarget(
-  target: TimelineReadonly<TimelineTrackHitTestResult> | null
-): target is TimelineReadonly<TimelineTrackHitTestResult> {
+  target: TimelineTrackHitTestResult | null
+): target is TimelineTrackHitTestResult {
   return target !== null;
 }
 

--- a/packages/utils/src/timecode.test.ts
+++ b/packages/utils/src/timecode.test.ts
@@ -176,3 +176,29 @@ describe('timecode utilities', () => {
     });
   });
 });
+
+it.each([false, true])(
+  'keeps object frame-rate cache independent of drop-frame mode (first: %s)',
+  (dropFrame) => {
+    const frameRate = { numerator: 30000, denominator: 1001 };
+    const expected = dropFrame ? '00:10:00;00' : '00:09:59:12';
+    expect(formatTimecode(600, { frameRate, dropFrame })).toBe(expected);
+    expect(resolveTimecodeFrameRate(frameRate)).toBe(30000 / 1001);
+    expect(formatTimecode(600, { frameRate, dropFrame: !dropFrame })).toBe(
+      dropFrame ? '00:09:59:12' : '00:10:00;00'
+    );
+    expect(parseTimecode('00:01:00;00', { frameRate, dropFrame: true })).toBeNull();
+    expect(parseTimecode('00:10:00;00', { frameRate, dropFrame: true })).toBeCloseTo(599.9994);
+  }
+);
+
+it('revalidates changed object frame rates for both normalization and drop-frame support', () => {
+  const frameRate = { numerator: 30000, denominator: 1001 };
+  formatTimecode(600, { frameRate, dropFrame: true });
+  frameRate.numerator = 24;
+  frameRate.denominator = 1;
+  expect(resolveTimecodeFrameRate(frameRate)).toBe(24);
+  expect(() => formatTimecode(600, { frameRate, dropFrame: true })).toThrow(RangeError);
+  frameRate.denominator = 0;
+  expect(() => resolveTimecodeFrameRate(frameRate)).toThrow(RangeError);
+});

--- a/packages/utils/src/timecode.ts
+++ b/packages/utils/src/timecode.ts
@@ -152,44 +152,17 @@ function getFrameRateValue(frameRate: TimecodeFrameRate) {
   return frameRate.numerator / frameRate.denominator;
 }
 
-const objectFrameRateCache = new WeakMap<object, NormalizedFrameRate>();
-const primitiveFrameRateCache = new Map<string, NormalizedFrameRate>();
+const frameRateCache = new Map<string, NormalizedFrameRate>();
 
 function normalizeFrameRate(frameRate: TimecodeFrameRate, dropFrame: boolean): NormalizedFrameRate {
-  if (typeof frameRate === 'object' && frameRate !== null) {
-    let cached = objectFrameRateCache.get(frameRate);
-    if (cached) {
-      return cached;
-    }
-    const value = getFrameRateValue(frameRate);
-    if (!Number.isFinite(value) || value <= 0) {
-      throw new RangeError('Timecode frame rate must be a positive finite value.');
-    }
-    const nominal = Math.round(value);
-    if (nominal <= 0) {
-      throw new RangeError('Timecode frame rate must round to at least one frame per second.');
-    }
-    if (dropFrame && !isSupportedDropFrameRate(value, nominal)) {
-      throw new RangeError('Drop-frame timecode is only supported for 29.97/59.94-style rates.');
-    }
-    cached = {
-      value,
-      nominal,
-      dropFrames: dropFrame ? Math.round(nominal * 0.06666666666666667) : 0,
-    };
-    objectFrameRateCache.set(frameRate, cached);
-    return cached;
-  }
-
-  const cacheKey = `${frameRate}_${dropFrame}`;
-  let cached = primitiveFrameRateCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
   const value = getFrameRateValue(frameRate);
   if (!Number.isFinite(value) || value <= 0) {
     throw new RangeError('Timecode frame rate must be a positive finite value.');
+  }
+  const cacheKey = `${value}_${dropFrame}`;
+  const cached = frameRateCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
   const nominal = Math.round(value);
   if (nominal <= 0) {
@@ -198,13 +171,13 @@ function normalizeFrameRate(frameRate: TimecodeFrameRate, dropFrame: boolean): N
   if (dropFrame && !isSupportedDropFrameRate(value, nominal)) {
     throw new RangeError('Drop-frame timecode is only supported for 29.97/59.94-style rates.');
   }
-  cached = {
+  const normalized = {
     value,
     nominal,
     dropFrames: dropFrame ? Math.round(nominal * 0.06666666666666667) : 0,
   };
-  primitiveFrameRateCache.set(cacheKey, cached);
-  return cached;
+  frameRateCache.set(cacheKey, normalized);
+  return normalized;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix sub-tick internal playback, fractional-time HTML media recovery, and mixed drop-frame/non-drop-frame timecode caching.
- Restore saved In/Out points, copy constructor time inputs, and validate complete track-height batches before changing state.
- Return cached readonly document records from geometry, active-media, and keyframe queries. Keep mutable lookups private and reject metadata that could corrupt snapshot/history ownership.

This addresses all eight repository-review findings with regression coverage.

## Release Impact

- Packages/API: minor Changeset for the complete seven-package lockstep release group.
- Docs/demos: full-editor restoration fix, migration guide, and Core README updated.
- **Breaking changes:** query records are readonly; helpers should accept `TimelineReadonly<Clip>` or `TimelineReadonly<Track>` and edits must use engine commands. `TimelineMetadata` accepts plain objects/arrays and finite primitive values; move Maps, Sets, Dates, buffers, class instances, and cyclic data to application stores keyed by clip/source ID.

## Validation

- `vp run ci` — passed: 724 tests across 66 files, type checks, lint (zero errors), package coverage gates, docs/app builds, and packed-consumer validation.
- `vp run changeset:status` — all seven packages receive a minor release.
- PR title validated with commitlint.

## Checklist

- [x] I added a changeset or an empty changeset.
- [x] I checked package/API impact.
- [x] I checked docs/demo impact.
- [x] I called out breaking changes, if any.
