### PR TITLE
fix(react)!: synchronize hook state and range updates

### DIFF
--- a/.changeset/react-hook-state-consistency.md
+++ b/.changeset/react-hook-state-consistency.md
@@ -1,0 +1,8 @@
+---
+'@techsquidtv/canvas-timeline-core': minor
+'@techsquidtv/canvas-timeline-react': minor
+---
+
+Keep history, paused active clips, content bounds, and pan/zoom constraints reactive in focused React hooks. Edit commands now read selection at invocation without subscribing to document changes. Add atomic `TimelineEngine.setInOutRange()` and expose current selected clip IDs for command integrations.
+
+**BREAKING:** `useTimelineRangeSelection().setRange()` and `clearRange()` return `TimelineCommandResult`. Invalid or reversed ranges are rejected without mutation. In/Out controls without an explicit duration or `max` use current content bounds instead of an arbitrary 100-second limit. The fixed package group releases together.

--- a/apps/www/src/content/docs/react-hooks.mdx
+++ b/apps/www/src/content/docs/react-hooks.mdx
@@ -68,6 +68,11 @@ scrubbing or playback should use focused live hooks such as
 `useTimelineClipDropFeedback()`. Use `useTimeline()` directly only when a
 component needs both the shared engine and the synchronized state snapshot.
 
+Edit command hooks read the current engine state when invoked, including commands issued
+consecutively in one event handler. History availability and viewport bounds have
+focused subscriptions: changing content or zoom limits updates controls even when
+the current scroll or zoom value does not change.
+
 Mutating hook commands return `TimelineCommandResult`, so custom controls can
 branch on `ok` and machine-readable failure reasons without reading private
 engine state.
@@ -114,7 +119,9 @@ Compose the focused hooks around it:
 - `useTimelineEditImpacts()` subscribes to affected-clip consequences for live
   guides, renderer overlays, and drag-time affordances.
 - `useTimelineRangeSelection()` adapts In/Out points to `delete-range` and
-  `lift-range` commands.
+  `lift-range` commands. Its `setRange()` replaces both boundaries atomically;
+  Core consumers can call `engine.setInOutRange(startTime, endTime)`. Invalid
+  ranges return a command failure without changing either boundary.
 - `useTimelineClipGroups()` reads timeline clip groups and exposes group,
   ungroup, and selected-group commands for editor chrome.
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -939,7 +939,8 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     );
   }
 
-  private getSelectedClipIds() {
+  /** Returns currently selected clip IDs in timeline track order. */
+  getSelectedClipIds() {
     const clipIds: string[] = [];
     for (const track of this.state.tracks) {
       for (const clip of track.clips) {
@@ -1565,6 +1566,30 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       this.publishSnapFeedback(result?.feedback ?? emptyTimelineSnapFeedback);
     }
     return result;
+  }
+
+  /**
+   * Atomically replaces both In/Out boundaries without intermediate range clearing.
+   * @param startTime - Inclusive, non-negative range start.
+   * @param endTime - Exclusive range end, after the start.
+   * @returns Success, or an input/range failure without changing either boundary.
+   */
+  setInOutRange(startTime: RationalTime, endTime: RationalTime): TimelineCommandResult {
+    try {
+      assertValidRationalTime(startTime, 'startTime');
+      assertValidRationalTime(endTime, 'endTime');
+    } catch (error) {
+      return timelineCommandInvalidInput('Invalid In/Out range.', error);
+    }
+    if (startTime.v < 0 || compareRational(startTime, endTime) >= 0) {
+      return timelineCommandFail('invalid-range');
+    }
+    this.state.inPoint = cloneRationalTime(startTime);
+    this.state.outPoint = cloneRationalTime(endTime);
+    this.publishSnapFeedback(emptyTimelineSnapFeedback);
+    this.emit('state:inOut', { state: this.state });
+    this.emit('render');
+    return timelineCommandOk();
   }
 
   /**

--- a/packages/react/src/hooks/clips/useActiveClips.ts
+++ b/packages/react/src/hooks/clips/useActiveClips.ts
@@ -1,3 +1,4 @@
+import { useTimelineSelector } from '#react/hooks/core/useTimelineSelector';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useTimelinePlayheadTime } from '#react/hooks/playback/useTimelinePlayheadTime';
 /**
@@ -19,6 +20,7 @@ import { useTimelinePlayheadTime } from '#react/hooks/playback/useTimelinePlayhe
  */
 export function useActiveClips() {
   const engine = useTimelineEngine();
+  useTimelineSelector((state) => state.tracks, Object.is);
   const playheadTime = useTimelinePlayheadTime();
 
   return engine.media.getActiveClips(playheadTime).map(({ clip }) => clip);

--- a/packages/react/src/hooks/core/timelineSnapshotEqual.ts
+++ b/packages/react/src/hooks/core/timelineSnapshotEqual.ts
@@ -1,0 +1,28 @@
+/** Compares scalar or shallow collection snapshots without allocating another value. */
+export function shallowEqual<Value>(previous: Value, next: Value): boolean {
+  if (Object.is(previous, next)) {
+    return true;
+  }
+  if (
+    typeof previous !== 'object' ||
+    previous === null ||
+    typeof next !== 'object' ||
+    next === null
+  ) {
+    return false;
+  }
+  if (Object.getPrototypeOf(previous) !== Object.getPrototypeOf(next)) {
+    return false;
+  }
+  if (!Array.isArray(next) && Object.getPrototypeOf(next) !== Object.prototype) {
+    return false;
+  }
+  if (Array.isArray(previous) && Array.isArray(next) && previous.length !== next.length) {
+    return false;
+  }
+  const keys = Object.keys(next) as (keyof Value)[];
+  return (
+    keys.length === Object.keys(previous).length &&
+    keys.every((key) => Object.hasOwn(previous, key) && Object.is(previous[key], next[key]))
+  );
+}

--- a/packages/react/src/hooks/core/useTimelineExternalStore.ts
+++ b/packages/react/src/hooks/core/useTimelineExternalStore.ts
@@ -1,6 +1,7 @@
+import { shallowEqual } from '#react/hooks/core/timelineSnapshotEqual';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import type { EngineEventMap, TimelineEngine } from '@techsquidtv/canvas-timeline-core';
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useRef, useSyncExternalStore } from 'react';
 type TimelineExternalStoreEvent = keyof EngineEventMap;
 type TimelineExternalStoreSnapshot<T> = (engine: TimelineEngine) => T;
 
@@ -9,9 +10,11 @@ type TimelineExternalStoreSnapshot<T> = (engine: TimelineEngine) => T;
  */
 export function useTimelineExternalStore<T>(
   events: readonly TimelineExternalStoreEvent[],
-  getSnapshotForEngine: TimelineExternalStoreSnapshot<T>
+  getSnapshotForEngine: TimelineExternalStoreSnapshot<T>,
+  isEqual: (previous: T, next: T) => boolean = shallowEqual
 ): T {
   const engine = useTimelineEngine();
+  const previous = useRef<{ engine: TimelineEngine; value: T } | undefined>(undefined);
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -25,10 +28,14 @@ export function useTimelineExternalStore<T>(
     [engine, events]
   );
 
-  const getSnapshot = useCallback(
-    () => getSnapshotForEngine(engine),
-    [engine, getSnapshotForEngine]
-  );
+  const getSnapshot = useCallback(() => {
+    const next = getSnapshotForEngine(engine);
+    if (previous.current?.engine === engine && isEqual(previous.current.value, next)) {
+      return previous.current.value;
+    }
+    previous.current = { engine, value: next };
+    return next;
+  }, [engine, getSnapshotForEngine, isEqual]);
 
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/packages/react/src/hooks/core/useTimelineSelector.ts
+++ b/packages/react/src/hooks/core/useTimelineSelector.ts
@@ -1,3 +1,4 @@
+import { shallowEqual } from '#react/hooks/core/timelineSnapshotEqual';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import type {
   EngineEventMap,
@@ -47,34 +48,6 @@ function createStore(engine: TimelineEngine) {
       };
     },
   };
-}
-
-function shallowEqual<Value>(previous: Value, next: Value): boolean {
-  if (Object.is(previous, next)) {
-    return true;
-  }
-  if (
-    typeof previous !== 'object' ||
-    previous === null ||
-    typeof next !== 'object' ||
-    next === null
-  ) {
-    return false;
-  }
-  if (Object.getPrototypeOf(previous) !== Object.getPrototypeOf(next)) {
-    return false;
-  }
-  if (!Array.isArray(next) && Object.getPrototypeOf(next) !== Object.prototype) {
-    return false;
-  }
-  if (Array.isArray(previous) && Array.isArray(next) && previous.length !== next.length) {
-    return false;
-  }
-  const keys = Object.keys(next) as (keyof Value)[];
-  return (
-    keys.length === Object.keys(previous).length &&
-    keys.every((key) => Object.hasOwn(previous, key) && Object.is(previous[key], next[key]))
-  );
 }
 
 /**

--- a/packages/react/src/hooks/editing/useTimelineEditCommands.ts
+++ b/packages/react/src/hooks/editing/useTimelineEditCommands.ts
@@ -20,7 +20,6 @@ import type {
   TimelineTrimEditCommand,
 } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
-import { useTimelineSelection } from '#react/hooks/selection/useTimelineSelection';
 import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { useCallback, useMemo } from 'react';
 /** Result returned by `useTimelineEditCommands`. */
@@ -115,7 +114,6 @@ function toTimelineCommandFailureReason(
  */
 export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
   const engine = useTimelineEngine();
-  const { selectedClipIds } = useTimelineSelection();
 
   const validateEdit = useCallback(
     (command: TimelineEditCommand) => engine.validateEdit(command),
@@ -161,7 +159,7 @@ export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
         commitEdit({ type: 'split', clipIds: [clipId], time }),
       splitClips: (command) => commitEdit({ type: 'split', ...command }),
       splitSelectedClipsAtTime: (time: RationalTime) =>
-        commitEdit({ type: 'split', clipIds: selectedClipIds, time }),
+        commitEdit({ type: 'split', clipIds: engine.getSelectedClipIds(), time }),
       deleteClip: (clipId: string) => commitEdit({ type: 'delete-clips', clipIds: [clipId] }),
       insertClip: (command: {
         clip: Clip;
@@ -180,6 +178,6 @@ export function useTimelineEditCommands(): UseTimelineEditCommandsResult {
       deleteRange: (command) => commitEdit({ type: 'delete-range', ...command }),
       liftRange: (command) => commitEdit({ type: 'lift-range', ...command }),
     }),
-    [cancelEdit, commitEdit, previewEdit, selectedClipIds, validateEdit]
+    [cancelEdit, commitEdit, previewEdit, engine, validateEdit]
   );
 }

--- a/packages/react/src/hooks/integration/state-consistency.test.tsx
+++ b/packages/react/src/hooks/integration/state-consistency.test.tsx
@@ -1,0 +1,208 @@
+import { act, renderHook } from '@testing-library/react';
+import { expect, test } from 'vite-plus/test';
+import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { fromSeconds, toSeconds } from '@techsquidtv/canvas-timeline-utils';
+import {
+  useActiveClips,
+  useTimelineHistory,
+  useTimelineViewport,
+  useTimelinePanControl,
+  useTimelineRulerTicks,
+  useTimelineEditCommands,
+  useTimelineInOutRangeControl,
+  useTimelineRangeSelection,
+  useTimelineZoomControl,
+} from '#react/hooks';
+import { createClip, createTrack, wrapper } from '#react/hooks/integration/testHelpers';
+
+function makeEngine() {
+  const engine = new TimelineEngine({
+    playheadTime: fromSeconds(1),
+    zoomScale: 100,
+    tracks: [createTrack('track', [createClip('clip', 0, 10)])],
+  });
+  engine.setViewportWidth(100);
+  return engine;
+}
+
+test('history availability updates after an edit', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelineHistory(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  expect(result.current.canUndo).toBe(false);
+  act(() => {
+    engine.updateClipProperties('clip', { label: 'changed' });
+  });
+  expect(engine.canUndo).toBe(true);
+  expect(result.current.canUndo).toBe(true);
+  act(() => {
+    result.current.undo();
+  });
+  expect(result.current.canUndo).toBe(false);
+  expect(result.current.canRedo).toBe(true);
+  act(() => {
+    result.current.redo();
+  });
+  expect(result.current.canUndo).toBe(true);
+  expect(result.current.canRedo).toBe(false);
+});
+
+test('active clips update when a track is hidden at a fixed playhead', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useActiveClips(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  expect(result.current.map((clip) => clip.id)).toEqual(['clip']);
+  act(() => {
+    engine.toggleTrackVisibility('track', false);
+  });
+  expect(engine.media.getActiveClips(engine.playheadTime)).toHaveLength(0);
+  expect(result.current).toHaveLength(0);
+});
+
+test('viewport content bounds update without scroll or zoom changes', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelineViewport(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  expect(toSeconds(result.current.maxContentTime)).toBe(10);
+  act(() => {
+    engine.addTrack(createTrack('long', [createClip('long-clip', 0, 30)]));
+  });
+  expect(engine.scrollLeft).toBe(0);
+  expect(engine.zoomScale).toBe(100);
+  expect(toSeconds(engine.maxContentTime)).toBe(30);
+  expect(toSeconds(result.current.maxContentTime)).toBe(30);
+});
+
+test('pan bounds update without moving scroll', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelinePanControl(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  expect(result.current.max).toBe(engine.maxScrollLeft);
+  act(() => {
+    engine.setViewportWidth(200);
+  });
+  expect(engine.scrollLeft).toBe(0);
+  expect(result.current.max).toBe(engine.maxScrollLeft);
+});
+
+test('ruler ignores playhead changes when viewport geometry is fixed', () => {
+  const engine = makeEngine();
+  let renders = 0;
+  const { result } = renderHook(
+    () => {
+      renders++;
+      return useTimelineRulerTicks();
+    },
+    {
+      wrapper: (props) => wrapper({ ...props, engine }),
+    }
+  );
+  const before = renders;
+  const ticks = result.current;
+  act(() => {
+    engine.updatePlayhead(fromSeconds(2));
+  });
+  expect(result.current).toEqual(ticks);
+  expect(renders).toBe(before);
+});
+
+test('command hook ignores clip presentation updates', () => {
+  const engine = makeEngine();
+  let renders = 0;
+  renderHook(
+    () => {
+      renders++;
+      return useTimelineEditCommands();
+    },
+    {
+      wrapper: (props) => wrapper({ ...props, engine }),
+    }
+  );
+  const before = renders;
+  act(() => {
+    engine.updateClipProperties('clip', { label: 'changed' });
+  });
+  expect(renders).toBe(before);
+});
+
+test('In/Out control uses content bounds for an implicit duration', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelineInOutRangeControl(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  expect(result.current.max).toBe(toSeconds(engine.maxContentTime));
+});
+
+test('replacing a range preserves both endpoints when crossing the old out point', () => {
+  const engine = makeEngine();
+  engine.setInPoint(fromSeconds(2));
+  engine.setOutPoint(fromSeconds(4));
+  const { result } = renderHook(() => useTimelineRangeSelection(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  act(() => {
+    result.current.setRange({ startTime: fromSeconds(4), endTime: fromSeconds(6) });
+  });
+  expect(result.current.range).toEqual({ startTime: fromSeconds(4), endTime: fromSeconds(6) });
+});
+
+test('zoom bounds update when constraints change without changing zoom', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelineZoomControl(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  act(() => {
+    engine.setZoomConstraints({ maxZoomScale: 300 });
+  });
+  expect(engine.zoomScale).toBe(100);
+  expect(result.current.max).toBe(300);
+});
+
+test('range replacement rejects invalid input before publishing either boundary', () => {
+  const engine = makeEngine();
+  engine.setInOutRange(fromSeconds(2), fromSeconds(4));
+  const snapshots: [number | undefined, number | undefined][] = [];
+  engine.on('state:inOut', () => {
+    const { inPoint, outPoint } = engine.getState();
+    snapshots.push([inPoint && toSeconds(inPoint), outPoint && toSeconds(outPoint)]);
+  });
+  expect(engine.setInOutRange(fromSeconds(6), fromSeconds(4))).toEqual({
+    ok: false,
+    reason: 'invalid-range',
+  });
+  expect(engine.setInOutRange({ v: 0, r: 0 }, fromSeconds(6))).toMatchObject({
+    ok: false,
+    reason: 'invalid-input',
+  });
+  expect(snapshots).toEqual([]);
+  engine.setInOutRange(fromSeconds(4), fromSeconds(6));
+  expect(snapshots).toEqual([[4, 6]]);
+});
+
+test('retained edit commands use the current selection without a React render', () => {
+  const engine = makeEngine();
+  const { result } = renderHook(() => useTimelineEditCommands(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  const commands = result.current;
+  act(() => {
+    engine.selectClip('clip');
+    expect(commands.splitSelectedClipsAtTime(fromSeconds(5)).ok).toBe(true);
+  });
+  expect(engine.tracks[0].clips).toHaveLength(2);
+  expect(result.current).toBe(commands);
+});
+
+test('In/Out slider applies both changed endpoints atomically', () => {
+  const engine = makeEngine();
+  engine.setInOutRange(fromSeconds(2), fromSeconds(4));
+  const { result } = renderHook(() => useTimelineInOutRangeControl(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  act(() => result.current.setValue([4, 6]));
+  expect(result.current.value).toEqual([4, 6]);
+});

--- a/packages/react/src/hooks/selection/useTimelineHistory.ts
+++ b/packages/react/src/hooks/selection/useTimelineHistory.ts
@@ -1,7 +1,10 @@
+import { useTimelineExternalStore } from '#react/hooks/core/useTimelineExternalStore';
 import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { useCallback } from 'react';
+const historyEvents = ['history:change'] as const;
+
 /** Result returned by `useTimelineHistory`. */
 export interface UseTimelineHistoryResult {
   /** Whether an undo snapshot is available. */
@@ -21,6 +24,10 @@ export interface UseTimelineHistoryResult {
  */
 export function useTimelineHistory(): UseTimelineHistoryResult {
   const engine = useTimelineEngine();
+  const availability = useTimelineExternalStore(historyEvents, (engine) => ({
+    canUndo: engine.canUndo,
+    canRedo: engine.canRedo,
+  }));
 
   const undo = useCallback(() => {
     if (!engine.canUndo) {
@@ -39,8 +46,7 @@ export function useTimelineHistory(): UseTimelineHistoryResult {
   }, [engine]);
 
   return {
-    canUndo: engine.canUndo,
-    canRedo: engine.canRedo,
+    ...availability,
     undo,
     redo,
   };

--- a/packages/react/src/hooks/selection/useTimelineRangeSelection.ts
+++ b/packages/react/src/hooks/selection/useTimelineRangeSelection.ts
@@ -1,3 +1,4 @@
+import { timelineCommandOk, timelineCommandFail } from '@techsquidtv/canvas-timeline-core';
 import type {
   TimelineCommandResult,
   TimelineEditCommitResult,
@@ -22,9 +23,9 @@ export interface UseTimelineRangeSelectionResult {
   /** Whether a complete range is selected. */
   hasRange: boolean;
   /** Sets both range boundaries. */
-  setRange: (range: TimelineRangeSelection) => void;
+  setRange: (range: TimelineRangeSelection) => TimelineCommandResult;
   /** Clears the range boundaries. */
-  clearRange: () => void;
+  clearRange: () => TimelineCommandResult;
   /** Deletes the selected range, closing the gap by default. */
   deleteRange: (options?: {
     trackIds?: readonly string[];
@@ -63,43 +64,45 @@ export function useTimelineRangeSelection(): UseTimelineRangeSelectionResult {
 
   const setRange = useCallback(
     (nextRange: TimelineRangeSelection) => {
-      engine.setInPoint(nextRange.startTime);
-      engine.setOutPoint(nextRange.endTime);
+      return engine.setInOutRange(nextRange.startTime, nextRange.endTime);
     },
     [engine]
   );
 
   const clearRange = useCallback(() => {
     engine.clearInOutPoints();
+    return timelineCommandOk();
   }, [engine]);
 
   const deleteRange = useCallback(
     (options: { trackIds?: readonly string[]; ripple?: boolean } = {}) => {
-      if (range === null) {
-        return { ok: false as const, reason: 'invalid-range' as const };
+      const { inPoint, outPoint } = engine.getState();
+      if (inPoint === undefined || outPoint === undefined) {
+        return timelineCommandFail<TimelineEditCommitResult>('invalid-range');
       }
       return commitDeleteRange({
-        startTime: range.startTime,
-        endTime: range.endTime,
+        startTime: inPoint,
+        endTime: outPoint,
         trackIds: options.trackIds,
         ripple: options.ripple,
       });
     },
-    [commitDeleteRange, range]
+    [commitDeleteRange, engine]
   );
 
   const liftRange = useCallback(
     (options: { trackIds?: readonly string[] } = {}) => {
-      if (range === null) {
-        return { ok: false as const, reason: 'invalid-range' as const };
+      const { inPoint, outPoint } = engine.getState();
+      if (inPoint === undefined || outPoint === undefined) {
+        return timelineCommandFail<TimelineEditCommitResult>('invalid-range');
       }
       return commitLiftRange({
-        startTime: range.startTime,
-        endTime: range.endTime,
+        startTime: inPoint,
+        endTime: outPoint,
         trackIds: options.trackIds,
       });
     },
-    [commitLiftRange, range]
+    [commitLiftRange, engine]
   );
 
   return useMemo(

--- a/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineInOutRangeControl.ts
@@ -1,3 +1,4 @@
+import { useTimelineViewportBounds } from '#react/hooks/viewport/useTimelineViewportBounds';
 import { formatTimelineRangeValue, formatTimelineTimeValue } from '#react/accessibility';
 import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
@@ -83,15 +84,15 @@ export function useTimelineInOutRangeControl(options: TimelineInOutRangeControlO
     step,
   } = options;
   const engine = useTimelineEngine();
+  const bounds = useTimelineViewportBounds();
   const state = useTimelineSelector((state) => ({
-    duration: state.duration,
     inPoint: state.inPoint,
     outPoint: state.outPoint,
   }));
   const preparedSnapIndexRef = useRef<number | null>(null);
   const control = useMemo(() => {
     const min = optionMin ?? 0;
-    const max = optionMax ?? (state.duration ? toSeconds(state.duration) : 100);
+    const max = optionMax ?? toSeconds(bounds.maxContentTime);
     const value: [number, number] = [
       state.inPoint ? toSeconds(state.inPoint) : min,
       state.outPoint ? toSeconds(state.outPoint) : max,
@@ -106,7 +107,7 @@ export function useTimelineInOutRangeControl(options: TimelineInOutRangeControlO
       value,
       valueText: formatTimelineRangeValue(value[0], value[1], { includeDuration: true }),
     };
-  }, [optionMax, optionMin, state.duration, state.inPoint, state.outPoint, step]);
+  }, [optionMax, optionMin, bounds.maxContentTime, state.inPoint, state.outPoint, step]);
 
   const setValue = useCallback(
     (nextValue: number[], eventDetails?: RangeChangeDetails) => {
@@ -128,6 +129,17 @@ export function useTimelineInOutRangeControl(options: TimelineInOutRangeControlO
         nextValue[0] === undefined ? undefined : clamp(nextValue[0], control.min, control.max);
       const nextOut =
         nextValue[1] === undefined ? undefined : clamp(nextValue[1], control.min, control.max);
+
+      if (
+        !shouldSnap &&
+        nextIn !== undefined &&
+        nextOut !== undefined &&
+        nextIn !== control.value[0] &&
+        nextOut !== control.value[1]
+      ) {
+        engine.setInOutRange(fromSeconds(nextIn), fromSeconds(nextOut));
+        return;
+      }
 
       if (nextIn !== undefined && nextIn !== control.value[0]) {
         engine.setInPoint(fromSeconds(nextIn), shouldSnap && activeThumbIndex === 0);

--- a/packages/react/src/hooks/viewport/useTimelinePanControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelinePanControl.ts
@@ -1,3 +1,4 @@
+import { useTimelineViewportBounds } from '#react/hooks/viewport/useTimelineViewportBounds';
 import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { createTimelineScalarControlProps } from '#react/hooks/core/timelineScalarControlProps';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
@@ -61,17 +62,18 @@ function formatPanValue(value: number) {
 export function useTimelinePanControl(options: TimelinePanControlOptions = {}) {
   const { label: optionLabel, max: optionMax, min: optionMin, onValueCommitted, step } = options;
   const engine = useTimelineEngine();
+  const bounds = useTimelineViewportBounds();
   const scrollLeft = useTimelineScrollLeft();
   const control = useMemo(
     () => ({
       label: optionLabel ?? 'Timeline pan',
-      max: optionMax ?? engine.maxScrollLeft,
+      max: optionMax ?? bounds.maxScrollLeft,
       min: optionMin ?? 0,
       step: step ?? 1,
       value: scrollLeft,
       valueText: formatPanValue(scrollLeft),
     }),
-    [engine.maxScrollLeft, optionLabel, optionMax, optionMin, scrollLeft, step]
+    [bounds.maxScrollLeft, optionLabel, optionMax, optionMin, scrollLeft, step]
   );
 
   const setValue = useCallback(

--- a/packages/react/src/hooks/viewport/useTimelineViewport.ts
+++ b/packages/react/src/hooks/viewport/useTimelineViewport.ts
@@ -1,3 +1,4 @@
+import { useTimelineViewportBounds } from '#react/hooks/viewport/useTimelineViewportBounds';
 import { timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type { TimelineCommandResult } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
@@ -65,6 +66,7 @@ export interface UseTimelineViewportResult {
  */
 export function useTimelineViewport(): UseTimelineViewportResult {
   const engine = useTimelineEngine();
+  const bounds = useTimelineViewportBounds();
   const state = useTimelineSelector((state) => ({
     duration: state.duration,
     viewportHeight: state.viewportHeight,
@@ -125,10 +127,10 @@ export function useTimelineViewport(): UseTimelineViewportResult {
   const viewportWidth = state.viewportWidth || 1000;
   const viewportHeight = state.viewportHeight ?? 600;
   const safeZoomScale = Math.max(zoomScale || 0, 0.1);
-  const maxContentTime = engine.maxContentTime;
+  const maxContentTime = bounds.maxContentTime;
   const duration = state.duration;
-  const maxScrollLeft = engine.maxScrollLeft;
-  const maxScrollTop = engine.maxScrollTop;
+  const maxScrollLeft = bounds.maxScrollLeft;
+  const maxScrollTop = bounds.maxScrollTop;
   const viewportDurationSeconds = viewportWidth / safeZoomScale;
   const visibleStartSeconds = clamp(scrollLeft / safeZoomScale, 0, toSeconds(maxContentTime));
   const visibleEndSeconds = Math.min(

--- a/packages/react/src/hooks/viewport/useTimelineViewportBounds.ts
+++ b/packages/react/src/hooks/viewport/useTimelineViewportBounds.ts
@@ -1,0 +1,29 @@
+import { useTimelineExternalStore } from '#react/hooks/core/useTimelineExternalStore';
+import type { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+
+const boundsEvents = ['content:change', 'viewport:resize', 'zoom:change', 'state:settled'] as const;
+
+function getBounds(engine: TimelineEngine) {
+  return {
+    maxContentTime: engine.maxContentTime,
+    maxScrollLeft: engine.maxScrollLeft,
+    maxScrollTop: engine.maxScrollTop,
+    minZoomScale: engine.minZoomScale,
+    maxZoomScale: engine.maxZoomScale,
+  };
+}
+
+/** Observes limits even when content, dimensions, or policy changes leave live values unchanged. */
+export function useTimelineViewportBounds() {
+  return useTimelineExternalStore(
+    boundsEvents,
+    getBounds,
+    (previous, next) =>
+      previous.maxContentTime.v === next.maxContentTime.v &&
+      previous.maxContentTime.r === next.maxContentTime.r &&
+      previous.maxScrollLeft === next.maxScrollLeft &&
+      previous.maxScrollTop === next.maxScrollTop &&
+      previous.minZoomScale === next.minZoomScale &&
+      previous.maxZoomScale === next.maxZoomScale
+  );
+}

--- a/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
+++ b/packages/react/src/hooks/viewport/useTimelineZoomControl.ts
@@ -1,3 +1,4 @@
+import { useTimelineViewportBounds } from '#react/hooks/viewport/useTimelineViewportBounds';
 import type { TimelineControlCommitDetails } from '#react/hooks/core/timelineControlEvents';
 import { createTimelineScalarControlProps } from '#react/hooks/core/timelineScalarControlProps';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
@@ -61,10 +62,11 @@ function formatZoomValue(value: number) {
 export function useTimelineZoomControl(options: TimelineZoomControlOptions = {}) {
   const { label: optionLabel, max: optionMax, min: optionMin, onValueCommitted, step } = options;
   const engine = useTimelineEngine();
+  const bounds = useTimelineViewportBounds();
   const zoomScale = useTimelineZoomScale();
   const control = useMemo(() => {
-    const engineMin = engine.minZoomScale;
-    const engineMax = engine.maxZoomScale;
+    const engineMin = bounds.minZoomScale;
+    const engineMax = bounds.maxZoomScale;
     const min = Math.max(optionMin ?? 10, engineMin);
     const requestedMax = optionMax ?? (Number.isFinite(engineMax) ? engineMax : 1000);
     const max = Math.max(min, Math.min(requestedMax, engineMax));
@@ -78,8 +80,8 @@ export function useTimelineZoomControl(options: TimelineZoomControlOptions = {})
       valueText: formatZoomValue(zoomScale),
     };
   }, [
-    engine.maxZoomScale,
-    engine.minZoomScale,
+    bounds.maxZoomScale,
+    bounds.minZoomScale,
     optionLabel,
     optionMax,
     optionMin,

--- a/scripts/checks/react-registry.mjs
+++ b/scripts/checks/react-registry.mjs
@@ -15,6 +15,7 @@ const outputDir = resolve(repoRoot, 'apps/www/.generated/react-registry-snippets
 const internalHookAllowlist = new Set([
   'useTimelineExternalStore',
   'useTimelineGeometryRevision',
+  'useTimelineViewportBounds',
   'useTimelineTrackCommands',
   'useTimelineTrackGeometry',
   'useTimelineMediaPlaybackInternal',


### PR DESCRIPTION
## Summary

Fix stale history availability, active clips while paused, viewport content limits, and pan/zoom bounds. Edit commands read current selection at invocation without subscribing to unrelated document changes. Add atomic Core In/Out range replacement so changing [2, 4] to [4, 6] preserves both endpoints.

## Release Impact

- Packages/API: Core and React changes; minor Changeset in the fixed seven-package group.
- Docs/demos: Document reactive bounds and atomic range updates.
- Breaking changes: Range setters return `TimelineCommandResult`; invalid/reversed ranges are rejected; In/Out controls derive their default maximum from content instead of 100 seconds. No compatibility aliases.

## Validation

- Focused Core and hook suites: 246 tests passed.
- Full `vp run ci`: passed, including 747 tests, coverage gates, docs/app builds, and packed consumer validation.
- Added regression coverage for history transitions, paused visibility, content growth, resized viewports, changed zoom constraints, atomic/invalid ranges, and retained selection commands.
