### PR TITLE
fix(mediabunny)!: upgrade to 1.56 and recover background read failures

### DIFF
--- a/.changeset/tidy-bunnies-recover.md
+++ b/.changeset/tidy-bunnies-recover.md
@@ -1,0 +1,14 @@
+---
+'@techsquidtv/canvas-timeline-mediabunny-adapter': minor
+---
+
+**BREAKING:** Require `mediabunny@^1.56.0`. Upgrade the Mediabunny peer alongside
+Canvas Timeline. This minor release follows the suite's fixed pre-1.0 release group.
+
+Route background URL and Blob read failures through existing source recovery and
+equivalent fallbacks, preserving the original terminal error and ignoring stale
+callbacks after disposal. Custom URL error callbacks remain observers; supplied
+inputs and factories retain responsibility for their source callbacks.
+
+Validate negative timestamp mapping and Matroska presentation duration against
+Mediabunny 1.56.0, and remove the obsolete BlobSource compatibility check.

--- a/apps/full-editor-demo/package.json
+++ b/apps/full-editor-demo/package.json
@@ -22,7 +22,7 @@
     "@techsquidtv/canvas-timeline-renderer": "workspace:*",
     "@techsquidtv/canvas-timeline-utils": "workspace:*",
     "lucide-react": "^1.25.0",
-    "mediabunny": "^1.50.8",
+    "mediabunny": "^1.56.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-resizable-panels": "^4.12.2"

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -44,7 +44,7 @@
     "astro-og-canvas": "^0.13.0",
     "canvaskit-wasm": "^0.41.1",
     "lucide-react": "^1.25.0",
-    "mediabunny": "^1.50.8",
+    "mediabunny": "^1.56.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-resizable-panels": "^4.12.2",

--- a/apps/www/src/content/docs/media-adapter-migration.mdx
+++ b/apps/www/src/content/docs/media-adapter-migration.mdx
@@ -5,6 +5,20 @@ section: packages
 order: 35
 ---
 
+## Mediabunny 1.56.0 minimum
+
+**BREAKING:** The Mediabunny adapter now requires `mediabunny@^1.56.0`.
+Upgrade the peer dependency alongside Canvas Timeline to enable background read
+error recovery for adapter-created URL and Blob sources:
+
+```bash
+pnpm add mediabunny@^1.56.0
+```
+
+Custom `urlSourceOptions.handleUnhandledError` callbacks still receive the
+original error, alongside the adapter's automatic recovery. Supplied inputs and
+input factories retain responsibility for configuring their source callbacks.
+
 ## Breaking change warning
 
 The media adapters now accept one app-resolved media choice for each logical

--- a/apps/www/src/content/docs/media-adapters.mdx
+++ b/apps/www/src/content/docs/media-adapters.mdx
@@ -112,6 +112,12 @@ The optional `timing` anchor says that `sourceTimeSeconds` and
 source timestamps already equal media timestamps. This keeps epoch/live source
 time, proxies, transcodes, and trimmed cache files aligned.
 
+Mediabunny preserves negative decode timestamps in `firstTimestampSeconds` and
+maps them into `sourceFirstTimestampSeconds`. Presentation starts at the later of
+zero and the first timestamp; `durationSeconds` excludes negative preroll.
+`endTimestampSeconds` is an end timestamp, including for Matroska files whose
+container duration is measured relative to their first packet.
+
 Use `setSources(nextSources)` when replacing the complete registry. Use
 `replaceSource(source)` for one app-level media choice, and `retrySource(id)` to
 retry the preferred input and its fallbacks. Replacement and retry return a
@@ -191,6 +197,12 @@ When synchronization reaches a source whose decoder is recovering, it waits for
 the fallback controller to commit. If recovery exhausts the source's fallback
 chain, synchronization reports `sync-failed` and the high-level transport
 pauses; superseded recovery work cannot publish an error.
+With Mediabunny 1.56.0 or later, background URL and Blob reads use the same recovery
+path even when no read promise is pending. A supplied
+`urlSourceOptions.handleUnhandledError` also receives the original error as an
+observer. For supplied inputs and input factories, configure error callbacks on
+the underlying Mediabunny source when constructing it.
+
 Terminal failures remain observable on later ticks, seeks, and preload requests
 until `retrySource()`, `replaceSource()`, an unload, or a changed source definition
 explicitly resets that source.

--- a/packages/mediabunny-adapter/README.md
+++ b/packages/mediabunny-adapter/README.md
@@ -13,7 +13,7 @@
 pnpm add @techsquidtv/canvas-timeline-mediabunny-adapter mediabunny
 ```
 
-`mediabunny` is a peer dependency. React and the Canvas Timeline React package are optional peers used only by the `./react` export. The framework-free root does not import React.
+`mediabunny` version `^1.56.0` is a peer dependency. React and the Canvas Timeline React package are optional peers used only by the `./react` export. The framework-free root does not import React.
 
 ## Choosing an API
 
@@ -84,6 +84,17 @@ The adapter implements `TimelineMediaSyncAdapter` directly. Its transport clock 
 Disposal is terminal. Operations already in flight release staged resources and cannot publish late state; new loading, decoding, rendering, or mutating calls after `dispose()` throw or reject. Read-only snapshots remain available, and repeated teardown calls such as `dispose()`, `stopClock()`, and `clearVideo()` remain safe.
 
 High-level React playback applies Core in/out and loop policy to the external clock. Paused preview, startup, loop, tick, pause, and rate operations are ordered so delayed lazy loading or decoding cannot overwrite a newer position. Concurrent `play()` calls share one pending startup; `pause()` cancels pending work with a non-error `cancelled` play result. `onError` receives a `TimelineMediaError` with a stable `reason`, including `sync-failed` for rendering or scheduling failures. Audio activation is requested without blocking visual transport, retained until a decodable audio track loads, and never resumes a supplied context for video-only media. If activation completes after visual playback has advanced, queued audio is discarded and scheduled again from the current transport position.
+
+## Background reads and timestamp origins
+
+The adapter routes background URL and Blob read failures through the same source
+recovery as decoder failures, including equivalent fallbacks and terminal errors
+in `sourceStateById`. A custom `urlSourceOptions.handleUnhandledError` still
+receives the original error as an observer. For supplied inputs and input factories,
+configure background error handling when constructing their Mediabunny sources.
+
+Negative decode timestamps are preserved in metadata and source-time mapping;
+presentation duration begins at the later of zero and the first media timestamp.
 
 ## Documentation
 

--- a/packages/mediabunny-adapter/package.json
+++ b/packages/mediabunny-adapter/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "@techsquidtv/canvas-timeline-react": "workspace:*",
-    "mediabunny": "^1.50.3",
+    "mediabunny": "^1.56.0",
     "react": "^19.2.7"
   },
   "peerDependenciesMeta": {
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@techsquidtv/canvas-timeline-react": "workspace:*",
-    "mediabunny": "^1.50.8",
+    "mediabunny": "^1.56.0",
     "react": "^19.2.7"
   }
 }

--- a/packages/mediabunny-adapter/src/internal/sourceController.ts
+++ b/packages/mediabunny-adapter/src/internal/sourceController.ts
@@ -5,6 +5,7 @@ export interface MediabunnySourceController {
   sourceId: string;
   disposed: boolean;
   input: Mediabunny.Input | null;
+  inputError: Error | null;
   ownsInput: boolean;
   inputIndex: number;
   mediaTimeOffsetSeconds: number;
@@ -151,6 +152,7 @@ export function createController(
     mediaTimeOffsetSeconds:
       timing === undefined ? 0 : timing.mediaTimeSeconds - timing.sourceTimeSeconds,
     input: null,
+    inputError: null,
     ownsInput: true,
     videoSink: null,
     audioSink: null,

--- a/packages/mediabunny-adapter/src/internal/sourceLifecycle.ts
+++ b/packages/mediabunny-adapter/src/internal/sourceLifecycle.ts
@@ -465,13 +465,22 @@ export class MediabunnySourceLifecycle {
     const token = this.beginLoad(source.sourceId);
     const replacementPromise = (async (): Promise<TimelineMediaSourceOperationResult> => {
       try {
-        const result = await this.#loadSource(source, {
+        let result = await this.#loadSource(source, {
           status: 'loading',
           token,
           replacement,
         });
         if (!this.isCurrentLoad(token) || operation.replacement !== replacement) {
           return createSupersededSourceLoadResult(source.sourceId);
+        }
+        if (result.ok && replacement.candidate?.inputError) {
+          result = {
+            ok: false,
+            sourceId: source.sourceId,
+            reason: 'load-failed',
+            error: replacement.candidate.inputError,
+          };
+          this.#controllerRuntime.disposeController(replacement.candidate);
         }
         if (result.ok) {
           if (replacement.candidate === null || replacement.readyState === null) {
@@ -737,9 +746,9 @@ export class MediabunnySourceLifecycle {
       return createSupersededSourceLoadResult(source.sourceId);
     }
     const attempts = [...previousAttempts];
-    let finalError = new Error(
-      `No remaining inputs are available for source "${source.sourceId}".`
-    );
+    let finalError =
+      previousAttempts.at(-1)?.error ??
+      new Error(`No remaining inputs are available for source "${source.sourceId}".`);
 
     for (let inputIndex = startIndex; inputIndex < inputs.length; inputIndex += 1) {
       const sourceInput = inputs[inputIndex];
@@ -756,13 +765,24 @@ export class MediabunnySourceLifecycle {
           this.#selectTracks,
           this.#controllerRuntime.ensureAudioRuntime,
           isCurrentLoad,
-          replacement !== undefined
+          replacement !== undefined,
+          () => {
+            if (
+              candidate.inputError !== null &&
+              this.getController(source.sourceId) === candidate
+            ) {
+              void this.recoverSource(source.sourceId, candidate, candidate.inputError);
+            }
+          }
         );
         if (!isCurrentLoad()) {
           this.#controllerRuntime.disposeController(candidate);
           return createSupersededSourceLoadResult(source.sourceId);
         }
 
+        if (candidate.inputError !== null) {
+          throw candidate.inputError;
+        }
         attempts.push({ inputIndex, status: 'ready', error: null });
         const readyState: MediabunnySourceState = {
           sourceId: source.sourceId,
@@ -1064,14 +1084,24 @@ async function loadMediabunnySourceController(
     gainNode: GainNode;
   } | null,
   isCurrentLoad: () => boolean,
-  deferAudioRuntime: boolean
+  deferAudioRuntime: boolean,
+  onInputError: () => void
 ): Promise<LoadedMediaInfo> {
   const assertCurrentLoad = () => {
     if (!isCurrentLoad()) {
       throw new SupersededSourceLoadError(source.sourceId);
     }
+    if (controller.inputError !== null) {
+      throw controller.inputError;
+    }
   };
-  const input = await createInput(mediabunny, sourceInput);
+  const input = await createInput(mediabunny, sourceInput, (error) => {
+    if (controller.disposed || controller.inputError !== null) {
+      return;
+    }
+    controller.inputError = error instanceof Error ? error : new Error(String(error));
+    onInputError();
+  });
   controller.input = input;
   controller.ownsInput = !isSuppliedMediabunnyInput(sourceInput);
   assertCurrentLoad();
@@ -1195,7 +1225,8 @@ async function loadMediabunnySourceController(
 
 async function createInput(
   mediabunny: MediabunnyModule,
-  sourceInput: MediabunnySourceInput
+  sourceInput: MediabunnySourceInput,
+  handleUnhandledError: NonNullable<Mediabunny.UrlSourceOptions['handleUnhandledError']>
 ): Promise<Mediabunny.Input> {
   if (isMediabunnyInputDescriptor(sourceInput) && sourceInput.kind === 'input') {
     return sourceInput.input;
@@ -1205,7 +1236,13 @@ async function createInput(
   }
   if (isMediabunnyInputDescriptor(sourceInput) && sourceInput.kind === 'url') {
     return new mediabunny.Input({
-      source: new mediabunny.UrlSource(sourceInput.url, sourceInput.urlSourceOptions),
+      source: new mediabunny.UrlSource(sourceInput.url, {
+        ...sourceInput.urlSourceOptions,
+        handleUnhandledError: (error) => {
+          handleUnhandledError(error);
+          return sourceInput.urlSourceOptions?.handleUnhandledError?.(error);
+        },
+      }),
       formats: [...(sourceInput.formats ?? mediabunny.ALL_FORMATS)],
     });
   }
@@ -1216,23 +1253,13 @@ async function createInput(
     sourceInput instanceof Request
   ) {
     return new mediabunny.Input({
-      source: new mediabunny.UrlSource(sourceInput),
+      source: new mediabunny.UrlSource(sourceInput, { handleUnhandledError }),
       formats: [...mediabunny.ALL_FORMATS],
     });
   }
 
-  const mediabunnyWithBlobSource = mediabunny as MediabunnyModule & {
-    BlobSource?: new (
-      blob: Blob | File
-    ) => ConstructorParameters<MediabunnyModule['Input']>[0]['source'];
-  };
-
-  if (mediabunnyWithBlobSource.BlobSource === undefined) {
-    throw new Error('This Mediabunny version does not expose BlobSource for local files.');
-  }
-
   return new mediabunny.Input({
-    source: new mediabunnyWithBlobSource.BlobSource(sourceInput),
+    source: new mediabunny.BlobSource(sourceInput, { handleUnhandledError }),
     formats: mediabunny.ALL_FORMATS,
   });
 }

--- a/packages/mediabunny-adapter/src/mediaTiming.test.ts
+++ b/packages/mediabunny-adapter/src/mediaTiming.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'vite-plus/test';
+import * as mediabunny from 'mediabunny';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { createMediabunnyAdapter } from '#mediabunny-adapter/index';
+import { mediabunnyTestFixtures } from '#mediabunny-adapter-test/testHelpers';
+
+const { createMockInput, createMockMediabunny, createActiveClip } = mediabunnyTestFixtures;
+
+test('preserves negative media timestamps when mapping frames and metadata to logical source time', async () => {
+  const input = createMockInput({ firstTimestamp: -0.5, metadataDuration: 2 });
+  const mock = createMockMediabunny([input]);
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mock.module,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: 'https://media.example/video.ts',
+        timing: { sourceTimeSeconds: 10, mediaTimeSeconds: 0 },
+      },
+    ],
+  });
+  await adapter.preloadSource('source-1');
+  expect(adapter.sourceStateById.get('source-1')?.metadata).toMatchObject({
+    firstTimestampSeconds: -0.5,
+    sourceFirstTimestampSeconds: 9.5,
+    presentationStartTimestampSeconds: 0,
+    endTimestampSeconds: 2,
+    sourceEndTimestampSeconds: 12,
+    durationSeconds: 2,
+  });
+  expect(input.computeDuration).not.toHaveBeenCalled();
+  const frame = await adapter.getFrame({
+    ...createActiveClip('visual', 'source-1', 0),
+    sourceTime: fromSeconds(9.75),
+  });
+  expect(mock.canvasSink.getCanvas).toHaveBeenCalledWith(-0.25);
+  expect(frame?.timestamp).toBe(9.75);
+  adapter.dispose();
+});
+
+test.each([-0.5, 2])('reads Matroska duration with a %ss timestamp origin', async (start) => {
+  const target = new mediabunny.BufferTarget();
+  const output = new mediabunny.Output({ format: new mediabunny.MkvOutputFormat(), target });
+  const source = new mediabunny.EncodedAudioPacketSource('pcm-s16');
+  output.addAudioTrack(source);
+  await output.start();
+  const sampleRate = 8000;
+  for (let index = 0; index < 4; index += 1) {
+    await source.add(
+      new mediabunny.EncodedPacket(new Uint8Array(sampleRate), 'key', start + index * 0.5, 0.5),
+      { decoderConfig: { codec: 'pcm-s16', sampleRate, numberOfChannels: 1 } }
+    );
+  }
+  await output.finalize();
+  const buffer = target.buffer;
+  if (buffer === null) {
+    throw new Error('Matroska fixture was not finalized');
+  }
+  const input = new mediabunny.Input({
+    formats: mediabunny.ALL_FORMATS,
+    source: new mediabunny.BufferSource(buffer),
+  });
+  const adapter = createMediabunnyAdapter({
+    mediabunny,
+    sources: [{ sourceId: 'source-1', input: { kind: 'input', input } }],
+  });
+  try {
+    await expect(adapter.preloadSource('source-1')).resolves.toMatchObject({ ok: true });
+    expect(adapter.sourceStateById.get('source-1')?.metadata).toMatchObject({
+      firstTimestampSeconds: start,
+      presentationStartTimestampSeconds: Math.max(0, start),
+      endTimestampSeconds: start + 2,
+      durationSeconds: start + 2 - Math.max(0, start),
+    });
+  } finally {
+    adapter.dispose();
+    input.dispose();
+  }
+});

--- a/packages/mediabunny-adapter/src/sourceErrors.test.ts
+++ b/packages/mediabunny-adapter/src/sourceErrors.test.ts
@@ -1,0 +1,152 @@
+import { expect, test, vi } from 'vite-plus/test';
+import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
+import { createMediabunnyAdapter, type MediabunnySourceInput } from '#mediabunny-adapter/index';
+import { mediabunnyTestFixtures } from '#mediabunny-adapter-test/testHelpers';
+
+const { createMockInput, createMockMediabunny, createActiveClip, createActiveLayers } =
+  mediabunnyTestFixtures;
+
+const sourceInputs = [
+  'https://media.example/video.mp4',
+  new URL('https://media.example/video.mp4'),
+  new Request('https://media.example/video.mp4'),
+  { kind: 'url', url: 'https://media.example/video.mp4' },
+  new Blob(['media']),
+  new File(['media'], 'video.mp4'),
+] as const satisfies readonly MediabunnySourceInput[];
+
+test.each(sourceInputs)('recovers background input errors for %s', async (input) => {
+  const firstInput = createMockInput();
+  const fallbackInput = createMockInput({ metadataDuration: 9 });
+  const mock = createMockMediabunny([firstInput, fallbackInput]);
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mock.module,
+    sources: [{ sourceId: 'source-1', input, fallbacks: ['https://media.example/fallback.mp4'] }],
+  });
+  await adapter.preloadSource('source-1');
+  const previousSnapshot = adapter.sourceStateById;
+  const handler = (mock.createdUrlSourceOptions[0] ?? mock.createdBlobSourceOptions[0])
+    ?.handleUnhandledError;
+  expect(handler).toBeTypeOf('function');
+  const error = new Error('background read failed');
+  handler?.(error);
+  handler?.(error);
+
+  await expect(adapter.preloadSource('source-1')).resolves.toMatchObject({ ok: true });
+  expect(adapter.sourceStateById).not.toBe(previousSnapshot);
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    status: 'ready',
+    selectedInputIndex: 1,
+    attempts: [
+      { inputIndex: 0, status: 'ready' },
+      { inputIndex: 0, status: 'failed', error },
+      { inputIndex: 1, status: 'ready' },
+    ],
+    metadata: { durationSeconds: 9 },
+  });
+  expect(firstInput.dispose).toHaveBeenCalledOnce();
+  expect(mock.constructInput).toHaveBeenCalledTimes(2);
+  adapter.dispose();
+});
+
+test('preserves caller URL options and reports terminal background failures to transport', async () => {
+  const observer = vi.fn();
+  const mock = createMockMediabunny([createMockInput()]);
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mock.module,
+    sources: [
+      {
+        sourceId: 'source-1',
+        input: {
+          kind: 'url',
+          url: 'https://media.example/video.mp4',
+          urlSourceOptions: { maxCacheSize: 1024, handleUnhandledError: observer },
+        },
+      },
+    ],
+  });
+  await adapter.preloadSource('source-1');
+  expect(mock.createdUrlSourceOptions[0]?.maxCacheSize).toBe(1024);
+  mock.createdUrlSourceOptions[0]?.handleUnhandledError?.('background failure');
+  await expect(adapter.preloadSource('source-1')).resolves.toMatchObject({ ok: false });
+  expect(observer).toHaveBeenCalledExactlyOnceWith('background failure');
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    status: 'failed',
+    error: expect.objectContaining({ message: 'background failure' }),
+  });
+  await expect(
+    adapter.seek(fromSeconds(0), createActiveLayers([createActiveClip('visual', 'source-1', 0)], 0))
+  ).rejects.toThrow('background failure');
+  adapter.dispose();
+});
+
+test('fails a load attempt when background reading fails before metadata finishes', async () => {
+  const initial = createMockInput();
+  const mock = createMockMediabunny([initial, createMockInput()]);
+  initial.getFirstTimestamp.mockImplementation(async () => {
+    mock.createdUrlSourceOptions[0]?.handleUnhandledError?.(new Error('prefetch failed'));
+    return 0;
+  });
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mock.module,
+    sources: [{ sourceId: 'source-1', input: sourceInputs[0], fallbacks: [sourceInputs[1]] }],
+  });
+  await expect(adapter.preloadSource('source-1')).resolves.toMatchObject({ ok: true });
+  expect(adapter.sourceStateById.get('source-1')).toMatchObject({
+    selectedInputIndex: 1,
+    attempts: [{ status: 'failed' }, { status: 'ready' }],
+  });
+  expect(initial.getDurationFromMetadata).not.toHaveBeenCalled();
+  expect(initial.dispose).toHaveBeenCalledOnce();
+  adapter.dispose();
+});
+
+test.each(['unload', 'replace', 'dispose'] as const)(
+  'ignores background callbacks after %s',
+  async (action) => {
+    const mock = createMockMediabunny([createMockInput(), createMockInput()]);
+    const adapter = createMediabunnyAdapter({
+      mediabunny: mock.module,
+      sources: [{ sourceId: 'source-1', input: sourceInputs[0] }],
+    });
+    await adapter.preloadSource('source-1');
+    const handler = mock.createdUrlSourceOptions[0]?.handleUnhandledError;
+    if (action === 'unload') {
+      adapter.unloadSource('source-1');
+    } else if (action === 'replace') {
+      await adapter.replaceSource({ sourceId: 'source-1', input: sourceInputs[1] });
+    } else {
+      adapter.dispose();
+    }
+    const snapshot = adapter.sourceStateById;
+    handler?.(new Error('late failure'));
+    await Promise.resolve();
+    expect(adapter.sourceStateById).toBe(snapshot);
+    expect(adapter.error).toBeNull();
+    adapter.dispose();
+  }
+);
+
+test('keeps the current source when a replacement has a background load failure', async () => {
+  const replacement = createMockInput();
+  const mock = createMockMediabunny([createMockInput(), replacement]);
+  replacement.getFirstTimestamp.mockImplementation(async () => {
+    mock.createdUrlSourceOptions[1]?.handleUnhandledError?.(new Error('replacement failed'));
+    return 0;
+  });
+  const adapter = createMediabunnyAdapter({
+    mediabunny: mock.module,
+    sources: [{ sourceId: 'source-1', input: sourceInputs[0] }],
+  });
+  await adapter.preloadSource('source-1');
+  const previousState = adapter.sourceStateById.get('source-1');
+  await expect(
+    adapter.replaceSource({ sourceId: 'source-1', input: sourceInputs[1] })
+  ).resolves.toMatchObject({
+    ok: false,
+    error: expect.objectContaining({ message: 'replacement failed' }),
+  });
+  expect(adapter.sourceStateById.get('source-1')).toBe(previousState);
+  expect(replacement.dispose).toHaveBeenCalledOnce();
+  adapter.dispose();
+});

--- a/packages/mediabunny-adapter/src/types.ts
+++ b/packages/mediabunny-adapter/src/types.ts
@@ -34,7 +34,10 @@ export type MediabunnySourceInput =
       url: string | URL | Request;
       /** Explicit formats such as `HLS_FORMATS`; defaults to `ALL_FORMATS`. */
       formats?: readonly Mediabunny.InputFormat[];
-      /** Cache, request, and parallel-loading options passed to `UrlSource`. */
+      /**
+       * Options passed to `UrlSource`. A supplied `handleUnhandledError` observes
+       * background read errors in addition to the adapter's source recovery.
+       */
       urlSourceOptions?: Mediabunny.UrlSourceOptions;
     }
   | {
@@ -93,7 +96,7 @@ export interface MediabunnySourceMetadata {
   firstTimestampSeconds: number;
   /** First timestamp mapped into the logical source time domain. */
   sourceFirstTimestampSeconds: number;
-  /** Earliest presentation timestamp across the selected audio and video tracks. */
+  /** Earliest non-negative presentation timestamp across the selected tracks. */
   presentationStartTimestampSeconds: number;
   /** End timestamp mapped into the logical source time domain. */
   sourceEndTimestampSeconds: number;

--- a/packages/mediabunny-adapter/src/videoOutput.test.ts
+++ b/packages/mediabunny-adapter/src/videoOutput.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vite-plus/test';
 import { fromSeconds } from '@techsquidtv/canvas-timeline-utils';
-import { createMediabunnyAdapter, type MediabunnyModule } from '#mediabunny-adapter/index';
+import { createMediabunnyAdapter } from '#mediabunny-adapter/index';
 import {
   mediabunnyTestFixtures,
   type MockVideoTrack,
@@ -442,25 +442,6 @@ test('createMediabunnyAdapter rejects undecodable video and permits video withou
   window.AudioContext = previousAudioContext;
   (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext =
     previousWebkitAudioContext;
-
-  const moduleWithoutBlobSource = {
-    ...createMockMediabunny([]).module,
-    BlobSource: undefined,
-  } as unknown as MediabunnyModule;
-  const missingBlobSourceAdapter = createMediabunnyAdapter({
-    mediabunny: moduleWithoutBlobSource,
-    sources: [
-      {
-        sourceId: 'local-file',
-        input: new Blob(['sample']),
-      },
-    ],
-  });
-
-  await waitForAdapterLoad(missingBlobSourceAdapter);
-  expect(missingBlobSourceAdapter.error?.message).toBe(
-    'This Mediabunny version does not expose BlobSource for local files.'
-  );
 });
 
 test('createMediabunnyAdapter exposes selected-track metadata and runtime audio controls', async () => {

--- a/packages/mediabunny-adapter/test/testHelpers.ts
+++ b/packages/mediabunny-adapter/test/testHelpers.ts
@@ -117,6 +117,8 @@ export interface MockMediabunny {
   constructCanvasSink: ReturnType<typeof vi.fn<() => void>>;
   constructInput: ReturnType<typeof vi.fn<() => void>>;
   createdBlobSources: Blob[];
+  createdBlobSourceOptions: RealMediabunny.BlobSourceOptions[];
+  createdUrlSourceOptions: RealMediabunny.UrlSourceOptions[];
   createdUrlSources: (string | URL | Request)[];
   module: MediabunnyModule;
 }
@@ -233,6 +235,8 @@ function createMockMediabunny(
 ): MockMediabunny {
   const createdUrlSources: (string | URL | Request)[] = [];
   const createdBlobSources: Blob[] = [];
+  const createdBlobSourceOptions: RealMediabunny.BlobSourceOptions[] = [];
+  const createdUrlSourceOptions: RealMediabunny.UrlSourceOptions[] = [];
   const { audioSink, canvasSink } = createSinkFactory(sinkOptions);
   const constructCanvasSink = vi.fn();
   const constructAudioSink = vi.fn();
@@ -249,14 +253,16 @@ function createMockMediabunny(
   }
 
   class MockUrlSource {
-    constructor(url: string | URL | Request) {
+    constructor(url: string | URL | Request, options: RealMediabunny.UrlSourceOptions = {}) {
       createdUrlSources.push(url);
+      createdUrlSourceOptions.push(options);
     }
   }
 
   class MockBlobSource {
-    constructor(blob: Blob) {
+    constructor(blob: Blob, options: RealMediabunny.BlobSourceOptions = {}) {
       createdBlobSources.push(blob);
+      createdBlobSourceOptions.push(options);
     }
   }
 
@@ -281,7 +287,9 @@ function createMockMediabunny(
     constructCanvasSink,
     constructInput,
     createdBlobSources,
+    createdBlobSourceOptions,
     createdUrlSources,
+    createdUrlSourceOptions,
     module: {
       ...RealMediabunny,
       Input: MockInputConstructor,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 5.2.11
       '@mediabunny/aac-encoder':
         specifier: ^1.50.8
-        version: 1.50.8(mediabunny@1.50.8)
+        version: 1.50.8(mediabunny@1.56.0)
       '@techsquidtv/canvas-timeline-core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -115,8 +115,8 @@ importers:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.7)
       mediabunny:
-        specifier: ^1.50.8
-        version: 1.50.8
+        specifier: ^1.56.0
+        version: 1.56.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -209,8 +209,8 @@ importers:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.7)
       mediabunny:
-        specifier: ^1.50.8
-        version: 1.50.8
+        specifier: ^1.56.0
+        version: 1.56.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -311,8 +311,8 @@ importers:
         specifier: workspace:*
         version: link:../react
       mediabunny:
-        specifier: ^1.50.8
-        version: 1.50.8
+        specifier: ^1.56.0
+        version: 1.56.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4177,8 +4177,8 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
-  mediabunny@1.50.8:
-    resolution: {integrity: sha512-LgykLyQzhdpo0V2yw3UXmOpj+b4JAGdpHBwsPE6kjSt8Za0d1VllD+FV7EGHBcdV4+oHUAo+yrqbVAWxNSDCPQ==}
+  mediabunny@1.56.0:
+    resolution: {integrity: sha512-VLVYEVXI4fA2PabQoZs3XOmxDsio4gpG1Npz0iVICRNCQ+XYI3fBOngnwHljafaEjHUbYzrIDoctZbxcVfQpgQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -6709,9 +6709,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mediabunny/aac-encoder@1.50.8(mediabunny@1.50.8)':
+  '@mediabunny/aac-encoder@1.50.8(mediabunny@1.56.0)':
     dependencies:
-      mediabunny: 1.50.8
+      mediabunny: 1.56.0
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
@@ -9229,7 +9229,7 @@ snapshots:
 
   mdurl@2.0.0: {}
 
-  mediabunny@1.50.8:
+  mediabunny@1.56.0:
     dependencies:
       '@types/dom-mediacapture-transform': 0.1.12
       '@types/dom-webcodecs': 0.1.13

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,3 +54,4 @@ minimumReleaseAgeExclude:
   - miniflare@4.20260701.0
   - workerd@1.20260702.1
   - wrangler@4.107.0
+  - mediabunny@1.56.0


### PR DESCRIPTION
## Summary

Upgrade Mediabunny from 1.50.8 to 1.56.0 across the adapter, docs, and full editor. Background URL/Blob prefetch failures previously escaped as unhandled rejections when no read was pending; they now enter the adapter's existing equivalent-input recovery, preserve the original terminal error, and reach transport error handling.

- Preserve caller URL error observers and ignore repeated or stale callbacks after unload, replacement, or disposal.
- Add 15 regression cases, including real Matroska fixtures with negative/positive timestamp origins and logical frame-time mapping.
- Remove the obsolete BlobSource compatibility check and document source ownership, timestamp semantics, and migration.

[Upstream release](https://github.com/Vanilagy/mediabunny/releases/tag/v1.56.0)

## Release Impact

- **BREAKING:** Consumers must upgrade the Mediabunny peer to `^1.56.0`. The minor Changeset releases all seven public packages together under the pre-1.0 fixed-group policy.
- Existing adapter signatures remain intact. Adapter-created sources recover automatically; supplied inputs and factories own their source callbacks.
- Docs and full editor resolve 1.56.0. The existing AAC encoder extension accepts this peer version. The release-age exception is restricted to `mediabunny@1.56.0`.

## Review findings and follow-ups

- Existing presentation-time clamping remains correct: preserve negative decode timestamps, but exclude negative preroll from presentation duration. Matroska metadata returns an end timestamp, not a duration to add again.
- Copy-based trimmed export needs a separate eligibility path. The full editor currently renders/re-encodes video and audio; transforms and mixing cannot simply switch to packet copying. Keep zero timestamp-shift tolerance for timeline alignment and define trim-boundary/unsupported-track behavior before exposing this feature.
- The demo's independent ingest/export Blob sources should adopt background-error reporting. `ExportMediaCache.close()` also needs explicit Mediabunny input disposal; it currently closes only image bitmaps. These application-owned paths are outside the shared adapter recovery change.

## Validation

- `vp test packages/mediabunny-adapter/src` — 95 tests passed.
- `vp run ci` — 841 tests; type/lint checks, package coverage, docs/full-editor builds, and built-package validation.
- `vp run repo:package:check` — clean package rebuild and validation.
- `vp run changeset:status` — all seven packages receive a minor release.
- Conventional PR title validated with commitlint.

## Checklist

- [x] I added a changeset or an empty changeset.
- [x] I checked package/API impact.
- [x] I checked docs/demo impact.
- [x] I called out breaking changes, if any.
