### PR TITLE
fix(release): match repository urls to provenance identity

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/core"
   },
   "keywords": [

--- a/packages/html-media-adapter/package.json
+++ b/packages/html-media-adapter/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/html-media-adapter"
   },
   "keywords": [

--- a/packages/mediabunny-adapter/package.json
+++ b/packages/mediabunny-adapter/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/mediabunny-adapter"
   },
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/react"
   },
   "keywords": [

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/renderer"
   },
   "keywords": [

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/timeline"
   },
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://canvastimeline.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/techsquidtv/canvas-timeline.git",
+    "url": "git+https://github.com/TechSquidTV/Canvas-Timeline.git",
     "directory": "packages/utils"
   },
   "keywords": [


### PR DESCRIPTION
Correct repository.url casing in all seven public manifests to TechSquidTV/Canvas-Timeline. npm now authenticates successfully but rejects the lowercase repository identity with E422 during provenance verification. This completes metadata preparation for the unpublished 0.3.0 release without another version bump. Validation: clean repo:package:check and the full pre-push CI suite passed.