### PR TITLE
fix: preserve edit transactions and media preview state

### DIFF
--- a/.changeset/repair-edit-transaction-boundaries.md
+++ b/.changeset/repair-edit-transaction-boundaries.md
@@ -1,0 +1,6 @@
+---
+'@techsquidtv/canvas-timeline-core': patch
+'@techsquidtv/canvas-timeline-react': patch
+---
+
+Validate keyframe updates before changing document state, enforce roll-trim bounds, and return owned marker copies. Restore history with cleared edit previews and valid viewport bounds. Keep clip drag and trim previews owned by their initiating gesture, and refresh paused media when effective layer selections change.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,4 +1,5 @@
 import { findClipInTracks } from '#core/engine/clip-lookup';
+import type { createDocumentSnapshot } from '#core/document-snapshot';
 import {
   timelineCommandOk,
   timelineCommandFail,
@@ -157,7 +158,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    * @param label - Optional visible marker label.
    * @param color - Optional marker color.
    * @param description - Optional longer marker note.
-   * @returns The created marker.
+   * @returns An owned copy of the created marker.
    */
   addMarker(time: RationalTime, label?: string, color?: string, description?: string) {
     assertValidRationalTime(time, 'time');
@@ -174,10 +175,10 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
     this.state.markers.push(marker);
     this.invalidateContent();
     this.snapshot();
-    this.emit('marker:add', { marker });
+    this.emit('marker:add', { marker: createMarkerSnapshots([marker])[0] });
     this.emit('state:settled');
     this.emit('render');
-    return marker;
+    return createMarkerSnapshots([marker])[0];
   }
 
   /**
@@ -207,7 +208,7 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    *
    * @param id - Marker id to update.
    * @param updates - Marker fields to merge into the existing marker.
-   * @returns The updated marker, or `null` when no marker was found.
+   * @returns An owned copy of the updated marker, or `null` when no marker was found.
    */
   updateMarker(id: string, updates: Partial<Omit<Marker, 'id'>>) {
     if (updates.time !== undefined) {
@@ -229,14 +230,14 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
           marker.description = updates.description;
         }
         if (Object.hasOwn(updates, 'snap')) {
-          marker.snap = updates.snap;
+          marker.snap = createMarkerSnapshots([{ ...marker, snap: updates.snap }])[0].snap;
         }
         this.invalidateContent();
         this.snapshot();
-        this.emit('marker:update', { marker });
+        this.emit('marker:update', { marker: createMarkerSnapshots([marker])[0] });
         this.emit('state:settled');
         this.emit('render');
-        return marker;
+        return createMarkerSnapshots([marker])[0];
       }
     }
     return null;
@@ -852,17 +853,21 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
    * Clears the active command-layer edit preview and snap guides.
    */
   cancelEdit() {
+    this.clearEditPreview();
+    this.publishSnapFeedback(emptyTimelineSnapFeedback);
+    this.emit('edit:preview', null);
+    this.emit('edit:impacts', null);
+    this.emit('state:preview');
+    this.emit('render');
+  }
+
+  private clearEditPreview() {
     this.previewIds.clear();
     this.previewTracks = null;
     this.renderSnapshot = undefined;
     this.renderedTracks = null;
     this.editPreview = null;
     this.editImpacts = null;
-    this.publishSnapFeedback(emptyTimelineSnapFeedback);
-    this.emit('edit:preview', null);
-    this.emit('edit:impacts', null);
-    this.emit('state:preview');
-    this.emit('render');
   }
 
   private publishEditPreview(preview: TimelineEditPreview) {
@@ -1236,7 +1241,12 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
       getClip: (id) => this.geometry.getClip(id),
     });
     this.playbackManager = new PlaybackManager(this, this.state);
-    this.historyManager = new HistoryManager(this, this.state, initialState.history);
+    this.historyManager = new HistoryManager(
+      this,
+      this.state,
+      (snapshot) => this.restoreHistoryDocument(snapshot),
+      initialState.history
+    );
     this.clipboardManager = new ClipboardManager(this);
     this.normalizeClipGroups();
     this.keyframes.validateRegisteredClipKeyframes();
@@ -1901,6 +1911,38 @@ export class TimelineEngine extends TypedEventEmitter<EngineEventMap> {
   }
 
   // --- Undo / Redo ---
+
+  private restoreHistoryDocument(snapshot: ReturnType<typeof createDocumentSnapshot>) {
+    const tracks = createTrackSnapshots(snapshot.tracks);
+    const markers = createMarkerSnapshots(snapshot.markers);
+    const clipGroups = createClipGroupSnapshots(snapshot.clipGroups);
+    const previousScrollLeft = this.state.scrollLeft;
+    const previousScrollTop = this.state.scrollTop;
+    const previousZoomScale = this.state.zoomScale;
+    this.state.tracks = tracks;
+    this.state.markers = markers;
+    this.state.clipGroups = clipGroups;
+    this.clearEditPreview();
+    this.state.zoomScale = this.clampZoomScale(this.state.zoomScale);
+    this.state.scrollLeft = Math.max(0, Math.min(this.state.scrollLeft, this.maxScrollLeft));
+    this.clampScrollTop();
+    this.invalidateContent();
+    this.publishSnapFeedback(emptyTimelineSnapFeedback);
+    this.clearClipDropFeedback();
+    this.emit('edit:preview', null);
+    this.emit('edit:impacts', null);
+    if (previousZoomScale !== this.state.zoomScale) {
+      this.emit('zoom:change', this.state.zoomScale);
+    }
+    if (
+      previousScrollLeft !== this.state.scrollLeft ||
+      previousScrollTop !== this.state.scrollTop
+    ) {
+      this.emitScrollChange();
+    }
+    this.emit('state:settled');
+    this.emit('render');
+  }
 
   /**
    * Stores the current track and marker state in undo history.

--- a/packages/core/src/engine/edit-evaluator.ts
+++ b/packages/core/src/engine/edit-evaluator.ts
@@ -447,6 +447,13 @@ function validateRollTrimEditCommand(
   );
 }
 
+function isWithinClipBounds(clip: Clip, start: RationalTime, end: RationalTime) {
+  return (
+    (clip.minStart === undefined || compareRational(start, clip.minStart) >= 0) &&
+    (clip.maxEnd === undefined || compareRational(end, clip.maxEnd) <= 0)
+  );
+}
+
 function validateResolvedRollTrimBoundary(
   context: EditContext,
   command: TimelineRollTrimEditCommand,
@@ -456,6 +463,12 @@ function validateResolvedRollTrimBoundary(
   const right = findClipInTracks(context.state.tracks, command.rightClipId);
   if (!left || !right) {
     return rejectEdit(context, 'not-found');
+  }
+  if (
+    !isWithinClipBounds(left.clip, left.clip.timelineStart, boundaryTime) ||
+    !isWithinClipBounds(right.clip, boundaryTime, right.clip.timelineEnd)
+  ) {
+    return rejectEdit(context, 'source-bounds');
   }
   const minDuration = fromSeconds(minimumTimelineEditDurationSeconds, boundaryTime.r);
   if (
@@ -915,11 +928,7 @@ function resolveMoveEdit(
     }
     const nextStart = addRational(linked.clip.timelineStart, deltaTime);
     const nextEnd = addRational(linked.clip.timelineEnd, deltaTime);
-    if (
-      (linked.clip.minStart !== undefined &&
-        compareRational(nextStart, linked.clip.minStart) < 0) ||
-      (linked.clip.maxEnd !== undefined && compareRational(nextEnd, linked.clip.maxEnd) > 0)
-    ) {
+    if (!isWithinClipBounds(linked.clip, nextStart, nextEnd)) {
       return createRejectedResolvedEdit(
         context,
         command,

--- a/packages/core/src/engine/keyframes.test.ts
+++ b/packages/core/src/engine/keyframes.test.ts
@@ -62,6 +62,73 @@ describe('TimelineEngine keyframes', () => {
   });
 
   describe('Keyframes', () => {
+    it.each(['value', 'incoming', 'outgoing'] as const)(
+      'rejects an invalid %s before moving a keyframe or deleting a collision',
+      (field) => {
+        const first = expectDefined(
+          engine.keyframes.setClipKeyframe({
+            clipId: 'clip1',
+            property: 'opacity',
+            time: fromSeconds(2),
+            value: 0.5,
+          }),
+          'first keyframe'
+        );
+        engine.keyframes.setClipKeyframe({
+          clipId: 'clip1',
+          property: 'opacity',
+          time: fromSeconds(3),
+          value: 0.8,
+        });
+        const before = engine.getState();
+        const invalid = { interpolation: 'bezier', handle: { x: NaN, y: 0.5 } } as const;
+        expect(() =>
+          engine.keyframes.updateClipKeyframe({
+            clipId: 'clip1',
+            keyframeId: first.id,
+            time: fromSeconds(3),
+            ...(field === 'value' ? { value: NaN } : { [field]: invalid }),
+          })
+        ).toThrow();
+        engine.invalidateContent();
+        expect(engine.getState().tracks).toEqual(before.tracks);
+        engine.undo();
+        expect(engine.keyframes.getClipKeyframes('clip1')).toHaveLength(1);
+      }
+    );
+
+    it('validates both interpolation sides before applying either side', () => {
+      const first = expectDefined(
+        engine.keyframes.setClipKeyframe({
+          clipId: 'clip1',
+          property: 'opacity',
+          time: fromSeconds(2),
+          value: 0.5,
+        }),
+        'first keyframe'
+      );
+      const before = engine.getState();
+      expect(() =>
+        engine.keyframes.updateClipKeyframeSides({
+          clipId: 'clip1',
+          keyframeId: first.id,
+          incoming: { interpolation: 'hold' },
+          outgoing: { interpolation: 'bezier', handle: { x: NaN, y: 0.5 } },
+        })
+      ).toThrow();
+      expect(() =>
+        engine.keyframes.setClipKeyframe({
+          clipId: 'clip1',
+          property: 'opacity',
+          time: fromSeconds(2),
+          value: 0.9,
+          outgoing: { interpolation: 'bezier', handle: { x: NaN, y: 0.5 } },
+        })
+      ).toThrow();
+      engine.invalidateContent();
+      expect(engine.getState().tracks).toEqual(before.tracks);
+    });
+
     function createKeyframeClip(id: string, start: number, end: number, values: number[]): Clip {
       return {
         id,

--- a/packages/core/src/engine/keyframes.ts
+++ b/packages/core/src/engine/keyframes.ts
@@ -257,14 +257,13 @@ export class TimelineKeyframes {
     }
 
     const time = this.clampKeyframeTimeToClip(found.clip, input.time);
-    found.clip.keyframes ??= [];
-    const existing = found.clip.keyframes.find(
+    const existing = found.clip.keyframes?.find(
       (keyframe) => keyframe.property === input.property && isSameRationalTime(keyframe.time, time)
     );
     const eventName = existing === undefined ? 'keyframe:add' : 'keyframe:update';
 
     const keyframe =
-      existing ??
+      (existing && cloneTimelineKeyframe(existing)) ??
       ({
         id: crypto.randomUUID(),
         property: input.property,
@@ -287,10 +286,7 @@ export class TimelineKeyframes {
       );
     }
 
-    if (existing === undefined) {
-      found.clip.keyframes.push(keyframe);
-    }
-    this.normalizeClipKeyframes(found.clip);
+    this.replaceClipKeyframe(found.clip, keyframe);
     this.context.emit(eventName, {
       clipId: input.clipId,
       keyframe: cloneTimelineKeyframe(keyframe),
@@ -316,10 +312,11 @@ export class TimelineKeyframes {
       return null;
     }
 
-    const keyframe = found.clip.keyframes.find((candidate) => candidate.id === input.keyframeId);
-    if (keyframe === undefined) {
+    const existing = found.clip.keyframes.find((candidate) => candidate.id === input.keyframeId);
+    if (existing === undefined) {
       return null;
     }
+    const keyframe = cloneTimelineKeyframe(existing);
 
     if (input.time !== undefined) {
       assertValidRationalTime(input.time, 'input.time');
@@ -339,8 +336,6 @@ export class TimelineKeyframes {
       if (options.commit === false) {
         // Preview updates (drags) must not destroy neighboring keyframes.
         nextTime = keyframe.time;
-      } else {
-        found.clip.keyframes = found.clip.keyframes.filter((candidate) => candidate !== collision);
       }
     }
 
@@ -365,7 +360,11 @@ export class TimelineKeyframes {
       );
     }
 
-    this.normalizeClipKeyframes(found.clip);
+    this.replaceClipKeyframe(
+      found.clip,
+      keyframe,
+      options.commit === false ? undefined : collision?.id
+    );
     this.context.emit('keyframe:update', {
       clipId: input.clipId,
       keyframe: cloneTimelineKeyframe(keyframe),
@@ -403,10 +402,11 @@ export class TimelineKeyframes {
       return null;
     }
 
-    const keyframe = found.clip.keyframes.find((candidate) => candidate.id === input.keyframeId);
-    if (keyframe === undefined || !this.context.keyframeProperties.has(keyframe.property)) {
+    const existing = found.clip.keyframes.find((candidate) => candidate.id === input.keyframeId);
+    if (existing === undefined || !this.context.keyframeProperties.has(existing.property)) {
       return null;
     }
+    const keyframe = cloneTimelineKeyframe(existing);
 
     const patches: Array<[TimelineKeyframeSide, TimelineKeyframeSidePatch | undefined]> = [
       ['incoming', input.incoming],
@@ -438,7 +438,7 @@ export class TimelineKeyframes {
       );
     }
 
-    this.normalizeClipKeyframes(found.clip);
+    this.replaceClipKeyframe(found.clip, keyframe);
     this.context.emit('keyframe:update', {
       clipId: input.clipId,
       keyframe: cloneTimelineKeyframe(keyframe),
@@ -1068,6 +1068,20 @@ export class TimelineKeyframes {
 
   private normalizeClipKeyframes(clip: Clip) {
     this.context.keyframeProperties.normalizeClipKeyframes(clip);
+  }
+
+  private replaceClipKeyframe(clip: Clip, keyframe: TimelineKeyframe, collisionId?: string) {
+    const next = {
+      ...clip,
+      keyframes: [
+        ...(clip.keyframes ?? []).filter(
+          (candidate) => candidate.id !== keyframe.id && candidate.id !== collisionId
+        ),
+        keyframe,
+      ],
+    };
+    this.normalizeClipKeyframes(next);
+    clip.keyframes = next.keyframes;
   }
 
   /** @internal Normalizes initial keyframes after registration. */

--- a/packages/core/src/engine/review-regressions.test.ts
+++ b/packages/core/src/engine/review-regressions.test.ts
@@ -18,6 +18,93 @@ function track(id: string, clips: Clip[] = []): Track {
 }
 
 describe('document transaction boundaries', () => {
+  it('undo and redo clear previews before notifying document subscribers', () => {
+    const engine = new TimelineEngine({ tracks: [track('a', [clip('clip')])] });
+    const move = (seconds: number) =>
+      ({ type: 'move', clipId: 'clip', startTime: fromSeconds(seconds), snap: false }) as const;
+    engine.commitEdit(move(4));
+    for (const restore of [() => engine.undo(), () => engine.redo()]) {
+      engine.previewEdit(move(7));
+      const unsubscribe = engine.on('content:change', () => {
+        expect(engine.getEditPreview()).toBeNull();
+        expect(engine.getRenderState().tracks).toBe(engine.getState().tracks);
+      });
+      restore();
+      unsubscribe();
+      expect(engine.getEditPreview()).toBeNull();
+    }
+    expect(toSeconds(engine.tracks[0].clips[0].timelineStart)).toBe(4);
+  });
+
+  it('reconciles both viewport axes when history restores smaller content', () => {
+    const engine = new TimelineEngine({ tracks: [track('a', [clip('clip')])] });
+    engine.setViewportWidth(100);
+    engine.addTrack({ ...track('tall', [clip('late', 40, 50)]), height: 2000 });
+    engine.setScrollTop(1000);
+    engine.setScrollLeft(1000);
+    let scrollChanges = 0;
+    engine.on('scroll:change', () => scrollChanges++);
+    engine.undo();
+    expect(engine.scrollTop).toBe(0);
+    expect(engine.scrollLeft).toBeLessThanOrEqual(engine.maxScrollLeft);
+    expect(scrollChanges).toBe(1);
+    engine.redo();
+    expect(engine.scrollTop).toBeLessThanOrEqual(engine.maxScrollTop);
+  });
+
+  it.each([2, 4])('rejects a roll boundary outside clip bounds at %ss', (boundary) => {
+    const engine = new TimelineEngine({
+      tracks: [
+        track('a', [
+          { ...clip('left', 0, 3), maxEnd: fromSeconds(3) },
+          { ...clip('right', 3, 6), minStart: fromSeconds(3) },
+        ]),
+      ],
+    });
+    const command = {
+      type: 'roll-trim',
+      leftClipId: 'left',
+      rightClipId: 'right',
+      boundaryTime: fromSeconds(boundary),
+      snap: false,
+    } as const;
+    expect(engine.validateEdit(command)).toMatchObject({ valid: false, reason: 'source-bounds' });
+    expect(engine.commitEdit(command).committed).toBe(false);
+    expect(engine.canUndo).toBe(false);
+  });
+
+  it('owns marker results, event payloads, and nested snap updates', () => {
+    const engine = new TimelineEngine({ tracks: [] });
+    engine.on('marker:add', ({ marker }) => {
+      marker.label = 'event mutation';
+    });
+    engine.on('marker:update', ({ marker }) => {
+      marker.description = 'event mutation';
+    });
+    const added = engine.addMarker(fromSeconds(1), 'Original');
+    expect(added.label).toBe('Original');
+    added.label = 'return mutation';
+    const snap = { priority: 5 };
+    const updated = expectDefined(
+      engine.updateMarker(added.id, { snap, description: 'Updated' }),
+      'updated marker'
+    );
+    snap.priority = 100;
+    updated.description = 'return mutation';
+    if (typeof updated.snap === 'object') {
+      updated.snap.priority = 200;
+    }
+    engine.invalidateContent();
+    expect(engine.markers[0]).toMatchObject({
+      label: 'Original',
+      description: 'Updated',
+      snap: { priority: 5 },
+    });
+    engine.undo();
+    expect(engine.markers[0]).toMatchObject({ label: 'Original' });
+    expect(engine.markers[0].description).toBeUndefined();
+  });
+
   it('commits against current content after a preview', () => {
     const engine = new TimelineEngine({ tracks: [track('a', [clip('clip')])] });
     const command = {

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -1,10 +1,6 @@
 import type { TimelineEngine } from '#core/engine';
-import {
-  createClipGroupSnapshots,
-  createMarkerSnapshots,
-  createTrackSnapshots,
-} from '#core/snapshot';
-import type { TimelineState, TimelineStateSnapshot } from '#core/types';
+import type { createDocumentSnapshot } from '#core/document-snapshot';
+import type { TimelineState } from '#core/types';
 /** Limits retained document history. The current document is always retained. */
 export interface TimelineHistoryOptions {
   /** Maximum snapshots, including the current document. Defaults to 100. */
@@ -13,10 +9,7 @@ export interface TimelineHistoryOptions {
   maxBytes?: number;
 }
 
-interface HistoryEntry {
-  tracks: TimelineStateSnapshot['tracks'];
-  markers: TimelineStateSnapshot['markers'];
-  clipGroups: TimelineStateSnapshot['clipGroups'];
+interface HistoryEntry extends ReturnType<typeof createDocumentSnapshot> {
   bytes: number;
 }
 
@@ -30,6 +23,7 @@ export class HistoryManager {
   constructor(
     private engine: TimelineEngine,
     private state: TimelineState,
+    private restoreDocument: (snapshot: ReturnType<typeof createDocumentSnapshot>) => void,
     options: TimelineHistoryOptions = {}
   ) {
     this.maxEntries = options.maxEntries ?? 100;
@@ -52,7 +46,7 @@ export class HistoryManager {
     }
     this.revision = revision;
     const last = this.history[this.historyIndex];
-    const { tracks, markers, clipGroups } = this.engine.getState();
+    const { tracks, markers = [], clipGroups } = this.engine.getState();
     if (
       last &&
       tracks === last.tracks &&
@@ -104,13 +98,7 @@ export class HistoryManager {
     this.engine.emit('history:change', { index: this.historyIndex, length: this.history.length });
   }
   private restoreSnapshot(snapshot: HistoryEntry) {
-    const state = this.state;
-    state.tracks = createTrackSnapshots(snapshot.tracks);
-    state.markers = createMarkerSnapshots(snapshot.markers);
-    state.clipGroups = createClipGroupSnapshots(snapshot.clipGroups);
-    this.engine.invalidateContent();
+    this.restoreDocument(snapshot);
     this.revision = '';
-    this.engine.emit('state:settled');
-    this.engine.emit('render');
   }
 }

--- a/packages/react/src/hooks/clips/useTimelineClipDrag.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipDrag.ts
@@ -9,6 +9,7 @@ import type {
   TimelineReadonly,
 } from '@techsquidtv/canvas-timeline-core';
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
+import { TimelineEditGesture } from '#react/hooks/editing/timelineEditGesture';
 import { useTimelineTrackDropTargets } from '#react/hooks/tracks/useTimelineTrackDropTargets';
 import type {
   TimelineTrackDropGuard,
@@ -77,6 +78,7 @@ export interface UseTimelineClipDragResult {
 }
 
 interface ActiveClipDrag {
+  gesture: TimelineEditGesture;
   clipId: string;
   startClientX: number;
   startLeft: number;
@@ -188,14 +190,16 @@ export function useTimelineClipDrag(
 
   useEffect(() => {
     return () => {
-      if (!activeDragRef.current) {
+      const active = activeDragRef.current;
+      if (!active) {
         return;
       }
 
       activeDragRef.current = null;
       setDragging(false);
-      engine.cancelEdit();
-      engine.clearClipDropFeedback();
+      if (active.gesture.cancel()) {
+        engine.clearClipDropFeedback();
+      }
     };
   }, [engine]);
 
@@ -221,6 +225,12 @@ export function useTimelineClipDrag(
 
   const startClipDrag = useCallback(
     (input: TimelineClipDragStartInput): TimelineCommandResult => {
+      if (activeDragRef.current) {
+        return timelineCommandFail('unsupported', 'A drag is already active.');
+      }
+      if (!Number.isFinite(input.clientX) || !Number.isFinite(input.viewportY)) {
+        return timelineCommandFail('invalid-input');
+      }
       const found = engine.geometry.getClip(input.clipId);
       const rect =
         input.clipRect ??
@@ -244,6 +254,7 @@ export function useTimelineClipDrag(
       engine.cancelEdit();
 
       activeDragRef.current = {
+        gesture: new TimelineEditGesture(engine),
         clipId: input.clipId,
         startClientX: input.clientX,
         startLeft: rect.x,
@@ -288,6 +299,12 @@ export function useTimelineClipDrag(
       if (!activeDrag) {
         return timelineCommandFail<TimelineClipMoveResult>('unsupported');
       }
+      if (!activeDrag.gesture.isCurrent()) {
+        return timelineCommandFail('unsupported', 'The drag preview was replaced.');
+      }
+      if (!Number.isFinite(input.clientX) || !Number.isFinite(input.viewportY)) {
+        return timelineCommandFail('invalid-input');
+      }
 
       const hoveredTarget = findTrackTargetAtY(activeDrag.trackTargets, input.viewportY);
       let dropResult: TimelineTrackDropResult | null = null;
@@ -321,7 +338,7 @@ export function useTimelineClipDrag(
       publishFeedback(activeDrag, hoveredTarget?.track.id ?? null, dropResult, penetrationRatio);
 
       const deltaX = input.clientX - activeDrag.startClientX;
-      const preview = engine.previewEdit({
+      const preview = activeDrag.gesture.publish({
         type: 'move',
         overwrite: true,
         clipId: activeDrag.clipId,
@@ -344,13 +361,19 @@ export function useTimelineClipDrag(
   );
 
   const endClipDrag = useCallback((): TimelineCommandResult => {
-    if (!activeDragRef.current) {
+    const active = activeDragRef.current;
+    if (!active) {
       return timelineCommandFail('unsupported');
     }
 
     activeDragRef.current = null;
     setDragging(false);
-    const command = engine.getEditPreview()?.command;
+    const current = active.gesture.isCurrent();
+    active.gesture.release();
+    if (!current) {
+      return timelineCommandFail('unsupported', 'The drag preview was replaced.');
+    }
+    const command = active.gesture.preview?.command;
     const result = command ? engine.commitEdit(command) : undefined;
     engine.cancelEdit();
     engine.clearClipDropFeedback();
@@ -360,15 +383,16 @@ export function useTimelineClipDrag(
   }, [engine]);
 
   const cancelClipDrag = useCallback((): TimelineCommandResult => {
-    if (!activeDragRef.current) {
-      engine.clearClipDropFeedback();
+    const active = activeDragRef.current;
+    if (!active) {
       return timelineCommandFail('unsupported');
     }
 
     activeDragRef.current = null;
     setDragging(false);
-    engine.cancelEdit();
-    engine.clearClipDropFeedback();
+    if (active.gesture.cancel()) {
+      engine.clearClipDropFeedback();
+    }
     return timelineCommandOk();
   }, [engine]);
 

--- a/packages/react/src/hooks/clips/useTimelineClipTrim.ts
+++ b/packages/react/src/hooks/clips/useTimelineClipTrim.ts
@@ -1,5 +1,6 @@
 import { useTimelineEngine } from '#react/hooks/core/useTimelineEngine';
 import { runTimelineCommand } from '#react/hooks/core/runTimelineCommand';
+import { TimelineEditGesture } from '#react/hooks/editing/timelineEditGesture';
 import { timelineCommandFail, timelineCommandOk } from '@techsquidtv/canvas-timeline-core';
 import type {
   TimelineCommandResult,
@@ -39,7 +40,7 @@ export interface UseTimelineClipTrimResult {
 interface ActiveTrim extends TimelineClipTrimStartInput {
   startTime: RationalTime;
   zoomScale: number;
-  preview: TimelineEditPreview | null;
+  gesture: TimelineEditGesture;
 }
 
 /**
@@ -74,25 +75,16 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
   const activeRef = useRef<ActiveTrim | null>(null);
   const [trimming, setTrimming] = useState(false);
 
-  const clearPreview = useCallback(
-    (active: ActiveTrim) => {
-      if (engine.getEditPreview() === active.preview) {
-        engine.cancelEdit();
-      }
-    },
-    [engine]
-  );
-
   useEffect(
     () => () => {
       const active = activeRef.current;
       activeRef.current = null;
       if (active) {
-        clearPreview(active);
+        active.gesture.cancel();
         setTrimming(false);
       }
     },
-    [clearPreview]
+    [engine]
   );
 
   const startClipTrim = useCallback(
@@ -118,7 +110,7 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
           ...(input.edge === 'start' ? found.clip.timelineStart : found.clip.timelineEnd),
         },
         zoomScale: engine.zoomScale,
-        preview: null,
+        gesture: new TimelineEditGesture(engine),
       };
       setTrimming(true);
       return timelineCommandOk();
@@ -138,10 +130,10 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
         if (!Number.isFinite(input.clientX)) {
           return timelineCommandFail('invalid-input');
         }
-        if (engine.getEditPreview() !== active.preview) {
+        if (!active.gesture.isCurrent()) {
           return timelineCommandFail('unsupported', 'The trim preview was replaced.');
         }
-        const preview = engine.previewEdit({
+        const preview = active.gesture.publish({
           type: 'trim',
           overwrite: true,
           clipId: active.clipId,
@@ -151,12 +143,11 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
             fromSeconds((input.clientX - active.clientX) / active.zoomScale, active.startTime.r)
           ),
         });
-        active.preview = preview;
         return preview.valid
           ? timelineCommandOk(preview)
           : timelineCommandFail(preview.reason ?? 'unsupported', preview.message);
       }),
-    [engine]
+    []
   );
 
   const endClipTrim = useCallback((): TimelineCommandResult => {
@@ -166,20 +157,23 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
     }
     activeRef.current = null;
     setTrimming(false);
-    if (engine.getEditPreview() !== active.preview) {
+    const current = active.gesture.isCurrent();
+    const preview = active.gesture.preview;
+    active.gesture.release();
+    if (!current) {
       return timelineCommandFail('unsupported', 'The trim preview was replaced.');
     }
-    if (!active.preview) {
-      clearPreview(active);
+    if (!preview) {
+      engine.cancelEdit();
       return timelineCommandOk();
     }
-    const result = engine.commitEdit(active.preview.command);
+    const result = engine.commitEdit(preview.command);
     // Failed commits publish a fresh preview; it still belongs to this gesture.
     engine.cancelEdit();
     return result.committed
       ? timelineCommandOk()
       : timelineCommandFail(result.preview.reason ?? 'unsupported', result.preview.message);
-  }, [clearPreview, engine]);
+  }, [engine]);
 
   const cancelClipTrim = useCallback((): TimelineCommandResult => {
     const active = activeRef.current;
@@ -188,9 +182,9 @@ export function useTimelineClipTrim(): UseTimelineClipTrimResult {
     }
     activeRef.current = null;
     setTrimming(false);
-    clearPreview(active);
+    active.gesture.cancel();
     return timelineCommandOk();
-  }, [clearPreview]);
+  }, []);
 
   return useMemo(
     () => ({ trimming, startClipTrim, moveClipTrim, endClipTrim, cancelClipTrim }),

--- a/packages/react/src/hooks/editing/timelineEditGesture.ts
+++ b/packages/react/src/hooks/editing/timelineEditGesture.ts
@@ -1,0 +1,49 @@
+import type {
+  TimelineEditCommand,
+  TimelineEditPreview,
+  TimelineEngine,
+} from '@techsquidtv/canvas-timeline-core';
+
+/** Owns one gesture's preview, including cancellation before its first move. */
+export class TimelineEditGesture {
+  preview: TimelineEditPreview | null = null;
+  private current = true;
+  private publishing = false;
+  private readonly unsubscribe: () => void;
+
+  constructor(private readonly engine: TimelineEngine) {
+    this.unsubscribe = engine.on('edit:preview', () => {
+      if (!this.publishing) {
+        this.current = false;
+      }
+    });
+  }
+
+  isCurrent() {
+    return this.current && this.engine.getEditPreview() === this.preview;
+  }
+
+  publish(command: TimelineEditCommand) {
+    this.publishing = true;
+    try {
+      this.preview = this.engine.previewEdit(command);
+      return this.preview;
+    } finally {
+      this.publishing = false;
+    }
+  }
+
+  cancel() {
+    const current = this.isCurrent();
+    this.release();
+    if (current) {
+      this.engine.cancelEdit();
+    }
+    return current;
+  }
+
+  release() {
+    this.unsubscribe();
+    this.current = false;
+  }
+}

--- a/packages/react/src/hooks/integration/gesture-ownership.test.tsx
+++ b/packages/react/src/hooks/integration/gesture-ownership.test.tsx
@@ -1,0 +1,82 @@
+import { useTimelineClipDrag } from '#react/hooks/clips/useTimelineClipDrag';
+import { useTimelineClipTrim } from '#react/hooks/clips/useTimelineClipTrim';
+import { createClip, createTrack, wrapper } from '#react/hooks/integration/testHelpers';
+import { TimelineEngine } from '@techsquidtv/canvas-timeline-core';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { act, renderHook } from '@testing-library/react';
+import { expect, test } from 'vite-plus/test';
+
+test.each(['move', 'end', 'cancel', 'unmount'] as const)(
+  'a superseded drag cannot affect a replacement preview on %s',
+  (action) => {
+    const engine = new TimelineEngine({
+      tracks: [createTrack('track', [createClip('clip', 1, 3)])],
+    });
+    const { result, unmount } = renderHook(() => useTimelineClipDrag(), {
+      wrapper: (props) => wrapper({ ...props, engine }),
+    });
+    act(() => {
+      result.current.startClipDrag({ clipId: 'clip', clientX: 100, viewportY: 50 });
+      result.current.moveClipDrag({ clientX: 200, viewportY: 50 });
+    });
+    let preview = engine.getEditPreview();
+    act(() => {
+      preview = engine.previewEdit({ type: 'delete-clips', clipIds: ['clip'] });
+    });
+    act(() => {
+      if (action === 'move') {
+        expect(result.current.moveClipDrag({ clientX: 300, viewportY: 50 }).ok).toBe(false);
+      }
+      if (action === 'end') {
+        expect(result.current.endClipDrag().ok).toBe(false);
+      }
+      if (action === 'cancel') {
+        result.current.cancelClipDrag();
+      }
+      if (action === 'unmount') {
+        unmount();
+      }
+    });
+    expect(engine.tracks[0].clips).toHaveLength(1);
+    expect(engine.getEditPreview()).toBe(preview);
+    expect(engine.canUndo).toBe(false);
+    unmount();
+    expect(engine.getEditPreview()).toBe(preview);
+  }
+);
+
+test('a new gesture supersedes an older gesture before either publishes a preview', () => {
+  const engine = new TimelineEngine({ tracks: [createTrack('track', [createClip('clip', 1, 3)])] });
+  const { result, unmount } = renderHook(
+    () => ({ drag: useTimelineClipDrag(), trim: useTimelineClipTrim() }),
+    {
+      wrapper: (props) => wrapper({ ...props, engine }),
+    }
+  );
+  act(() => {
+    result.current.drag.startClipDrag({ clipId: 'clip', clientX: 100, viewportY: 50 });
+    result.current.trim.startClipTrim({ clipId: 'clip', edge: 'end', clientX: 300 });
+    expect(result.current.drag.moveClipDrag({ clientX: 200, viewportY: 50 }).ok).toBe(false);
+    result.current.drag.cancelClipDrag();
+    expect(result.current.trim.moveClipTrim({ clientX: 400 }).ok).toBe(true);
+    expect(result.current.trim.endClipTrim().ok).toBe(true);
+  });
+  expect(engine.tracks[0].clips[0].timelineEnd).toEqual(fromSeconds(4));
+  unmount();
+});
+
+test('history restoration invalidates a trim before its first move', () => {
+  const engine = new TimelineEngine({ tracks: [createTrack('track', [createClip('clip', 1, 3)])] });
+  engine.renameTrack('track', 'Renamed');
+  const { result, unmount } = renderHook(() => useTimelineClipTrim(), {
+    wrapper: (props) => wrapper({ ...props, engine }),
+  });
+  act(() => {
+    result.current.startClipTrim({ clipId: 'clip', edge: 'end', clientX: 300 });
+    engine.undo();
+    expect(result.current.moveClipTrim({ clientX: 400 }).ok).toBe(false);
+    expect(result.current.endClipTrim().ok).toBe(false);
+  });
+  expect(engine.tracks[0].clips[0].timelineEnd).toEqual(fromSeconds(3));
+  unmount();
+});

--- a/packages/react/src/hooks/integration/mediaSync.test.tsx
+++ b/packages/react/src/hooks/integration/mediaSync.test.tsx
@@ -9,6 +9,55 @@ import type { RationalTime } from '@techsquidtv/canvas-timeline-utils';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { expect, test, vi } from 'vite-plus/test';
+test('paused media refreshes changed layer membership without seeking for equivalent inline selectors', async () => {
+  const engine = createMediaSyncEngine();
+  let frame: FrameRequestCallback | undefined;
+  const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    frame = callback;
+    return 1;
+  });
+  const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {
+    frame = undefined;
+  });
+  const seek = vi.fn<NonNullable<TimelineMediaSyncAdapter['seek']>>();
+  const adapter = { getClockTime: () => 1, startClock: () => true, seek };
+  const { rerender, unmount } = renderHook(
+    ({ enabled }) =>
+      useTimelineMediaSync({
+        adapter,
+        layers: { visuals: { trackKind: 'visual', predicate: () => enabled } },
+      }),
+    {
+      initialProps: { enabled: true },
+      wrapper: ({ children }) => React.createElement(TimelineProvider, { engine }, children),
+    }
+  );
+  const flushFrame = async () => {
+    const pending = frame;
+    frame = undefined;
+    await act(async () => {
+      pending?.(0);
+    });
+  };
+  try {
+    await flushFrame();
+    expect(seek).toHaveBeenCalledOnce();
+    rerender({ enabled: true });
+    expect(frame).toBeUndefined();
+    rerender({ enabled: false });
+    await flushFrame();
+    expect(seek).toHaveBeenCalledTimes(2);
+    expect(seek.mock.calls[1]?.[1].hasActiveClips).toBe(false);
+    rerender({ enabled: true });
+    await flushFrame();
+    expect(seek.mock.calls[2]?.[1].hasActiveClips).toBe(true);
+  } finally {
+    unmount();
+    raf.mockRestore();
+    cancel.mockRestore();
+  }
+});
+
 test('useTimelineMediaSync reports loop clock restart failures', async () => {
   const engine = createMediaSyncEngine();
   engine.setInPoint(fromSeconds(1), false);

--- a/packages/react/src/hooks/playback/internal/pausedMediaPreviewScheduler.ts
+++ b/packages/react/src/hooks/playback/internal/pausedMediaPreviewScheduler.ts
@@ -72,6 +72,7 @@ export function usePausedMediaPreviewSynchronization<LayerName extends string>({
   const playingRef = useRef(playing);
   const onErrorRef = useRef(onError);
   const primedRef = useRef(false);
+  const layerSelectionRef = useRef<{ engine: TimelineEngine; signature: string } | null>(null);
   const [scheduler] = useState(() => new PausedMediaPreviewScheduler());
 
   useEffect(() => {
@@ -142,6 +143,24 @@ export function usePausedMediaPreviewSynchronization<LayerName extends string>({
       });
     });
   }, [canSeek, engine, operationQueue, scheduler]);
+
+  useEffect(() => {
+    if (!canSeek()) {
+      return;
+    }
+    const activeLayers = engine.media.getActiveLayers({ layers });
+    const signature = JSON.stringify(
+      (Object.keys(activeLayers.layers) as LayerName[]).map((name) => [
+        name,
+        activeLayers.layers[name].map((entry) => entry.syncKey),
+      ])
+    );
+    const previous = layerSelectionRef.current;
+    layerSelectionRef.current = { engine, signature };
+    if (previous && (previous.engine !== engine || previous.signature !== signature)) {
+      schedule();
+    }
+  }, [canSeek, engine, layers, playing, ready, schedule]);
 
   useEffect(() => {
     const unsubscribers = [


### PR DESCRIPTION
## Summary

- Validate keyframe changes before mutating document state, enforce roll-trim bounds, and return owned marker copies.
- Keep drag and trim previews owned by their initiating gesture. Undo/redo clears stale previews and reconciles viewport bounds before publishing restored state.
- Refresh paused media when effective layer selections change, while coalescing equivalent inline selectors.
- Add regression coverage for all seven issues, including superseded gestures before their first move.

## Release Impact

- Packages/API: Core and React fixes with a Changeset; all seven public packages remain in the fixed release group. Marker results remain mutable owned copies.
- Docs/demos: Package documentation, the docs site, and the full editor build successfully.
- Breaking changes: No intentional breaking API changes or compatibility aliases.
- Follow-ups from the second review: non-snapshot release tagging, audio export bounds, and stable active-layer aggregation order remain separate issues.

## Validation

- `vp run ci:quality`: 72 test files and 783 tests passed; type, format, lint, dependency, policy, registry, and package coverage checks passed.
- `vp run repo:build`: all packages, docs, and the full editor passed.
- `vp run repo:package:validate`: packed-package checks, isolated consumer TypeScript/Vite build, and headless SSR passed.
- `vp run changeset:status`, commitlint, and `git diff --check` passed.
- Browser/media tests use simulated surfaces; no live codec playback or performance benchmark was run.

## Checklist

- [x] I added a changeset or an empty changeset.
- [x] I checked package/API impact.
- [x] I checked docs/demo impact.
- [x] I called out breaking changes, if any.
