### PR TITLE
fix(ci): preserve oidc environment during release publishing

### DIFF
--- a/.changeset/uncached-release-publishing.md
+++ b/.changeset/uncached-release-publishing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Disable caching for release publishing so npm receives GitHub's OIDC request environment and every release invocation performs its publish step.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -342,7 +342,11 @@ export default defineConfig({
         command: 'vp run --filter @techsquidtv/canvas-timeline-www preview',
         cache: false,
       },
-      'release:publish': ['vp run repo:package:check', 'vp exec changeset publish'],
+      'release:publish': {
+        command: ['vp run repo:package:check', 'vp exec changeset publish'],
+        // Publishing must run every time and retain GitHub's OIDC request environment.
+        cache: false,
+      },
       'repo:typecheck': {
         command: 'tsc -b',
         input: [


### PR DESCRIPTION
## Summary

The cached release task stripped `ACTIONS_ID_TOKEN_REQUEST_URL` before spawning Changesets, so npm could not request its trusted-publishing credential and rejected every 0.3.0 upload with E404. Mark the release task uncached, preserving its existing package-validation sequence and ensuring publishing runs on every invocation.

## Release Impact

Repairs CI publication of the already-versioned seven-package 0.3.0 suite. No package API changes or additional version bump. Includes an empty Changeset.

## Validation

- Reproduced with dummy OIDC values: cached command array loses the request URL; the same array with `cache: false` retains both required variables.
- `vp run repo:check`, commit title validation, and `git diff --check` passed.
- Full CI runs through the pre-push hook and GitHub checks.

Upstream issue: https://github.com/voidzero-dev/vite-task/issues/690
