### PR TITLE
fix(www): canonicalize generated API documentation

### DIFF
--- a/.changeset/consistent-website-seo.md
+++ b/.changeset/consistent-website-seo.md
@@ -1,0 +1,4 @@
+---
+---
+
+Resolve generated API pages to their declaration-owning packages. Route API links to canonical pages, omit re-export copies from the sitemap and site search, and redirect duplicate Markdown to its owner. Align canonical URLs and structured data with deployed routes, and prevent preview deployment indexing.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ coverage/
 .vercel/
 .netlify/
 apps/www/public/open-graph/
+apps/www/public/_redirects
 apps/www/public/demos/
 apps/www/public/full-editor-demo/
 *.tsbuildinfo

--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -36,8 +36,24 @@ function mediabunnySsrStub() {
   };
 }
 
+// Read lazily: docs:api produces this data before the Astro build starts.
+let reexportPaths;
+function getReexportPaths() {
+  reexportPaths ??= new Set(
+    JSON.parse(
+      readFileSync(new URL('./.generated/api-reference.json', import.meta.url), 'utf8')
+    ).packages.flatMap((packageDoc) =>
+      packageDoc.symbols
+        .filter((symbol) => symbol.canonicalPackageSlug !== packageDoc.slug)
+        .map((symbol) => `/packages/${packageDoc.slug}/api/${symbol.slug}/`)
+    )
+  );
+  return reexportPaths;
+}
+
 export default defineConfig({
   site: 'https://canvastimeline.com',
+  trailingSlash: 'always',
   adapter: cloudflare(),
   integrations: [
     sentry(),
@@ -47,7 +63,9 @@ export default defineConfig({
     }),
     mdx(),
     react(),
-    sitemap(),
+    sitemap({
+      filter: (page) => !getReexportPaths().has(new URL(page).pathname),
+    }),
   ],
   markdown: {
     syntaxHighlight: false,

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -22,7 +22,7 @@
     "docs:editor:verify": "node scripts/demos/verify-full-editor-build.mjs",
     "docs:search": "tsx scripts/generate/search-catalog.ts && pagefind --site dist/client && node scripts/verify/search-build.mjs",
     "docs:demo:new": "node scripts/demos/scaffold.mjs",
-    "clean": "rm -rf .astro dist .generated public/open-graph public/demos/full-editor-demo public/full-editor-demo"
+    "clean": "rm -rf .astro dist .generated public/open-graph public/_redirects public/demos/full-editor-demo public/full-editor-demo"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^14.1.7",

--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -1,0 +1,22 @@
+# Prefer the HTML documentation when Markdown copies appear in search.
+/docs.md
+  Link: <https://canvastimeline.com/docs/>; rel="canonical"
+
+/docs/*.md
+  Link: <https://canvastimeline.com/docs/:splat/>; rel="canonical"
+
+/packages/:package/api.md
+  Link: <https://canvastimeline.com/packages/:package/api/>; rel="canonical"
+
+/packages/:package/api/*.md
+  Link: <https://canvastimeline.com/packages/:package/api/:splat/>; rel="canonical"
+
+/packages/react/registry/*.llms.md
+  Link: <https://canvastimeline.com/packages/react/registry/:splat/>; rel="canonical"
+
+# Keep Pages deployment aliases out of search results.
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+https://:version.:project.pages.dev/*
+  X-Robots-Tag: noindex

--- a/apps/www/scripts/generate/api-reference.mjs
+++ b/apps/www/scripts/generate/api-reference.mjs
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
@@ -757,7 +757,7 @@ function normalizeSymbol(reflection, packageEntry, warnings) {
     sourcePackage: packageEntry.slug,
     source: source
       ? {
-          fileName: source.fileName,
+          fileName: relative(rootDir, sourceFilePath(source, packageEntry)).replaceAll('\\', '/'),
           line: source.line,
           url: source.url,
         }
@@ -838,6 +838,28 @@ for (const packageEntry of packageEntries) {
   packages.push(await runTypedoc(packageEntry));
 }
 
+// Resolve ownership from declaration identity, never from a coincidental name match.
+for (const packageDoc of packages) {
+  for (const symbol of packageDoc.symbols) {
+    const declaration = symbol.source;
+    const ownerSlug = declaration?.fileName.match(/^packages\/([^/]+)\/src\//u)?.[1];
+    const owner = packages.find((candidate) => candidate.slug === ownerSlug);
+    const ownerSymbol = owner?.symbols.find(
+      (candidate) =>
+        candidate.name === symbol.name &&
+        candidate.kind === symbol.kind &&
+        candidate.source?.fileName === declaration?.fileName &&
+        candidate.source?.line === declaration?.line
+    );
+
+    if (!ownerSymbol) {
+      throw new Error(`Cannot resolve declaration owner for ${packageDoc.slug}.${symbol.name}.`);
+    }
+
+    symbol.canonicalPackageSlug = owner.slug;
+  }
+}
+
 const symbols = packages.flatMap((packageDoc) =>
   packageDoc.symbols.map((symbol) => ({
     ...symbol,
@@ -881,6 +903,19 @@ const reference = {
   symbols,
   warnings,
 };
+const markdownRedirects = packages.flatMap((packageDoc) =>
+  packageDoc.symbols
+    .filter((symbol) => symbol.canonicalPackageSlug !== packageDoc.slug)
+    .map(
+      (symbol) =>
+        `/packages/${packageDoc.slug}/api/${symbol.slug}.md /packages/${symbol.canonicalPackageSlug}/api/${symbol.slug}.md 301`
+    )
+);
+if (markdownRedirects.length > 2000) {
+  throw new Error('API Markdown redirects exceed the Cloudflare Pages static redirect limit.');
+}
+await writeFile(resolve(appDir, 'public/_redirects'), `${markdownRedirects.join('\n')}\n`);
+
 const serializedReference = `${JSON.stringify(reference, null, 2)}\n`;
 const serializedWarnings =
   warnings.length > 0 ? `${warnings.join('\n')}\n` : 'No API documentation warnings.\n';

--- a/apps/www/src/layouts/BaseLayout.astro
+++ b/apps/www/src/layouts/BaseLayout.astro
@@ -7,6 +7,7 @@ import SiteFooter from '#www/components/SiteFooter.astro';
 import {
   createSiteStructuredData,
   normalizeStructuredData,
+  toAbsoluteUrl,
   type StructuredDataInput,
 } from '#www/lib/structured-data';
 import { openGraphImage, openGraphRouteForPath } from '#www/lib/open-graph';
@@ -55,7 +56,7 @@ if (search) {
 }
 const searchDocument = search?.exclude ? undefined : search;
 const pageTitle = title ? `${title} | ${site.name}` : site.name;
-const canonicalUrl = providedCanonicalUrl ?? new URL(Astro.url.pathname, site.url).toString();
+const canonicalUrl = toAbsoluteUrl(providedCanonicalUrl ?? Astro.url.pathname);
 const pageImage =
   image ??
   {
@@ -105,7 +106,7 @@ const structuredDataItems = [
         </>
       ) : null
     }
-    {noindex ? <meta name="robots" content="noindex, nofollow" /> : null}
+    {noindex ? <meta name="robots" content="noindex, follow" /> : null}
     <meta name="theme-color" content="#ffffff" />
     <link class="canonical-link" rel="canonical" href={canonicalUrl} />
     <link rel="sitemap" href="/sitemap-index.xml" />
@@ -113,6 +114,7 @@ const structuredDataItems = [
     <link rel="stylesheet" href="/pagefind/pagefind-component-ui.css" />
     <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
     <meta property="og:site_name" content={site.name} />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:type" content={pageType} />
     <meta property="og:title" content={metaTitle} />
     <meta property="og:description" content={description} />
@@ -131,7 +133,7 @@ const structuredDataItems = [
     {tags.map((tag) => <meta property="article:tag" content={tag} />)}
     {
       structuredDataItems.map((item) => (
-        <script type="application/ld+json" set:html={JSON.stringify(item)} />
+        <script type="application/ld+json" set:html={JSON.stringify(item).replaceAll('<', '\\u003c')} />
       ))
     }
     <title>{pageTitle}</title>

--- a/apps/www/src/lib/api-markdown.test.ts
+++ b/apps/www/src/lib/api-markdown.test.ts
@@ -88,6 +88,7 @@ describe('API Markdown builder', () => {
         ],
       ],
       sourcePackage: 'react',
+      canonicalPackageSlug: 'react',
     });
 
     expect(markdown).toContain('## Usage notes');

--- a/apps/www/src/lib/api-ownership.test.ts
+++ b/apps/www/src/lib/api-ownership.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vite-plus/test';
+import { apiReference, apiSymbolHref, getApiSymbol } from '#www/lib/api-reference';
+
+describe('API declaration ownership', () => {
+  test('routes aggregate re-exports and transitive exports to their declaration owner', () => {
+    expect(apiSymbolHref('timeline', 'timeline-engine')).toBe('/packages/core/api/timeline-engine');
+    expect(apiSymbolHref('timeline', 'rational-time')).toBe('/packages/utils/api/rational-time');
+    expect(apiSymbolHref('core', 'timeline-engine')).toBe('/packages/core/api/timeline-engine');
+  });
+
+  test('every canonical target exists, owns the same declaration, and points to itself', () => {
+    for (const packageDoc of apiReference.packages) {
+      for (const symbol of packageDoc.symbols) {
+        const owner = getApiSymbol(symbol.canonicalPackageSlug, symbol.slug);
+        expect(owner, `${packageDoc.slug}.${symbol.name}`).toBeDefined();
+        expect(owner?.canonicalPackageSlug).toBe(symbol.canonicalPackageSlug);
+        expect(owner?.name).toBe(symbol.name);
+        expect(owner?.kind).toBe(symbol.kind);
+        expect(owner?.source?.fileName).toBe(symbol.source?.fileName);
+        expect(owner?.source?.line).toBe(symbol.source?.line);
+      }
+    }
+  });
+
+  test('does not emit a link to an unknown symbol', () => {
+    expect(() => apiSymbolHref('core', 'missing-symbol')).toThrow('Unknown API symbol');
+  });
+});

--- a/apps/www/src/lib/api-reference.ts
+++ b/apps/www/src/lib/api-reference.ts
@@ -70,6 +70,7 @@ export interface ApiSymbol {
   examples: string[];
   see: ApiDocTextPart[][];
   sourcePackage: string;
+  canonicalPackageSlug: string;
   packageName?: string;
   source?: {
     fileName: string;
@@ -329,6 +330,10 @@ function parseApiSymbol(value: JsonValue, fieldName: string): ApiSymbol {
     examples: readStringArray(object.examples, `${fieldName}.examples`),
     see: parseApiDocTextPartBlocks(object.see, `${fieldName}.see`),
     sourcePackage: readString(object.sourcePackage, `${fieldName}.sourcePackage`),
+    canonicalPackageSlug: readString(
+      object.canonicalPackageSlug,
+      `${fieldName}.canonicalPackageSlug`
+    ),
     packageName: readOptionalString(object.packageName, `${fieldName}.packageName`),
     source: parseApiSource(object.source, `${fieldName}.source`),
   };
@@ -367,12 +372,15 @@ export const apiReference = parseApiReference(
   apiReferenceData as typeof apiReferenceData & JsonValue
 );
 
-function getApiPackage(slug: string) {
-  return apiReference.packages.find((packageDoc) => packageDoc.slug === slug);
-}
+const apiSymbolsByPackage = new Map(
+  apiReference.packages.map((packageDoc) => [
+    packageDoc.slug,
+    new Map(packageDoc.symbols.map((symbol) => [symbol.slug, symbol])),
+  ])
+);
 
 export function getApiSymbol(packageSlug: string, symbolSlug: string) {
-  return getApiPackage(packageSlug)?.symbols.find((symbol) => symbol.slug === symbolSlug);
+  return apiSymbolsByPackage.get(packageSlug)?.get(symbolSlug);
 }
 
 export function apiPackageHref(packageSlug: string) {
@@ -380,7 +388,18 @@ export function apiPackageHref(packageSlug: string) {
 }
 
 export function apiSymbolHref(packageSlug: string, symbolSlug: string) {
-  return `${apiPackageHref(packageSlug)}/${symbolSlug}`;
+  const symbol = getApiSymbol(packageSlug, symbolSlug);
+  if (!symbol) {
+    throw new Error(`Unknown API symbol: ${packageSlug}.${symbolSlug}`);
+  }
+  return `${apiPackageHref(symbol.canonicalPackageSlug)}/${symbolSlug}`;
+}
+
+export function getApiSymbolMetadata(packageDoc: ApiPackage, symbol: ApiSymbol) {
+  return {
+    title: `${symbol.name} (${packageDoc.slug}) API`,
+    description: `${symbol.name} API reference for ${packageDoc.name}.${symbol.summary ? ` ${symbol.summary}` : ''}`,
+  };
 }
 
 export function apiDocPartHref(

--- a/apps/www/src/lib/open-graph-pages.ts
+++ b/apps/www/src/lib/open-graph-pages.ts
@@ -140,16 +140,18 @@ export async function getOpenGraphPages(): Promise<Record<string, OpenGraphPage>
           description: `Generated API reference for ${packageDoc.name}.`,
         },
       ] as const,
-      ...packageDoc.symbols.map(
-        (symbol) =>
-          [
-            apiSymbolHref(packageDoc.slug, symbol.slug),
-            {
-              title: `${symbol.name} API`,
-              description: symbol.summary || `Generated API reference for ${symbol.name}.`,
-            },
-          ] as const
-      ),
+      ...packageDoc.symbols
+        .filter((symbol) => symbol.canonicalPackageSlug === packageDoc.slug)
+        .map(
+          (symbol) =>
+            [
+              apiSymbolHref(packageDoc.slug, symbol.slug),
+              {
+                title: `${symbol.name} API`,
+                description: symbol.summary || `Generated API reference for ${symbol.name}.`,
+              },
+            ] as const
+        ),
     ]),
     ...reactRegistryItems.map((item) => {
       const entry = registryDocsByKey.get(item.slug);

--- a/apps/www/src/lib/structured-data.test.ts
+++ b/apps/www/src/lib/structured-data.test.ts
@@ -14,14 +14,21 @@ import {
 
 describe('structured data helpers', () => {
   test('converts paths and URLs to canonical absolute URLs', () => {
-    expect(toAbsoluteUrl('/docs')).toBe('https://canvastimeline.com/docs');
+    expect(toAbsoluteUrl('/docs')).toBe('https://canvastimeline.com/docs/');
     expect(toAbsoluteUrl('https://example.com/path')).toBe('https://example.com/path');
+    expect(toAbsoluteUrl('/docs/')).toBe('https://canvastimeline.com/docs/');
+    expect(toAbsoluteUrl('/docs?ref=nav#intro')).toBe(
+      'https://canvastimeline.com/docs/?ref=nav#intro'
+    );
+    expect(toAbsoluteUrl('/open-graph/index.png')).toBe(
+      'https://canvastimeline.com/open-graph/index.png'
+    );
   });
 
   test('builds breadcrumb lists with stable positions', () => {
     const structuredData = createBreadcrumbStructuredData(
       [{ label: 'Home', href: '/' }, { label: 'Docs', href: '/docs' }, { label: 'Current' }],
-      'https://canvastimeline.com/docs/current'
+      'https://canvastimeline.com/docs/current/'
     );
 
     expect(structuredData?.itemListElement).toEqual([
@@ -35,13 +42,13 @@ describe('structured data helpers', () => {
         '@type': 'ListItem',
         position: 2,
         name: 'Docs',
-        item: 'https://canvastimeline.com/docs',
+        item: 'https://canvastimeline.com/docs/',
       },
       {
         '@type': 'ListItem',
         position: 3,
         name: 'Current',
-        item: 'https://canvastimeline.com/docs/current',
+        item: 'https://canvastimeline.com/docs/current/',
       },
     ]);
   });
@@ -93,7 +100,7 @@ describe('structured data helpers', () => {
     expect(createPackageStructuredData(createPackageDoc())).toMatchObject({
       '@type': 'SoftwareSourceCode',
       name: '@techsquidtv/canvas-timeline-react',
-      url: 'https://canvastimeline.com/packages/react',
+      url: 'https://canvastimeline.com/packages/react/',
       codeRepository: 'https://github.com/techsquidtv/canvas-timeline/tree/main/packages/react',
       keywords: 'React, You need React bindings., Wrap editors in TimelineProvider.',
       targetProduct: {
@@ -112,12 +119,12 @@ describe('structured data helpers', () => {
       {
         position: 1,
         name: 'Basic Timeline',
-        url: 'https://canvastimeline.com/demos/basic-editor-surface',
+        url: 'https://canvastimeline.com/demos/basic-editor-surface/',
       },
       {
         position: 2,
         name: 'Timeline Stress Test',
-        url: 'https://canvastimeline.com/demos/timeline-stress-test',
+        url: 'https://canvastimeline.com/demos/timeline-stress-test/',
       },
     ]);
 

--- a/apps/www/src/lib/structured-data.ts
+++ b/apps/www/src/lib/structured-data.ts
@@ -4,7 +4,7 @@ import type { PackageDoc } from '#www/data/packages';
 import type { ReactRegistryApi, ReactRegistryItem } from '#www/data/react-registry';
 import { site } from '#www/data/site';
 import type { ApiPackage, ApiSymbol } from '#www/lib/api-reference';
-import { apiPackageHref, apiSymbolHref } from '#www/lib/api-reference';
+import { apiPackageHref, apiSymbolHref, getApiSymbolMetadata } from '#www/lib/api-reference';
 import { openGraphRouteForPath } from '#www/lib/open-graph';
 
 const reactRegistryPackageName = '@techsquidtv/canvas-timeline-react';
@@ -51,7 +51,12 @@ interface ArticleStructuredDataInput {
 }
 
 export function toAbsoluteUrl(pathOrUrl: string): string {
-  return new URL(pathOrUrl, site.url).toString();
+  const url = new URL(pathOrUrl, site.url);
+  // Match Cloudflare's HTML directory routes while preserving assets and external URLs.
+  if (url.origin === site.url && !url.pathname.split('/').at(-1)?.includes('.')) {
+    url.pathname = `${url.pathname.replace(/\/$/u, '')}/`;
+  }
+  return url.toString();
 }
 
 export function normalizeStructuredData(input: StructuredDataInput | undefined): JsonLdObject[] {
@@ -153,6 +158,7 @@ function createTechArticleStructuredData(input: ArticleStructuredDataInput): Jso
     description: input.description,
     url: toAbsoluteUrl(input.url),
     mainEntityOfPage: toAbsoluteUrl(input.url),
+    image: toAbsoluteUrl(openGraphRouteForPath(input.url)),
     keywords: input.keywords?.join(', '),
     author: {
       '@id': toAbsoluteUrl('/#organization'),
@@ -190,7 +196,7 @@ export function createBlogPostStructuredData(post: BlogPost): JsonLdObject {
     publisher: {
       '@id': toAbsoluteUrl('/#organization'),
     },
-    mainEntityOfPage: post.data.canonicalUrl ?? postUrl,
+    mainEntityOfPage: toAbsoluteUrl(post.data.canonicalUrl ?? postUrl),
     image: toAbsoluteUrl(postImageSrc),
     keywords: post.data.tags.join(', '),
   };
@@ -276,8 +282,7 @@ export function createApiSymbolArticleStructuredData(
   symbol: ApiSymbol
 ): JsonLdObject {
   return createTechArticleStructuredData({
-    title: `${symbol.name} API`,
-    description: symbol.summary || `Generated API reference for ${symbol.name}.`,
+    ...getApiSymbolMetadata(packageDoc, symbol),
     url: apiSymbolHref(packageDoc.slug, symbol.slug),
     keywords: [packageDoc.name, symbol.name, symbol.kind, 'API reference'],
   });

--- a/apps/www/src/pages/404.astro
+++ b/apps/www/src/pages/404.astro
@@ -7,6 +7,7 @@ import { site } from '#www/data/site';
   title="Page Not Found"
   description="The requested Canvas Timeline page could not be found."
   canonicalUrl={`${site.url}/404`}
+  image={site.defaultSocialImage}
   noindex
 >
   <section class="page-band">

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -90,7 +90,7 @@ function App() {
 
 <BaseLayout
   title="React Timeline Component & Canvas Editor"
-  description="A high-performance canvas react timeline editor and component. Build frame-accurate editing interfaces in React with 60fps rendering, headless state, and customizable UI."
+  description="Build React video, audio, and animation timeline editors with frame-accurate editing, a headless engine, canvas rendering, and customizable components."
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-16 pb-20 md:pt-24 md:pb-28 border-b border-border">

--- a/apps/www/src/pages/packages/[slug]/api/[symbol].astro
+++ b/apps/www/src/pages/packages/[slug]/api/[symbol].astro
@@ -3,12 +3,14 @@ import BaseLayout from '#www/layouts/BaseLayout.astro';
 import CodeBlock from '#www/components/CodeBlock.astro';
 import ApiTypeText from '#www/components/ApiTypeText.astro';
 import MarkdownCopyButton from '#www/components/MarkdownCopyButton.astro';
+import { openGraphImage, openGraphRouteForPath } from '#www/lib/open-graph';
 import {
   apiPackageHref,
   apiDocPartHref,
   apiReference,
   apiSymbolHref,
   getApiSymbol,
+  getApiSymbolMetadata,
   type ApiDocTextPart,
   type ApiPackage,
   type ApiSymbol,
@@ -73,6 +75,9 @@ const returnMembersHeading =
 const examplesHeading = resolvedSymbol.examples.length > 0 ? 'Examples' : 'Aliased examples';
 const hexColorPattern = /^#[0-9a-f]{3,8}$/i;
 const structuredData = createApiSymbolArticleStructuredData(packageDoc, resolvedSymbol);
+const metadata = getApiSymbolMetadata(packageDoc, resolvedSymbol);
+const canonicalHref = apiSymbolHref(packageDoc.slug, resolvedSymbol.slug);
+const isCanonical = resolvedSymbol.canonicalPackageSlug === packageDoc.slug;
 const search = createApiSymbolSearchDocument({
   slug: packageDoc.slug,
   name: packageDoc.name,
@@ -176,8 +181,10 @@ function descriptionHtml(
 ---
 
 <BaseLayout
-  title={`${resolvedSymbol.name} API`}
-  description={resolvedSymbol.summary || `Generated API reference for ${resolvedSymbol.name}.`}
+  canonicalUrl={canonicalHref}
+  image={{ ...openGraphImage, src: openGraphRouteForPath(canonicalHref) }}
+  title={metadata.title}
+  description={metadata.description}
   breadcrumbs={[
     { label: 'Home', href: '/' },
     { label: 'Packages', href: '/packages' },
@@ -186,7 +193,7 @@ function descriptionHtml(
     { label: resolvedSymbol.name },
   ]}
   structuredData={structuredData}
-  search={search}
+  search={isCanonical ? search : undefined}
 >
   <!-- Hero Section -->
   <section class="relative overflow-hidden bg-background pt-12 pb-16 md:pt-16 md:pb-20 border-b border-border">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -229,6 +229,7 @@ export default defineConfig({
         output: [
           'apps/www/.generated/api-reference.json',
           'apps/www/.generated/api-reference-warnings.txt',
+          'apps/www/public/_redirects',
         ],
       },
       'docs:demos': {


### PR DESCRIPTION
## Summary

API re-exports currently generate separate indexable pages containing the same declaration documentation. Resolve each symbol to its declaration-owning package, point API links and canonical metadata there, and exclude re-export copies from the sitemap and Pagefind. For example, the aggregate `TimelineEngine` page now canonicalizes to Core's reference page.

Keep package export listings and existing HTML routes available. Redirect duplicate Markdown to the owner's Markdown and reuse canonical social images. Also align trailing-slash URLs, add Markdown canonical headers and preview noindex rules, improve structured data serialization and article images, and repair the 404 social image.

## Release Impact

- Packages/API: no published package changes; empty Changeset included.
- Docs/demos: 984 symbol routes resolve to 506 canonical symbols. The rendered sitemap includes 567 URLs; 478 re-export copies are excluded from both the sitemap and site search.
- Breaking changes: none to public APIs. Re-export Markdown URLs now permanently redirect to their owning package.
- Release risk: declaration ownership is checked against source file, line, name, and kind; generation fails for unresolved owners. Cloudflare routing headers and redirects require deployment to take effect.

## Validation

- `vp run ci` passed against main at `473ada4bb`: 75 test files, 826 tests, coverage gates, typechecking, docs build, and package validation.
- Ownership regression tests verify target existence, matching declarations, self-canonical ownership, and rejection of invalid API links.
- Rendered audit passed for 1,046 HTML pages: unique titles/descriptions, one H1 each, valid JSON-LD, and existing social/article images.
- All 567 sitemap URLs match their canonical pages; all 478 re-export copies are excluded from sitemap/search and their Markdown redirects resolve to existing owner files.
- No rendered internal links target duplicate API HTML routes. Generated deployment headers retain Astro's asset caching rules.
- `git diff --check` passed.
