### PR TITLE
fix(www): keep demo code examples complete and copyable

### DIFF
--- a/.changeset/copyable-demo-imports.md
+++ b/.changeset/copyable-demo-imports.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix demo code tabs to use local imports and include their instrumentation dependencies.

--- a/apps/www/scripts/demos/verify.mjs
+++ b/apps/www/scripts/demos/verify.mjs
@@ -1,5 +1,7 @@
+import { preProcessFile } from 'typescript';
+import { toCopyableDemoSource } from '../../src/data/demo-snippets.ts';
 import { access, readFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -70,7 +72,25 @@ for (const id of registryIds) {
     try {
       const absolutePath = resolve(appDir, '..', '..', file);
       await access(absolutePath);
-      const source = await readFile(absolutePath, 'utf8');
+      const source = toCopyableDemoSource(await readFile(absolutePath, 'utf8'));
+
+      if (/\.tsx?$/.test(file)) {
+        for (const { fileName } of preProcessFile(source).importedFiles) {
+          if (/^(?:#|@\/)/.test(fileName)) {
+            errors.push(`demoCodeExamples["${id}"] exposes private import ${fileName} in ${file}.`);
+          }
+          if (
+            fileName.startsWith('.') &&
+            !files.some(
+              (candidate) => `./${basename(candidate).replace(/\.tsx?$/, '')}` === fileName
+            )
+          ) {
+            errors.push(
+              `demoCodeExamples["${id}"] is missing source for local import ${fileName}.`
+            );
+          }
+        }
+      }
 
       if (/import\s+['"]\.\/timeline-editor\.css['"]/.test(source)) {
         if (!/\bcss:\s*/.test(block)) {

--- a/apps/www/scripts/demos/verify.mjs
+++ b/apps/www/scripts/demos/verify.mjs
@@ -1,5 +1,5 @@
 import { preProcessFile } from 'typescript';
-import { toCopyableDemoSource } from '../../src/data/demo-snippets.ts';
+import { toCopyableDemoSource } from '#www/data/demo-snippets.ts';
 import { access, readFile } from 'node:fs/promises';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/apps/www/src/data/demo-code.test.ts
+++ b/apps/www/src/data/demo-code.test.ts
@@ -37,6 +37,20 @@ function namedImportsFrom(source: string, packageName: string): string[] {
 }
 
 describe('demo code examples', () => {
+  it('preserves type-only imports with trailing commas without adding an empty binding', () => {
+    const source = [
+      'import type {',
+      '  Track,',
+      '  Clip,',
+      "} from '@techsquidtv/canvas-timeline-core';",
+      "import { Timeline } from '@techsquidtv/canvas-timeline-react';",
+    ].join('\n');
+
+    expect(toCopyableDemoSource(source).trim()).toBe(
+      "import { type Track, type Clip, Timeline } from '@techsquidtv/canvas-timeline';"
+    );
+  });
+
   it('keeps adapter imports separate from the public timeline package projection', () => {
     const source = [
       "import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';",

--- a/apps/www/src/data/demo-code.test.ts
+++ b/apps/www/src/data/demo-code.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { preProcessFile } from 'typescript';
 import { describe, expect, it } from 'vite-plus/test';
 import { demoCodeExamples } from '#www/data/demo-code';
 import { toCopyableDemoSource } from '#www/data/demo-snippets';
@@ -105,3 +108,42 @@ describe('demo code examples', () => {
     }
   });
 });
+
+it.each(Object.entries(demoCodeExamples))(
+  '%s includes every local module referenced by its code tabs',
+  (_id, example) => {
+    const codeTabs = [
+      example.tsx,
+      example.data,
+      ...(example.extraTabs ?? []).map((tab) => tab.code),
+    ];
+    const files = [
+      example.sourceFiles.component,
+      example.sourceFiles.data,
+      ...[example.sourceFiles.utilities ?? []].flat(),
+    ];
+    const repositoryRoot = process.cwd();
+    for (const source of codeTabs) {
+      for (const { fileName } of preProcessFile(source).importedFiles) {
+        expect(fileName).not.toMatch(/^(?:#|@\/)/);
+        if (!fileName.startsWith('.')) {
+          continue;
+        }
+        if (fileName.endsWith('.css')) {
+          expect(example.css).toBeTruthy();
+          expect(fileName).toBe(`./${basename(example.sourceFiles.styles ?? '')}`);
+          continue;
+        }
+        const dependency = files.find(
+          (file) => basename(file).replace(/\.tsx?$/, '') === fileName.slice(2)
+        );
+        expect(dependency, `Missing source for ${fileName}`).toBeDefined();
+        if (dependency !== undefined) {
+          expect(codeTabs, `Missing code tab for ${fileName}`).toContain(
+            toCopyableDemoSource(readFileSync(resolve(repositoryRoot, dependency), 'utf8'))
+          );
+        }
+      }
+    }
+  }
+);

--- a/apps/www/src/data/demo-code.ts
+++ b/apps/www/src/data/demo-code.ts
@@ -31,6 +31,7 @@ import customPlayheadTimelineSource from '#www/demos/custom-playhead/CustomPlayh
 import customPlayheadDataSource from '#www/demos/custom-playhead/timeline-demo-data?raw';
 import demoClipColorsSource from '#www/demos/demo-clip-colors?raw';
 import demoInstrumentationSource from '#www/demos/demo-instrumentation?raw';
+import metricsCommonSource from '#www/lib/metrics-common?raw';
 import { toCopyableDemoSource } from '#www/data/demo-snippets';
 
 interface DemoCodeTab {
@@ -64,6 +65,13 @@ const demoInstrumentationTab: DemoCodeTab = {
   id: 'instrumentation',
   label: 'Instrumentation',
   code: toCopyableDemoSource(demoInstrumentationSource),
+  lang: 'ts',
+};
+
+const metricsCommonTab: DemoCodeTab = {
+  id: 'metrics-common',
+  label: 'Metric helpers',
+  code: toCopyableDemoSource(metricsCommonSource),
   lang: 'ts',
 };
 
@@ -101,26 +109,28 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
   'media-sync': {
     tsx: toCopyableDemoSource(mediaSyncTimelineSource),
     data: toCopyableDemoSource(mediaSyncDataSource),
-    extraTabs: [demoClipColorsTab, demoInstrumentationTab],
+    extraTabs: [demoClipColorsTab, demoInstrumentationTab, metricsCommonTab],
     sourceFiles: {
       component: 'apps/www/src/demos/media-preview-sync/MediaTimelineSync.tsx',
       data: 'apps/www/src/demos/media-preview-sync/timeline-demo-data.ts',
       utilities: [
         'apps/www/src/demos/demo-clip-colors.ts',
         'apps/www/src/demos/demo-instrumentation.ts',
+        'apps/www/src/lib/metrics-common.ts',
       ],
     },
   },
   'html-media-sync': {
     tsx: toCopyableDemoSource(htmlMediaSyncTimelineSource),
     data: toCopyableDemoSource(htmlMediaSyncDataSource),
-    extraTabs: [demoClipColorsTab, demoInstrumentationTab],
+    extraTabs: [demoClipColorsTab, demoInstrumentationTab, metricsCommonTab],
     sourceFiles: {
       component: 'apps/www/src/demos/html-media-sync/HTMLMediaTimelineSync.tsx',
       data: 'apps/www/src/demos/html-media-sync/timeline-demo-data.ts',
       utilities: [
         'apps/www/src/demos/demo-clip-colors.ts',
         'apps/www/src/demos/demo-instrumentation.ts',
+        'apps/www/src/lib/metrics-common.ts',
       ],
     },
   },
@@ -183,6 +193,8 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
     css: keyframeOpacityStylesSource,
     extraTabs: [
       demoClipColorsTab,
+      demoInstrumentationTab,
+      metricsCommonTab,
       {
         id: 'keyframe-utils',
         label: 'Keyframe utilities',
@@ -195,6 +207,8 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
       component: 'apps/www/src/demos/keyframe-opacity/KeyframeOpacityTimeline.tsx',
       utilities: [
         'apps/www/src/demos/keyframe-opacity/keyframe-opacity-utils.ts',
+        'apps/www/src/demos/demo-instrumentation.ts',
+        'apps/www/src/lib/metrics-common.ts',
         'apps/www/src/demos/demo-clip-colors.ts',
         'apps/www/src/demos/shared-timeline-editor.css',
       ],
@@ -207,6 +221,7 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
     extraTabs: [
       demoClipColorsTab,
       demoInstrumentationTab,
+      metricsCommonTab,
       {
         id: 'controls',
         label: 'Benchmark controls',
@@ -228,6 +243,7 @@ export const demoCodeExamples: Record<LiveDemoId, DemoCodeExample> = {
         'apps/www/src/demos/react-dom-timeline/DOMTimelineComponents.tsx',
         'apps/www/src/demos/demo-clip-colors.ts',
         'apps/www/src/demos/demo-instrumentation.ts',
+        'apps/www/src/lib/metrics-common.ts',
       ],
       data: 'apps/www/src/demos/timeline-stress-test/timeline-demo-data.ts',
     },

--- a/apps/www/src/data/demo-snippets.ts
+++ b/apps/www/src/data/demo-snippets.ts
@@ -26,9 +26,12 @@ function mergePublicPackageImports(source: string): string {
     (_statement, typeOnly, importedNames) => {
       for (const importedName of importedNames.split(',')) {
         const trimmedName = importedName.trim();
+        if (!trimmedName) {
+          continue;
+        }
         const specifier =
           typeOnly && !trimmedName.startsWith('type ') ? `type ${trimmedName}` : trimmedName;
-        if (specifier && !seen.has(specifier)) {
+        if (!seen.has(specifier)) {
           seen.add(specifier);
           specifiers.push(specifier);
         }

--- a/apps/www/src/data/demo-snippets.ts
+++ b/apps/www/src/data/demo-snippets.ts
@@ -67,5 +67,11 @@ export function toCopyableDemoSource(source: string): string {
     source
   );
 
-  return mergePublicPackageImports(publicPackageSource);
+  // Code tabs form one copyable folder, including shared demo helpers and styles.
+  const localModuleSource = publicPackageSource.replace(
+    /((?:\bfrom\s+|\bimport\s*)['"])#www\/(?:[^/'"\n]+\/)*([^/'"\n]+)(['"])/g,
+    '$1./$2$3'
+  );
+
+  return mergePublicPackageImports(localModuleSource);
 }

--- a/apps/www/src/data/demos.ts
+++ b/apps/www/src/data/demos.ts
@@ -133,7 +133,7 @@ export const demoDocs: DemoDoc[] = [
     slug: 'timeline-editor-controls',
     title: 'Timeline Editor Controls',
     description:
-      'A timeline with a complete playback control bar, demonstrating play/pause transport controls, editable playhead timecode, loop range boundaries (in/out markers), snapping toggle, and zooming/panning sliders.',
+      'A timeline with playback controls, editable timecode, in/out loop boundaries, snapping, markers, clip splitting, resizable track headers, and scrollbars for zooming and panning.',
     status: 'Controls',
     difficulty: 'Beginner',
     packageFocus: [


### PR DESCRIPTION
## Summary

Demo code tabs now replace website-only aliases with sibling file imports and include
the instrumentation helpers used by media, keyframe, and stress-test demos. Type-only
imports with trailing commas no longer produce a bogus `type` binding. The controls
demo description also matches its current toolbar and scrollbars.

Regression checks cover the local module dependencies of all 10 source-backed demos
so published examples stay complete as their live implementations change.

## Release Impact

- Packages/API: None; empty Changeset included.
- Docs/demos: Correct copyable code tabs and refresh the controls demo description.
- Breaking changes: None.

## Validation

- `vp run ci`: 735 tests, typechecks, lint, docs/app builds, and package validation.
- All 10 source-backed demos pass dependency and registry verification.
- Production smoke checks confirm controls, HTML media, and Mediabunny playback.

## Checklist

- [x] I added a changeset or an empty changeset.
- [x] I checked package/API impact.
- [x] I checked docs/demo impact.
- [x] I called out breaking changes, if any.
