### PR TITLE
chore(release): consume publishing fix changeset

### DIFF
--- a/.changeset/uncached-release-publishing.md
+++ b/.changeset/uncached-release-publishing.md
@@ -1,4 +1,0 @@
----
----
-
-Disable caching for release publishing so npm receives GitHub's OIDC request environment and every release invocation performs its publish step.


### PR DESCRIPTION
Consume the empty CI-fix Changeset using `vp run changeset:version`. All seven packages remain at 0.3.0. Changesets Action skips publication while only empty Changesets exist; removing the consumed file allows the already-versioned release to publish. The full pre-push validation passed.