### PR TITLE
fix(ci): surface trusted publishing authentication failures

### DIFF
--- a/scripts/release/check-publish-auth.mjs
+++ b/scripts/release/check-publish-auth.mjs
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises';
+import { URL } from 'node:url';
+
+const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+
+if (!requestUrl || !requestToken) {
+  throw new Error('Publishing requires the GitHub Actions OIDC request URL and token.');
+}
+
+const url = new URL(requestUrl);
+url.searchParams.set('audience', 'npm:registry.npmjs.org');
+const identityResponse = await globalThis.fetch(url, {
+  headers: { Authorization: `Bearer ${requestToken}` },
+});
+if (!identityResponse.ok) {
+  throw new Error(`GitHub OIDC identity request failed: HTTP ${identityResponse.status}`);
+}
+const identity = await identityResponse.json();
+if (typeof identity.value !== 'string') {
+  throw new Error('GitHub OIDC response did not contain an identity token.');
+}
+
+const config = JSON.parse(
+  await readFile(new URL('../../.changeset/config.json', import.meta.url), 'utf8')
+);
+for (const name of config.fixed.flat()) {
+  const response = await globalThis.fetch(
+    `https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(name)}`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${identity.value}`, 'Content-Length': '0' },
+      body: '',
+    }
+  );
+  if (!response.ok) {
+    const error = await response.json();
+    // Only report error fields; successful responses contain credentials.
+    throw new Error(
+      `npm OIDC exchange failed for ${name}: HTTP ${response.status}; ${error.message ?? error.body?.message ?? 'no error message'}`
+    );
+  }
+  await response.body?.cancel();
+  console.log(`npm trusted publishing verified: ${name}`);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -343,7 +343,11 @@ export default defineConfig({
         cache: false,
       },
       'release:publish': {
-        command: ['vp run repo:package:check', 'vp exec changeset publish'],
+        command: [
+          'node scripts/release/check-publish-auth.mjs',
+          'vp run repo:package:check',
+          'vp exec changeset publish',
+        ],
         // Publishing must run every time and retain GitHub's OIDC request environment.
         cache: false,
       },


### PR DESCRIPTION
Verify GitHub OIDC identity and npm token exchange for all seven fixed-group packages before building or uploading the release. pnpm masks exchange errors by falling back to an unauthenticated upload; this preflight reports the actual error without logging credentials. Package versions remain 0.3.0. Validation: mocked successful exchanges and immediate rejection, repository checks, and the full pre-push CI suite passed. This release preparation branch has no package-content changes or pending Changeset.