### PR TITLE
fix(ci): restore changesets release compatibility

### DIFF
--- a/.changeset/compatible-release-action.md
+++ b/.changeset/compatible-release-action.md
@@ -1,0 +1,4 @@
+---
+---
+
+Use Changesets Action v1 with the repository's Changesets CLI v2 so stable releases can version and publish packages.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Create release PR or publish to npm
         id: changesets
-        uses: changesets/action@v2.1.1
+        # Action v1 supports the repository's Changesets CLI v2 and input names.
+        uses: changesets/action@v1.9.0
         with:
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'


### PR DESCRIPTION
## Summary

Pin Changesets Action to v1.9.0, which supports this repository's CLI v2 and existing action inputs. Action v2 rejected the release before versioning or publishing.

## Release Impact

Restores the existing lockstep version and validated npm publish workflow. No package API changes or new breaking changes. Includes an empty Changeset.

## Validation

- `vp run repo:check` passed (existing warnings).
- Conventional title validation and `git diff --check` passed.
- Verified v1.9.0 action input definitions.
